### PR TITLE
[codex] fix release promotion automation

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,17 +1,20 @@
 name: Promote Pre-release to Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: promote-release-main
+  cancel-in-progress: false
+
 jobs:
   promote:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,56 +22,75 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get version from branch
-        id: get_version
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          if [[ $BRANCH_NAME =~ feature/v([0-9]+\.[0-9]+) ]]; then
-            VERSION="${BASH_REMATCH[1]}.0"
-            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-            echo "Found version: $VERSION"
-          else
-            echo "No version found in branch name"
-            exit 0
-          fi
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
 
-      - name: Check if pre-release exists
-        id: check_prerelease
-        run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-          if [ -z "$VERSION" ]; then
-            echo "exists=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+      - name: Get version from package.json
+        id: version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
 
-          if gh release view "v$VERSION" --json isPrerelease -q .isPrerelease 2>/dev/null | grep -q "true"; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Pre-release v$VERSION exists"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "No pre-release found for v$VERSION"
-          fi
+      - name: Find matching pre-release
+        id: prerelease
+        uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const version = process.env.VERSION;
+            const stableTag = `v${version}`;
 
-      - name: Update tag to point to main
-        if: steps.check_prerelease.outputs.exists == 'true'
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: stableTag,
+              });
+              core.info(`Stable release ${stableTag} already exists`);
+              core.setOutput("create_tag", "false");
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const prereleases = releases
+              .filter((release) => release.prerelease)
+              .filter((release) =>
+                new RegExp(`^v${version}-rc\\.[0-9]+$`).test(release.tag_name),
+              )
+              .sort((a, b) => {
+                const aTime = Date.parse(a.published_at || a.created_at || "");
+                const bTime = Date.parse(b.published_at || b.created_at || "");
+                return bTime - aTime;
+              });
+
+            if (prereleases.length === 0) {
+              core.info(`No matching pre-release found for v${version}`);
+              core.setOutput("create_tag", "false");
+              return;
+            }
+
+            core.info(`Found matching pre-release ${prereleases[0].tag_name}`);
+            core.setOutput("create_tag", "true");
+            core.setOutput("matched_tag", prereleases[0].tag_name);
+
+      - name: Create stable tag on merged main commit
+        if: steps.prerelease.outputs.create_tag == 'true'
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git tag -d "v$VERSION" || true
-          git push origin --delete "v$VERSION" || true
-
-          git tag "v$VERSION"
+          git tag -a "v$VERSION" "$GITHUB_SHA" -m "v$VERSION"
           git push origin "v$VERSION"
-
-      - name: Promote pre-release to release
-        if: steps.check_prerelease.outputs.exists == 'true'
-        run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-          gh release edit "v$VERSION" --prerelease=false --latest
-          echo "Promoted v$VERSION to full release"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,34 +13,75 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Get version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Extract changelog for version
-        id: changelog
-        run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          CHANGELOG=$(awk "/## \[$VERSION\]/,/## \[/{if(/## \[/ && !/## \[$VERSION\]/)exit;print}" CHANGELOG.md)
-          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body: ${{ steps.changelog.outputs.CHANGELOG }}
-          draft: false
-          prerelease: false
+      - name: Publish GitHub release from tag
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.TAG_NAME;
+            const prereleasePattern = /^v\d+\.\d+\.\d+-(?:rc|beta|alpha)\.\d+$/;
+            const stablePattern = /^v\d+\.\d+\.\d+$/;
+            const isPrerelease = prereleasePattern.test(tag);
+
+            if (!isPrerelease && !stablePattern.test(tag)) {
+              core.info(`Skipping unsupported tag format: ${tag}`);
+              return;
+            }
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+              core.info(`Release ${tag} already exists (${existing.data.html_url})`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            let body = "";
+            let generateNotes = true;
+
+            if (!isPrerelease) {
+              const version = tag.replace(/^v/, "");
+              const releases = await github.paginate(github.rest.repos.listReleases, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+
+              const prereleases = releases
+                .filter((release) => release.prerelease)
+                .filter((release) =>
+                  new RegExp(`^v${version}-rc\\.[0-9]+$`).test(release.tag_name),
+                )
+                .sort((a, b) => {
+                  const aTime = Date.parse(a.published_at || a.created_at || "");
+                  const bTime = Date.parse(b.published_at || b.created_at || "");
+                  return bTime - aTime;
+                });
+
+              if (prereleases.length > 0) {
+                const prerelease = prereleases[0];
+                body = `Promoted from \`${prerelease.tag_name}\` after merge to \`main\`.\n\n${prerelease.body || ""}`.trim();
+                generateNotes = false;
+              }
+            }
+
+            await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag_name: tag,
+              name: tag,
+              prerelease: isPrerelease,
+              make_latest: isPrerelease ? "false" : "true",
+              body: body || undefined,
+              generate_release_notes: generateNotes,
+            });


### PR DESCRIPTION
## Summary
Fixes the GitHub release automation so merging a versioned change to `main` promotes the matching `vX.Y.Z-rc.*` pre-release into the stable `vX.Y.Z` release.

## Root Cause
The previous promotion workflow depended on branch names like `feature/v1.2` and looked for a pre-release named `v1.2.0`, which does not match the actual `v1.2.0-rc.1` tagging flow.

## Changes
- Updates `.github/workflows/promote-release.yml` to read the version from `package.json` on `main`
- Promotes by creating the stable `vX.Y.Z` tag on the merged `main` commit when a matching `vX.Y.Z-rc.*` release exists
- Updates `.github/workflows/release.yml` to create prereleases for RC tags and stable releases for stable tags
- Reuses the matching RC release notes when publishing the stable release, including the promotion reference
- Avoids duplicate release creation by no-oping when a release for the tag already exists

## Validation
- Verified against the existing `v1.2.0-rc.1` / merged `v1.2.0` flow and corrected the logic gap in the workflows

## Notes
- Your unrelated local change in `src/routes/__root.tsx` was left untouched and is not part of this branch.
