### PR TITLE
[codex] remove rc after stable promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -29,7 +29,9 @@ jobs:
 
       - name: Get version from package.json
         id: version
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Find matching pre-release
         id: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,22 +32,9 @@ jobs:
               return;
             }
 
-            try {
-              const existing = await github.rest.repos.getReleaseByTag({
-                owner,
-                repo,
-                tag,
-              });
-              core.info(`Release ${tag} already exists (${existing.data.html_url})`);
-              return;
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-            }
-
             let body = "";
             let generateNotes = true;
+            let matchedPrerelease = null;
 
             if (!isPrerelease) {
               const version = tag.replace(/^v/, "");
@@ -69,19 +56,59 @@ jobs:
                 });
 
               if (prereleases.length > 0) {
-                const prerelease = prereleases[0];
-                body = `Promoted from \`${prerelease.tag_name}\` after merge to \`main\`.\n\n${prerelease.body || ""}`.trim();
+                matchedPrerelease = prereleases[0];
+                body = matchedPrerelease.body || "";
                 generateNotes = false;
               }
             }
 
-            await github.rest.repos.createRelease({
-              owner,
-              repo,
-              tag_name: tag,
-              name: tag,
-              prerelease: isPrerelease,
-              make_latest: isPrerelease ? "false" : "true",
-              body: body || undefined,
-              generate_release_notes: generateNotes,
-            });
+            let releaseExists = false;
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+              core.info(`Release ${tag} already exists (${existing.data.html_url})`);
+              releaseExists = true;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            if (!releaseExists) {
+              await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                name: tag,
+                prerelease: isPrerelease,
+                make_latest: isPrerelease ? "false" : "true",
+                body: body || undefined,
+                generate_release_notes: generateNotes,
+              });
+            }
+
+            if (!isPrerelease && matchedPrerelease) {
+              core.info(`Cleaning up prerelease ${matchedPrerelease.tag_name}`);
+
+              await github.rest.repos.deleteRelease({
+                owner,
+                repo,
+                release_id: matchedPrerelease.id,
+              });
+
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `tags/${matchedPrerelease.tag_name}`,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
Updates the release automation so a successful stable promotion removes the matching RC prerelease and RC tag.

## Root Cause
The previous automation could create the stable `vX.Y.Z` release from a matching `vX.Y.Z-rc.*`, but it left the RC release and RC tag in place.

## Changes
- Fixes the `package.json` version extraction step in `promote-release.yml`
- Keeps the stable tag creation on merge to `main`
- Updates `release.yml` so stable release publication reuses the RC notes without adding extra promotion text
- Deletes the matched RC GitHub release after the stable release is successfully created
- Deletes the matched RC git tag after the stable release is successfully created

## Result
After merge to `main`, the flow becomes:
1. RC release exists, for example `v1.2.1-rc.1`
2. Stable `v1.2.1` tag is created on the merged `main` commit
3. Stable `v1.2.1` release is published as latest
4. Matching RC release and RC tag are removed
