### PR TITLE
fix: add Railway start command for web deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cli:publish-dry": "yarn build && npm publish ./packages/cli --dry-run",
     "check": "yarn workspace @gtfs-viz/duckdb-extension run check && yarn workspace @gtfs-viz/web run check && yarn workspace @gabrielahn/gtfs-viz-cli run check",
     "preview": "yarn workspace @gtfs-viz/web run preview",
+    "start": "yarn workspace @gtfs-viz/web run preview --host 0.0.0.0 --port ${PORT:-4173}",
     "postinstall": "node scripts/fix-duckdb-sourcemaps.mjs",
     "version": "echo v$(node -p \"require('./package.json').version\")",
     "release:patch": "npm version patch -m 'chore: release v%s'",

--- a/railway.json
+++ b/railway.json
@@ -12,6 +12,7 @@
     ]
   },
   "deploy": {
+    "startCommand": "yarn start",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## Summary
- add a root start script that runs the web preview server on 0.0.0.0 and Railway's PORT
- set Railway deploy.startCommand to use that script explicitly

## Why
Railway HTTP logs showed repeated connection dial timeouts and 502s, which indicates the deployed container was not listening on the port Railway expected.

## Verification
- ran yarn build:web
- smoke-tested yarn start
- verified / and a built asset returned HTTP 200 locally

## Notes
- yarn run check still fails on pre-existing formatting drift in the repo and was not changed here