### PR TITLE
fix: use Caddy for Railway web runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cli:publish-dry": "yarn build && npm publish ./packages/cli --dry-run",
     "check": "yarn workspace @gtfs-viz/duckdb-extension run check && yarn workspace @gtfs-viz/web run check && yarn workspace @gabrielahn/gtfs-viz-cli run check",
     "preview": "yarn workspace @gtfs-viz/web run preview",
-    "start": "yarn workspace @gtfs-viz/web run preview --host 0.0.0.0 --port ${PORT:-4173}",
     "postinstall": "node scripts/fix-duckdb-sourcemaps.mjs",
     "version": "echo v$(node -p \"require('./package.json').version\")",
     "release:patch": "npm version patch -m 'chore: release v%s'",

--- a/railway.json
+++ b/railway.json
@@ -12,7 +12,7 @@
     ]
   },
   "deploy": {
-    "startCommand": "yarn start",
+    "startCommand": "caddy run --config /Caddyfile --adapter caddyfile 2>&1",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## Summary
- remove the Yarn-based root start script added in PR #13
- set Railway deploy.startCommand to run Caddy directly with the generated /Caddyfile

## Why
The Railpack runtime image for this static web deploy includes Caddy but does not expose yarn or node on PATH. The previous startCommand crashed with yarn: command not found, and a Node-only attempt crashed with node: command not found.

## Verification
- ran railway up --detach
- deployment 47271f51-caa7-4f17-8bdc-aefd6aec91e4 reached SUCCESS
- runtime logs show Caddy starting and serving configuration
- curl -I https://gtfs-viz-production-f1a4.up.railway.app/ returned HTTP/2 200
- curl -I https://gtfs-viz-production-f1a4.up.railway.app/stations/pathways returned HTTP/2 200