### PR TITLE
release: v1.5.0 — trip compare, trip editing, map & CLI improvements

### DIFF
--- a/.agents/skills/tanstack-router/SKILL.md
+++ b/.agents/skills/tanstack-router/SKILL.md
@@ -1,0 +1,734 @@
+---
+name: tanstack-router
+description: Type-safe routing for React and Solid applications with first-class search params, data loading, and seamless integration with the React ecosystem.
+---
+
+
+## Overview
+
+TanStack Router is a fully type-safe router for React (and Solid) applications. It provides file-based routing, first-class search parameter management, built-in data loading, code splitting, and deep TypeScript integration. It serves as the routing foundation for TanStack Start (the full-stack framework).
+
+**Package:** `@tanstack/react-router`
+**CLI:** `@tanstack/router-cli` or `@tanstack/router-plugin` (Vite/Rspack/Webpack)
+**Devtools:** `@tanstack/react-router-devtools`
+
+## Installation
+
+```bash
+npm install @tanstack/react-router
+# For file-based routing with Vite:
+npm install -D @tanstack/router-plugin
+# Or standalone CLI:
+npm install -D @tanstack/router-cli
+```
+
+## Core Concepts
+
+### Route Trees
+
+Routes are organized in a tree structure. The root route is the top-level layout, and child routes nest underneath.
+
+```tsx
+import { createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
+
+const rootRoute = createRootRoute({
+  component: RootLayout,
+})
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: HomePage,
+})
+
+const aboutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/about',
+  component: AboutPage,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+const router = createRouter({ routeTree })
+```
+
+### File-Based Routing
+
+File-based routing automatically generates the route tree from your file structure. Configure with Vite plugin:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
+
+export default defineConfig({
+  plugins: [
+    TanStackRouterVite(),
+    // ... other plugins
+  ],
+})
+```
+
+#### File Naming Conventions
+
+| File Pattern | Route Type | Example Path |
+|---|---|---|
+| `__root.tsx` | Root layout | N/A (wraps all) |
+| `index.tsx` | Index route | `/` |
+| `about.tsx` | Static route | `/about` |
+| `$postId.tsx` | Dynamic param | `/posts/$postId` |
+| `posts.tsx` | Layout route | `/posts/*` (layout) |
+| `posts/index.tsx` | Nested index | `/posts` |
+| `posts/$postId.tsx` | Nested dynamic | `/posts/123` |
+| `posts_.$postId.tsx` | Pathless layout | `/posts/123` (different layout) |
+| `_layout.tsx` | Pathless layout | N/A (groups routes) |
+| `_layout/dashboard.tsx` | Grouped route | `/dashboard` |
+| `$.tsx` | Splat/catch-all | `/*` |
+| `posts.$postId.edit.tsx` | Dot notation | `/posts/123/edit` |
+
+#### Special Prefixes
+- `_` prefix: Pathless routes (layout groups without URL segment)
+- `$` prefix: Dynamic path parameters
+- `(folder)` parentheses: Route groups (organizational, no URL impact)
+
+### Route Configuration
+
+Each route can define:
+
+```tsx
+// routes/posts.$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  // Validation for path params
+  params: {
+    parse: (params) => ({ postId: Number(params.postId) }),
+    stringify: (params) => ({ postId: String(params.postId) }),
+  },
+
+  // Search params validation
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      page: Number(search.page ?? 1),
+      filter: (search.filter as string) || '',
+    }
+  },
+
+  // Data loading
+  loader: async ({ params, context, abortController }) => {
+    return fetchPost(params.postId)
+  },
+
+  // Loader dependencies (re-run loader when these change)
+  loaderDeps: ({ search }) => ({ page: search.page }),
+
+  // Stale time for cached loader data
+  staleTime: 5_000,
+
+  // Preloading
+  preloadStaleTime: 30_000,
+
+  // Error component
+  errorComponent: PostErrorComponent,
+
+  // Pending/loading component
+  pendingComponent: PostLoadingComponent,
+
+  // 404 component
+  notFoundComponent: PostNotFoundComponent,
+
+  // Before load hook (authentication, redirects)
+  beforeLoad: async ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: { redirect: location.href },
+      })
+    }
+  },
+
+  // Head/meta management
+  head: () => ({
+    meta: [{ title: 'Post Details' }],
+  }),
+
+  // Component
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { postId } = Route.useParams()
+  const post = Route.useLoaderData()
+  const { page, filter } = Route.useSearch()
+
+  return <div>{post.title}</div>
+}
+```
+
+## Data Loading
+
+### Route Loaders
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: async ({ context }) => {
+    // Access router context (e.g., queryClient)
+    const posts = await context.queryClient.ensureQueryData({
+      queryKey: ['posts'],
+      queryFn: fetchPosts,
+    })
+    return { posts }
+  },
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const { posts } = Route.useLoaderData()
+  // ...
+}
+```
+
+### Loader Dependencies
+
+Control when loaders re-execute:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loaderDeps: ({ search: { page, filter } }) => ({ page, filter }),
+  loader: async ({ deps: { page, filter } }) => {
+    return fetchPosts({ page, filter })
+  },
+})
+```
+
+### Deferred Data Loading
+
+Stream non-critical data:
+
+```tsx
+import { Await, defer } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/dashboard')({
+  loader: async () => {
+    const criticalData = await fetchCriticalData()
+    const deferredData = defer(fetchSlowData())
+    return { criticalData, deferredData }
+  },
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const { criticalData, deferredData } = Route.useLoaderData()
+
+  return (
+    <div>
+      <CriticalSection data={criticalData} />
+      <Suspense fallback={<Loading />}>
+        <Await promise={deferredData}>
+          {(data) => <SlowSection data={data} />}
+        </Await>
+      </Suspense>
+    </div>
+  )
+}
+```
+
+### Context-Based Data Loading
+
+Provide shared dependencies via router context:
+
+```tsx
+// Create router with context
+const router = createRouter({
+  routeTree,
+  context: {
+    queryClient,
+    auth: undefined!, // Will be provided by RouterProvider
+  },
+})
+
+// In root/app component
+function App() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+// In routes
+export const Route = createFileRoute('/protected')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.user) throw redirect({ to: '/login' })
+  },
+  loader: ({ context }) => {
+    return context.queryClient.ensureQueryData(userQueryOptions())
+  },
+})
+```
+
+## Search Parameters
+
+### Validation
+
+```tsx
+import { z } from 'zod'
+
+const postSearchSchema = z.object({
+  page: z.number().default(1),
+  filter: z.string().default(''),
+  sort: z.enum(['date', 'title']).default('date'),
+})
+
+export const Route = createFileRoute('/posts')({
+  validateSearch: postSearchSchema,
+  // Or manual validation:
+  // validateSearch: (search) => postSearchSchema.parse(search),
+})
+```
+
+### Reading Search Params
+
+```tsx
+function PostsComponent() {
+  // From route
+  const { page, filter, sort } = Route.useSearch()
+
+  // Or from any component with useSearch hook
+  const search = useSearch({ from: '/posts' })
+}
+```
+
+### Updating Search Params
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function Pagination() {
+  const navigate = useNavigate()
+  const { page } = Route.useSearch()
+
+  return (
+    <button
+      onClick={() =>
+        navigate({
+          search: (prev) => ({ ...prev, page: prev.page + 1 }),
+        })
+      }
+    >
+      Next Page
+    </button>
+  )
+}
+
+// Or via Link component
+<Link
+  to="/posts"
+  search={(prev) => ({ ...prev, page: 2 })}
+>
+  Page 2
+</Link>
+```
+
+### Search Param Options
+
+```tsx
+const router = createRouter({
+  routeTree,
+  // Custom serialization
+  search: {
+    strict: true, // Reject unknown params
+  },
+  // Default search param serializer
+  stringifySearch: defaultStringifySearch,
+  parseSearch: defaultParseSearch,
+})
+```
+
+## Navigation
+
+### Link Component
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+// Static route
+<Link to="/about">About</Link>
+
+// Dynamic route with params
+<Link to="/posts/$postId" params={{ postId: '123' }}>
+  Post 123
+</Link>
+
+// With search params
+<Link to="/posts" search={{ page: 2, filter: 'react' }}>
+  Page 2
+</Link>
+
+// Active link styling
+<Link
+  to="/posts"
+  activeProps={{ className: 'active' }}
+  inactiveProps={{ className: 'inactive' }}
+  activeOptions={{ exact: true }}
+>
+  Posts
+</Link>
+
+// Preloading
+<Link to="/posts" preload="intent">Posts</Link>
+<Link to="/dashboard" preload="viewport">Dashboard</Link>
+
+// Hash
+<Link to="/docs" hash="api-reference">API Reference</Link>
+```
+
+### Programmatic Navigation
+
+```tsx
+import { useNavigate, useRouter } from '@tanstack/react-router'
+
+function MyComponent() {
+  const navigate = useNavigate()
+  const router = useRouter()
+
+  // Navigate to a route
+  navigate({ to: '/posts', search: { page: 1 } })
+
+  // Navigate with replace
+  navigate({ to: '/posts', replace: true })
+
+  // Relative navigation
+  navigate({ to: '.', search: (prev) => ({ ...prev, page: 2 }) })
+
+  // Go back/forward
+  router.history.back()
+  router.history.forward()
+
+  // Invalidate and reload current route
+  router.invalidate()
+}
+```
+
+### Redirects
+
+```tsx
+import { redirect } from '@tanstack/react-router'
+
+// In beforeLoad or loader
+throw redirect({
+  to: '/login',
+  search: { redirect: location.href },
+  // Optional status code
+  statusCode: 301, // Permanent redirect (SSR)
+})
+```
+
+### Navigation Blocking
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+
+function FormComponent() {
+  const [isDirty, setIsDirty] = useState(false)
+
+  useBlocker({
+    shouldBlockFn: () => isDirty,
+    withResolver: true, // Shows confirm dialog
+  })
+
+  // Or with custom UI
+  const { proceed, reset, status } = useBlocker({
+    shouldBlockFn: () => isDirty,
+  })
+
+  if (status === 'blocked') {
+    return (
+      <div>
+        <p>Are you sure you want to leave?</p>
+        <button onClick={proceed}>Leave</button>
+        <button onClick={reset}>Stay</button>
+      </div>
+    )
+  }
+}
+```
+
+## Code Splitting
+
+### Automatic (File-Based Routing)
+
+With file-based routing, create a lazy file:
+
+```
+routes/
+  posts.tsx          # Critical: loader, beforeLoad, meta
+  posts.lazy.tsx     # Lazy: component, pendingComponent, errorComponent
+```
+
+```tsx
+// posts.tsx (loaded eagerly)
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+})
+
+// posts.lazy.tsx (loaded lazily)
+import { createLazyFileRoute } from '@tanstack/react-router'
+
+export const Route = createLazyFileRoute('/posts')({
+  component: PostsComponent,
+  pendingComponent: PostsLoading,
+  errorComponent: PostsError,
+})
+```
+
+### Manual Code Splitting
+
+```tsx
+const postsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/posts',
+  loader: () => fetchPosts(),
+}).lazy(() => import('./posts.lazy').then((d) => d.Route))
+```
+
+## Preloading
+
+```tsx
+// Router-level defaults
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent', // 'intent' | 'viewport' | 'render' | false
+  defaultPreloadStaleTime: 30_000, // 30 seconds
+})
+
+// Route-level
+export const Route = createFileRoute('/posts/$postId')({
+  // Stale time for the loader data
+  staleTime: 5_000,
+  // How long preloaded data stays fresh
+  preloadStaleTime: 30_000,
+})
+
+// Link-level
+<Link to="/posts" preload="intent" preloadDelay={100}>
+  Posts
+</Link>
+```
+
+## Type Safety
+
+### Register Router Type
+
+```tsx
+// Declare module for type inference
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+### Type-Safe Hooks
+
+All hooks are fully typed based on the route tree:
+
+```tsx
+// useParams - typed to route's params
+const { postId } = useParams({ from: '/posts/$postId' })
+
+// useSearch - typed to route's search schema
+const { page } = useSearch({ from: '/posts' })
+
+// useLoaderData - typed to loader return
+const data = useLoaderData({ from: '/posts/$postId' })
+
+// useRouteContext - typed to route context
+const { auth } = useRouteContext({ from: '/protected' })
+```
+
+### Route Generics
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  // TypeScript infers:
+  // params: { postId: string }
+  // search: validated search schema type
+  // loaderData: return type of loader
+  // context: router context type
+})
+```
+
+## Authenticated Routes
+
+```tsx
+// __root.tsx
+export const Route = createRootRouteWithContext<{
+  auth: AuthContext
+}>()({
+  component: RootComponent,
+})
+
+// _authenticated.tsx (pathless layout for auth)
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: { redirect: location.href },
+      })
+    }
+  },
+})
+
+// _authenticated/dashboard.tsx
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  component: Dashboard, // Only accessible when authenticated
+})
+```
+
+## Scroll Restoration
+
+```tsx
+const router = createRouter({
+  routeTree,
+  // Enable scroll restoration
+  defaultScrollRestoration: true,
+})
+
+// Or per-route
+export const Route = createFileRoute('/posts')({
+  // Scroll to top on navigation
+  scrollRestoration: true,
+})
+
+// Custom scroll restoration key
+<ScrollRestoration
+  getKey={(location) => location.pathname}
+/>
+```
+
+## Route Masking
+
+Display a different URL than the actual route:
+
+```tsx
+<Link
+  to="/photos/$photoId"
+  params={{ photoId: photo.id }}
+  mask={{ to: '/photos', search: { photoId: photo.id } }}
+>
+  View Photo
+</Link>
+
+// Or programmatically
+navigate({
+  to: '/photos/$photoId',
+  params: { photoId: photo.id },
+  mask: { to: '/photos', search: { photoId: photo.id } },
+})
+```
+
+## Not Found Handling
+
+```tsx
+// Global 404
+const router = createRouter({
+  routeTree,
+  defaultNotFoundComponent: () => <div>Page not found</div>,
+})
+
+// Route-level 404
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    const post = await fetchPost(params.postId)
+    if (!post) throw notFound()
+    return post
+  },
+  notFoundComponent: () => <div>Post not found</div>,
+})
+```
+
+## Head Management
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData.title },
+      { name: 'description', content: loaderData.excerpt },
+      { property: 'og:title', content: loaderData.title },
+    ],
+    links: [
+      { rel: 'canonical', href: `https://example.com/posts/${loaderData.id}` },
+    ],
+  }),
+})
+```
+
+## Integration with TanStack Query
+
+```tsx
+import { queryOptions } from '@tanstack/react-query'
+
+const postsQueryOptions = queryOptions({
+  queryKey: ['posts'],
+  queryFn: fetchPosts,
+})
+
+export const Route = createFileRoute('/posts')({
+  loader: ({ context: { queryClient } }) => {
+    // Ensure data is in cache, won't refetch if fresh
+    return queryClient.ensureQueryData(postsQueryOptions)
+  },
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  // Use the same query options for reactive updates
+  const { data: posts } = useSuspenseQuery(postsQueryOptions)
+  return <PostsList posts={posts} />
+}
+```
+
+## Router Hooks Reference
+
+| Hook | Purpose |
+|------|---------|
+| `useRouter()` | Access router instance |
+| `useRouterState()` | Subscribe to router state |
+| `useParams()` | Get route path params |
+| `useSearch()` | Get validated search params |
+| `useLoaderData()` | Get route loader data |
+| `useRouteContext()` | Get route context |
+| `useNavigate()` | Get navigate function |
+| `useLocation()` | Get current location |
+| `useMatches()` | Get all matched routes |
+| `useMatch()` | Get specific route match |
+| `useBlocker()` | Block navigation |
+| `useLinkProps()` | Get link props for custom components |
+| `useMatchRoute()` | Check if a route matches |
+
+## Best Practices
+
+1. **Use file-based routing** for most applications - it's simpler and auto-generates the route tree
+2. **Validate search params** with Zod or custom validators for type safety
+3. **Use `loaderDeps`** to control when loaders re-execute based on search param changes
+4. **Leverage context** for dependency injection (QueryClient, auth state)
+5. **Use `beforeLoad`** for authentication guards, not in components
+6. **Separate critical vs lazy code** - keep loaders in the main file, components in `.lazy.tsx`
+7. **Use `preload="intent"`** on Links for perceived performance
+8. **Use `staleTime`** to prevent unnecessary refetches during navigation
+9. **Register the router type** for full TypeScript inference across the app
+10. **Use `notFound()`** instead of conditional rendering for 404 states
+11. **Colocate search param logic** with routes that own them
+12. **Use pathless layouts** (`_authenticated`) for shared auth/layout logic without URL segments
+
+## Common Pitfalls
+
+- Forgetting to register the router type (`declare module`)
+- Not using `loaderDeps` when loader depends on search params (causes stale data)
+- Putting auth checks in components instead of `beforeLoad` (flash of protected content)
+- Not handling the loading state with `pendingComponent`
+- Using `useEffect` for data fetching instead of route loaders
+- Mutating search params directly instead of using navigate/Link
+- Not wrapping the app with `RouterProvider`
+- Forgetting `getParentRoute` in code-based route definitions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtfs-viz",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "Lightweight GTFS data visualizer and editor",
   "keywords": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gabrielahn/gtfs-viz-cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Lightweight GTFS data visualizer and editor — import, browse stations/stops/routes/pathways, edit connections, compare schedules, and export feeds from the terminal with DuckDB and a browser dashboard",
   "license": "MIT",
   "author": "Gabriel AHN",

--- a/packages/cli/skills/gtfs-viz/SKILL.md
+++ b/packages/cli/skills/gtfs-viz/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: gtfs-viz
-description: Import GTFS transit feeds, query station/stop/pathway/route data, edit connections, nodes, and routes, compare trip service patterns, export changes to GTFS CSV, and open a local browser dashboard. Use when working with GTFS data, transit stations, pathways, routes, or accessibility audits.
+description: Import GTFS transit feeds, query station/stop/pathway/route/trip/calendar/shape data, edit connections, nodes, routes, trips, and stop times, compare trip service patterns and schedules, export changes to GTFS CSV, and open a local browser dashboard. Use when working with GTFS data, transit stations, pathways, routes, trips, schedules, or accessibility audits.
 license: MIT
 compatibility: Requires Node.js 18+ and DuckDB CLI on PATH or DUCKDB_BIN
+install: npx skills add gabrielAHN/gtfs-viz
 metadata:
   author: gabrielahn
-  version: "1.4.0"
+  version: "1.5.0"
+  repository: gabrielAHN/gtfs-viz
 ---
 
 # GTFS Viz CLI
 
-Import GTFS feeds, query transit data, browse routes and service patterns, edit stations/pathways/routes, export changes, or open the local dashboard.
+Import GTFS feeds, query transit data, browse routes/trips/calendars/shapes, compare trip schedules, edit stations/pathways/routes/trips/stop times, export changes, or open the local dashboard.
 
 ## Reference Files
 
@@ -24,12 +26,20 @@ Read these when you need exact column names, SQL syntax, or flag details:
 
 ## Install
 
+Install the skill via npx:
+
+```bash
+npx skills add gabrielAHN/gtfs-viz
+```
+
+Or install the CLI globally and register the skill:
+
 ```bash
 npm install -g @gabrielahn/gtfs-viz-cli
 gtfs-viz install-skill
 ```
 
-Or from the repo:
+From the repo:
 
 ```bash
 yarn build
@@ -72,6 +82,20 @@ gtfs-viz stops --location-type "Stop"             # By type
 gtfs-viz stops --wheelchair "unknown"             # By wheelchair status
 ```
 
+```bash
+gtfs-viz trips                                   # Open trips view
+gtfs-viz trips --route R1 --data                 # Trips for a route
+gtfs-viz trip trip-123 --data                    # Stop times for a trip
+gtfs-viz trip trip-123 --view timeline           # Open timeline view
+gtfs-viz trip trip-123 --compare trip-456        # Compare two trips
+
+gtfs-viz calendar --data                         # List all services
+gtfs-viz calendar SAT-1 --data                   # Calendar for a service
+
+gtfs-viz shapes --data                           # List all shapes
+gtfs-viz shapes shape-123 --data                 # Points for a shape
+```
+
 Add `--format json` for JSON output.
 
 ## Dashboard
@@ -111,17 +135,43 @@ gtfs-viz station_pathways place-pktrm --node-id node-pktrm-stair7-gl --data
 
 When checking for missing station pieces or broken internal connectivity, use station-part and network functions only. Start with `get_station_stops(station_id)`, then inspect `get_station_pathways(station_id)`, `get_station_routes(station_id)`, `find_shortest_path`, or `find_reachable_stops`. Do not audit station-internal connectivity from `StopsTable`, because that table is for standalone stops. See [references/gtfs-schedule-reference.md](references/gtfs-schedule-reference.md).
 
-## Service Routes
+## Routes & Service
 
 ```bash
 gtfs-viz routes                                   # List all routes
 gtfs-viz routes --type Bus                        # Filter by type
 gtfs-viz routes --route-name "Metro"              # Filter by name
 gtfs-viz routes --route-id ROUTE_ID               # Filter by ID
-gtfs-viz routes --dashboard --route map           # Open routes map
 gtfs-viz route "Line 1"                           # Open route info
 gtfs-viz route --route-id ROUTE_ID --data         # Print route data
-gtfs-viz route "Line 1" --route service           # Open service view
+gtfs-viz route "Line 1" --view service            # Open service view
+```
+
+## Trips & Stop Times
+
+```bash
+gtfs-viz trips --data                             # List all trips
+gtfs-viz trips --route R1 --data                  # Trips for a route
+gtfs-viz trip trip-123 --data                     # Stop times with stop names
+gtfs-viz trip trip-123 --data --view info          # Trip metadata
+gtfs-viz trip trip-123 --view timeline             # Open timeline view
+gtfs-viz trip trip-123 --view map                  # Open map view
+gtfs-viz trip trip-123 --compare trip-456 --data   # Compare stop times
+gtfs-viz trip trip-123 --compare trip-456,trip-789 --view map # Compare 3 trips on map
+gtfs-viz trips --compare trip-1,trip-2,trip-3      # Compare trips in dashboard
+```
+
+Views: `timetable` (default), `timeline` (time chart), `map` (location), `info` (metadata with --data).
+
+## Calendar & Shapes
+
+```bash
+gtfs-viz calendar --data                          # List services with trip counts
+gtfs-viz calendar --route R1 --data               # Services for a route
+gtfs-viz calendar SAT-1 --data                    # Calendar + dates for a service
+gtfs-viz shapes --data                            # List shapes with point counts
+gtfs-viz shapes --route R1 --data                 # Shapes for a route
+gtfs-viz shapes shape-123 --data                  # Points for a shape
 ```
 
 ## Station Routes & Pathfinding
@@ -174,7 +224,10 @@ gtfs-viz query --name station-stops --args-json '{"stationId":"place-pktrm"}' --
 Review pending edits:
 
 ```bash
-gtfs-viz edit_table
+gtfs-viz edit_table                               # Show all edit tables
+gtfs-viz edit_table stop_times                    # Show stop time edits
+gtfs-viz edit_table calendar                      # Show calendar edits
+gtfs-viz edit_table trips                         # Show trip edits
 ```
 
 ## Export

--- a/packages/cli/skills/gtfs-viz/references/commands.md
+++ b/packages/cli/skills/gtfs-viz/references/commands.md
@@ -1,6 +1,7 @@
 # GTFS Viz CLI — Command Reference
 
-Install: `npm install -g @gabrielahn/gtfs-viz-cli`
+Install skill: `npx skills add gabrielAHN/gtfs-viz`
+Install CLI: `npm install -g @gabrielahn/gtfs-viz-cli`
 
 ## Import & Status
 
@@ -72,6 +73,56 @@ Flags: `--service`, `--service-id`, `--trip`, `--trip-id`, `--compare <t1,t2,...
 
 `--compare` requires `--service` and accepts up to 5 comma-separated trip IDs.
 
+## Trips & Stop Times
+
+```bash
+gtfs-viz trips --data                              # List all trips with stop counts
+gtfs-viz trips --route R1 --data                   # Trips for a route
+gtfs-viz trips --route R1 --service SAT --data     # Trips for route+service
+gtfs-viz trips trip-123 --data                     # Stop times for a trip
+gtfs-viz trips --compare t1,t2 --data              # Compare stop times side-by-side
+gtfs-viz trips --compare t1,t2,t3                  # Compare trips in dashboard
+gtfs-viz trips --compare t1,t2 --view map          # Compare on map
+```
+
+```bash
+gtfs-viz trip trip-123                              # Open trip in dashboard
+gtfs-viz trip trip-123 --data                      # Print stop times with stop names
+gtfs-viz trip trip-123 --data --view info           # Print trip metadata
+gtfs-viz trip trip-123 --compare trip-456 --data   # Compare two trips
+gtfs-viz trip trip-123 --view timeline              # Open timeline view
+gtfs-viz trip trip-123 --view map                  # Open map view
+gtfs-viz trip trip-123 --compare trip-456 --view map # Compare on map
+```
+
+Flags: `--route`, `--route-id`, `--service`, `--service-id`, `--trip`, `--trip-id`, `--compare <t1,t2,...>`, `--view <timetable|timeline|map|info>`
+
+Views: `timetable` (default, table of stops), `timeline` (time-based chart), `map` (stops on map), `info` (trip metadata, --data only).
+
+**Compare pattern**: `--compare` lists all trip IDs to compare. Example: to compare trips A, B, C use `--compare A,B,C`. With `trip` command, the positional trip ID is automatically included: `gtfs-viz trip A --compare B,C` compares A, B, C.
+
+## Calendar & Services
+
+```bash
+gtfs-viz calendar --data                           # List all services with trip counts
+gtfs-viz calendar --route R1 --data                # Services for a route
+gtfs-viz calendar SAT-1 --data                     # Calendar + dates for a service
+gtfs-viz calendar SAT-1                            # Open service view in dashboard
+```
+
+Flags: `--service-id`, `--service`, `--route-id`, `--route`
+
+## Shapes
+
+```bash
+gtfs-viz shapes --data                             # List all shapes with stats
+gtfs-viz shapes --route R1 --data                  # Shapes for a route
+gtfs-viz shapes shape-123 --data                   # Points for a shape
+gtfs-viz shapes                                    # Open route map in dashboard
+```
+
+Flags: `--shape-id`, `--shape`, `--route-id`, `--route`
+
 ## Pathways & Connections
 
 ```bash
@@ -105,6 +156,9 @@ gtfs-viz edit_table                                          # Show all edits
 gtfs-viz edit_table pathways                                 # Show pathway edits
 gtfs-viz edit_table routes                                   # Show route edits
 gtfs-viz edit_table stops --format json                      # JSON output
+gtfs-viz edit_table stop_times                               # Show stop time edits
+gtfs-viz edit_table calendar                                 # Show calendar edits
+gtfs-viz edit_table trips                                    # Show trip edits
 ```
 
 ## Data Editing (CLI)

--- a/packages/cli/skills/gtfs-viz/references/examples.sql
+++ b/packages/cli/skills/gtfs-viz/references/examples.sql
@@ -163,3 +163,79 @@ FROM targets t
 LEFT JOIN reachable_exits r USING (stop_id)
 WHERE r.stop_id IS NULL
 ORDER BY t.location_type_name, t.stop_name, t.stop_id;
+
+-- ============================================================================
+-- TRIPS & STOP TIMES
+-- ============================================================================
+
+-- List trips with stop counts for a route
+SELECT t.trip_id, t.service_id, t.trip_headsign, COUNT(st.stop_id) AS stop_count
+FROM trips t
+LEFT JOIN stop_times st ON st.trip_id = t.trip_id
+WHERE t.route_id = 'ROUTE_ID'
+GROUP BY t.trip_id, t.service_id, t.trip_headsign
+ORDER BY t.service_id, t.trip_id;
+
+-- Stop times for a trip with stop names
+SELECT st.stop_sequence, st.stop_id, s.stop_name, st.arrival_time, st.departure_time
+FROM stop_times st
+LEFT JOIN stops s ON s.stop_id = st.stop_id
+WHERE st.trip_id = 'TRIP_ID'
+ORDER BY st.stop_sequence;
+
+-- Convert GTFS time strings to seconds for comparison
+SELECT trip_id,
+       gtfs_time_to_seconds(arrival_time) AS arrival_sec,
+       gtfs_time_to_seconds(departure_time) AS departure_sec
+FROM stop_times
+WHERE trip_id = 'TRIP_ID';
+
+-- Find trips with most stops
+SELECT t.trip_id, t.route_id, COUNT(*) AS stops
+FROM stop_times st JOIN trips t ON t.trip_id = st.trip_id
+GROUP BY t.trip_id, t.route_id
+ORDER BY stops DESC LIMIT 10;
+
+-- ============================================================================
+-- CALENDAR & SERVICES
+-- ============================================================================
+
+-- List services with trip counts
+SELECT c.service_id, c.monday, c.tuesday, c.wednesday, c.thursday,
+       c.friday, c.saturday, c.sunday, c.start_date, c.end_date,
+       COUNT(DISTINCT t.trip_id) AS trip_count
+FROM calendar c
+LEFT JOIN trips t ON t.service_id = c.service_id
+GROUP BY c.service_id, c.monday, c.tuesday, c.wednesday, c.thursday,
+         c.friday, c.saturday, c.sunday, c.start_date, c.end_date
+ORDER BY trip_count DESC;
+
+-- Calendar exception dates for a service
+SELECT * FROM calendar_dates WHERE service_id = 'SERVICE_ID' ORDER BY date;
+
+-- ============================================================================
+-- SHAPES
+-- ============================================================================
+
+-- List shapes with point counts and bounding box
+SELECT shape_id, COUNT(*) AS points,
+       MIN(shape_pt_lat) AS min_lat, MAX(shape_pt_lat) AS max_lat,
+       MIN(shape_pt_lon) AS min_lon, MAX(shape_pt_lon) AS max_lon
+FROM shapes GROUP BY shape_id ORDER BY shape_id;
+
+-- Shape points for a specific shape
+SELECT shape_pt_sequence, shape_pt_lat, shape_pt_lon, shape_dist_traveled
+FROM shapes WHERE shape_id = 'SHAPE_ID' ORDER BY shape_pt_sequence;
+
+-- ============================================================================
+-- EDIT TRACKING
+-- ============================================================================
+
+-- Check pending stop time edits
+SELECT * FROM EditStopTimesTable WHERE status != '';
+
+-- Check pending calendar edits
+SELECT * FROM EditCalendarTable WHERE status != '';
+
+-- Check pending trip edits
+SELECT * FROM EditTripsTable WHERE status != '';

--- a/packages/cli/skills/gtfs-viz/references/procedures.md
+++ b/packages/cli/skills/gtfs-viz/references/procedures.md
@@ -1,5 +1,34 @@
 # GTFS Extension — SQL Procedures Reference
 
+## Scalar Macros
+
+Utility macros for data conversion, available in any SQL query.
+
+### gtfs_time_to_seconds(time_str)
+
+Convert GTFS time string (HH:MM:SS, supports >24h for overnight trips) to total seconds.
+
+```sql
+SELECT gtfs_time_to_seconds('08:30:00');  -- Returns 30600
+SELECT gtfs_time_to_seconds('25:15:00');  -- Returns 90900 (next day)
+```
+
+### location_type_to_name(location_type, parent_station)
+
+Convert GTFS location_type integer to name: Stop, Station, Platform, Exit/Entrance, Pathway Node, Boarding Area.
+
+### pathway_mode_to_name(mode)
+
+Convert pathway_mode integer to name: Walkway(1), Stairs(2), Moving sidewalk(3), Escalator(4), Elevator(5), Fare gate(6), Exit gate(7).
+
+### wheelchair_to_emoji(wheelchair_boarding)
+
+Convert wheelchair_boarding integer to emoji: 🔵(0), 🟢(1), 🔴(2), 🟡(other).
+
+### bidirectional_to_direction(is_bidirectional)
+
+Convert is_bidirectional to text: directional(0), bidirectional(1).
+
 ## Query Macros
 
 These macros are available after the GTFS extension is installed. Call them with `SELECT * FROM macro_name(args)`.

--- a/packages/cli/skills/gtfs-viz/references/tables.md
+++ b/packages/cli/skills/gtfs-viz/references/tables.md
@@ -239,6 +239,54 @@ Tracks pathway/connection edits. Status: `new`, `edit`, `new edit`, `deleted`.
 | reversed_signposted_as | TEXT    |
 | status                 | TEXT    |
 
+### EditStopTimesTable
+
+Tracks stop time edits for trips. Status: `new`, `edit`, `new edit`, `deleted`.
+
+| Column         | Type    |
+| -------------- | ------- |
+| trip_id        | TEXT    |
+| stop_sequence  | INTEGER |
+| stop_id        | TEXT    |
+| arrival_time   | TEXT    |
+| departure_time | TEXT    |
+| stop_headsign  | TEXT    |
+| pickup_type    | INTEGER |
+| drop_off_type  | INTEGER |
+| status         | TEXT    |
+
+### EditCalendarTable
+
+Tracks calendar/service edits. Status: `new`, `edit`, `new edit`, `deleted`.
+
+| Column     | Type    |
+| ---------- | ------- |
+| service_id | TEXT    |
+| monday     | INTEGER |
+| tuesday    | INTEGER |
+| wednesday  | INTEGER |
+| thursday   | INTEGER |
+| friday     | INTEGER |
+| saturday   | INTEGER |
+| sunday     | INTEGER |
+| start_date | TEXT    |
+| end_date   | TEXT    |
+| status     | TEXT    |
+
+### EditTripsTable
+
+Tracks trip edits. Status: `new`, `edit`, `new edit`, `deleted`.
+
+| Column       | Type    |
+| ------------ | ------- |
+| trip_id      | TEXT    |
+| route_id     | TEXT    |
+| service_id   | TEXT    |
+| trip_headsign| TEXT    |
+| direction_id | INTEGER |
+| shape_id     | TEXT    |
+| status       | TEXT    |
+
 ## Enum Values
 
 ### location_type_to_name(location_type, parent_station)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -652,7 +652,7 @@ async function resolveStationFromArgs(args: Args): Promise<{ stopId: string; sto
   return resolveSelection(ds.dbPath, "StationsTable", si);
 }
 
-async function resolveStopFromArgs(args: Args): Promise<{ stopId: string; stopName?: string }> {
+async function resolveStopFromArgs(args: Args): Promise<{ stopId: string; stopName?: string; stopLat?: number; stopLon?: number }> {
   const positional = args.positionals.filter((p) => !VIEW_NAMES.has(p)).join(" ").trim();
   const flags = { ...args.flags };
   const id = getFlagString(flags, "id") || getFlagString(flags, "stop-id");
@@ -664,7 +664,12 @@ async function resolveStopFromArgs(args: Args): Promise<{ stopId: string; stopNa
   const si = getStopSelectionInput(flags);
   if (!si) throw new Error("Provide a stop value");
   const ds = await readDatasetState();
-  return resolveSelection(ds.dbPath, "StopsTable", si);
+  try {
+    return await resolveSelection(ds.dbPath, "StopsTable", si);
+  } catch {
+    // Fall back to StationsTable so station names (e.g. "Alewife") also resolve
+    return resolveSelection(ds.dbPath, "StationsTable", si);
+  }
 }
 
 const getServiceRouteSelectionInput = (flags: Record<string, string | boolean>) =>
@@ -2343,7 +2348,8 @@ const commandStationShortestRoute = async (args: Args) => {
   const st = await resolveStationFromArgs(args);
   const ds = await readDatasetState();
 
-  const rows = await queryRows(
+  // Prefer entrance-to-entrance; fall back to any route with a time
+  let rows = await queryRows(
     ds.dbPath,
     `
     SELECT *
@@ -2355,6 +2361,18 @@ const commandStationShortestRoute = async (args: Args) => {
     LIMIT 1`,
   );
 
+  if (rows.length === 0) {
+    rows = await queryRows(
+      ds.dbPath,
+      `
+      SELECT *
+      FROM get_station_routes(${sqlString(st.stopId)})
+      WHERE shortest_time IS NOT NULL
+      ORDER BY shortest_time, start_stop, end_stop
+      LIMIT 1`,
+    );
+  }
+
   if (wantsDataOutput(args.flags)) {
     printResult(
       {
@@ -2362,6 +2380,7 @@ const commandStationShortestRoute = async (args: Args) => {
         stationName: st.stopName,
         columns: rows.length > 0 ? Object.keys(rows[0]) : [],
         rows,
+        ...(rows.length === 0 ? { message: "No timed routes found for this station" } : {}),
       },
       args.flags,
     );
@@ -2394,10 +2413,17 @@ const commandStopInfo = async (args: Args) => {
   };
   if (wantsDataOutput(args.flags)) {
     const ds = await readDatasetState();
-    const rows = await queryRows(
+    let rows = await queryRows(
       ds.dbPath,
       `SELECT * FROM StopsTable WHERE stop_id = ${sqlString(st.stopId)}`,
     );
+    // If no stop row, try StationsTable (resolveStopFromArgs may have fallen back)
+    if (rows.length === 0) {
+      rows = await queryRows(
+        ds.dbPath,
+        `SELECT * FROM StationsTable WHERE stop_id = ${sqlString(st.stopId)}`,
+      );
+    }
     printResult(
       {
         stopId: st.stopId,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -667,8 +667,19 @@ async function resolveStopFromArgs(args: Args): Promise<{ stopId: string; stopNa
   try {
     return await resolveSelection(ds.dbPath, "StopsTable", si);
   } catch {
-    // Fall back to StationsTable so station names (e.g. "Alewife") also resolve
-    return resolveSelection(ds.dbPath, "StationsTable", si);
+    try {
+      // Fall back to StationsTable so station names (e.g. "Alewife") also resolve
+      return await resolveSelection(ds.dbPath, "StationsTable", si);
+    } catch {
+      // Last resort: raw stops table for IDs not in either view (e.g. subway platforms)
+      const { idE, idL, nmE, nmL, idC, nmC } = selectionExpressions(si);
+      const rows = await queryRows(ds.dbPath, `SELECT stop_id, stop_name, stop_lat, stop_lon FROM stops WHERE ${idE} OR ${idL} OR ${nmE} OR ${nmL} OR ${idC} OR ${nmC} LIMIT 1`);
+      if (rows.length > 0) {
+        const row = rows[0];
+        return { stopId: String(row.stop_id), stopName: typeof row.stop_name === "string" ? row.stop_name : undefined, stopLat: numberOrUndefined(row.stop_lat), stopLon: numberOrUndefined(row.stop_lon) };
+      }
+      throw new Error(`No stop matched "${si.value}" from --${si.flag}`);
+    }
   }
 }
 
@@ -960,8 +971,16 @@ const commandStations = async (args: Args) => {
       getFlagString(args.flags, "pathways-status") || getFlagString(args.flags, "pathways");
     if (id) filters.push(`stop_id = ${sqlString(id)}`);
     if (name) filters.push(`LOWER(stop_name) LIKE LOWER(${sqlString(`%${name}%`)})`);
-    if (wheelchair) filters.push(`wheelchair_status = ${sqlString(wheelchair)}`);
-    if (pathways) filters.push(`pathways_status = ${sqlString(pathways)}`);
+    if (wheelchair) {
+      const wMap: Record<string, string> = { accessible: "🟢", "not accessible": "🔴", "not-accessible": "🔴", unknown: "🔵", no: "🔴", yes: "🟢" };
+      const wVal = wMap[wheelchair.toLowerCase()] || wheelchair;
+      filters.push(`wheelchair_status = ${sqlString(wVal)}`);
+    }
+    if (pathways) {
+      const pMap: Record<string, string> = { yes: "✅", no: "❌", partial: "⚠️" };
+      const pVal = pMap[pathways.toLowerCase()] || pathways;
+      filters.push(`pathways_status = ${sqlString(pVal)}`);
+    }
     const where = filters.length > 0 ? ` WHERE ${filters.join(" AND ")}` : "";
     const rows = await queryRows(dataset.dbPath, `SELECT * FROM StationsTable${where}`);
     printOrNone(rows, args);
@@ -994,10 +1013,18 @@ const commandStops = async (args: Args) => {
     const locationType = getFlagString(args.flags, "location-type");
     if (id) filters.push(`stop_id = ${sqlString(id)}`);
     if (name) filters.push(`LOWER(stop_name) LIKE LOWER(${sqlString(`%${name}%`)})`);
-    if (wheelchair) filters.push(`wheelchair_status = ${sqlString(wheelchair)}`);
+    if (wheelchair) {
+      const wMap: Record<string, string> = { accessible: "🟢", "not accessible": "🔴", "not-accessible": "🔴", unknown: "🔵", no: "🔴", yes: "🟢" };
+      const wVal = wMap[wheelchair.toLowerCase()] || wheelchair;
+      filters.push(`wheelchair_status = ${sqlString(wVal)}`);
+    }
     if (locationType) filters.push(`location_type_name = ${sqlString(locationType)}`);
     const where = filters.length > 0 ? ` WHERE ${filters.join(" AND ")}` : "";
-    const rows = await queryRows(dataset.dbPath, `SELECT * FROM StopsTable${where}`);
+    let rows = await queryRows(dataset.dbPath, `SELECT * FROM StopsTable${where}`);
+    // Fall back to raw stops table for IDs not in StopsTable (e.g. subway platforms)
+    if (rows.length === 0 && id && filters.length === 1) {
+      rows = await queryRows(dataset.dbPath, `SELECT * FROM stops WHERE stop_id = ${sqlString(id)}`);
+    }
     printOrNone(rows, args);
     return;
   }
@@ -1193,7 +1220,7 @@ const commandRoutes = async (args: Args) => {
     if (type) {
       const numericType = Number(type);
       if (Number.isFinite(numericType)) filters.push(`route_type = ${numericType}`);
-      else filters.push(`route_type_name = ${sqlString(type)}`);
+      else filters.push(`LOWER(route_type_name) LIKE LOWER(${sqlString(`%${type}%`)})`);
     }
     const where = filters.length > 0 ? ` WHERE ${filters.join(" AND ")}` : "";
     const rows = await queryRows(dataset.dbPath, `SELECT * FROM RoutesTable${where}`);
@@ -2417,11 +2444,17 @@ const commandStopInfo = async (args: Args) => {
       ds.dbPath,
       `SELECT * FROM StopsTable WHERE stop_id = ${sqlString(st.stopId)}`,
     );
-    // If no stop row, try StationsTable (resolveStopFromArgs may have fallen back)
+    // If no stop row, try StationsTable, then raw stops table
     if (rows.length === 0) {
       rows = await queryRows(
         ds.dbPath,
         `SELECT * FROM StationsTable WHERE stop_id = ${sqlString(st.stopId)}`,
+      );
+    }
+    if (rows.length === 0) {
+      rows = await queryRows(
+        ds.dbPath,
+        `SELECT * FROM stops WHERE stop_id = ${sqlString(st.stopId)}`,
       );
     }
     printResult(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -69,6 +69,7 @@ const supportedViews = new Set([
   "routes/service",
   "routes/table",
   "routes/trips",
+  "trips/table",
   "stops/map",
   "stops/table",
 ]);
@@ -914,6 +915,9 @@ const commandImport = async (args: Args) => {
     console.log(
       `Stops: ${metadata.counts.stops}  Stations: ${metadata.counts.stations}  Pathways: ${metadata.counts.pathways}  Routes: ${metadata.counts.routes}`,
     );
+    // Start session so dashboard is accessible without opening browser
+    const daemon = await spawnDaemon();
+    console.log(`Dashboard: ${daemon.dashboardUrl}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Import failed: ${path.basename(feedArg)}`);
@@ -1014,13 +1018,9 @@ const addRouteServiceParams = (args: Args, params: Record<string, string>) => {
   const compare = getFlagString(args.flags, "compare");
   if (serviceId) params.selectedServiceId = serviceId;
   if (compare) {
-    // First trip becomes selectedTripId so the trip panel renders,
-    // ALL trips go to compareTripIds so they all show in compare view
-    const trips = compare.split(",").map((s) => s.trim()).filter(Boolean);
-    if (trips.length > 0) {
-      params.selectedTripId = tripId || trips[0];
-      params.compareTripIds = compare;
-    }
+    const allIds = compare.split(",").map((s) => s.trim()).filter(Boolean);
+    if (tripId && !allIds.includes(tripId)) allIds.unshift(tripId);
+    params.compareTripIds = allIds.join(",");
   } else if (tripId) {
     params.selectedTripId = tripId;
   }
@@ -1164,7 +1164,10 @@ const printOrNone = (rows: Record<string, unknown>[], args: Args) => {
     console.log("No results found.");
     return;
   }
-  printResult({ columns: Object.keys(rows[0]), rows }, args.flags);
+  // Union of all keys across all rows (handles compare where trips have different stop_sequences)
+  const colSet = new Set<string>();
+  for (const row of rows) for (const key of Object.keys(row)) colSet.add(key);
+  printResult({ columns: Array.from(colSet), rows }, args.flags);
 };
 
 const commandRoutes = async (args: Args) => {
@@ -1208,7 +1211,17 @@ const commandRoutes = async (args: Args) => {
     params.selectedRouteId = id;
   }
   addRouteServiceParams(args, params);
-  await openDashboardView(serviceRoutesViewForRoute(getViewFlag(args), id), params);
+  // When comparing trips or selecting a specific trip, use trips/table which supports those params
+  const compareRaw = getFlagString(args.flags, "compare");
+  const tripId = getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "trip");
+  if (compareRaw || tripId) {
+    if (id) params.routeId = id; // trips/table uses routeId for filtering
+    const view = getViewFlag(args);
+    if (view === "timeline" || view === "map") params.view = view;
+    await openDashboardView("trips/table", params);
+  } else {
+    await openDashboardView(serviceRoutesViewForRoute(getViewFlag(args), id), params);
+  }
 };
 
 const commandRoute = async (args: Args) => {
@@ -1229,7 +1242,250 @@ const commandRoute = async (args: Args) => {
   params.cliSelectedRoute = route.routeId;
   params.selectedRouteId = route.routeId;
   addRouteServiceParams(args, params);
-  await openDashboardView(serviceRoutesViewForRoute(getViewFlag(args), route.routeId), params);
+  const compareRaw = getFlagString(args.flags, "compare");
+  const tripId = getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "trip");
+  if (compareRaw || tripId) {
+    params.routeId = route.routeId; // trips/table uses routeId for filtering
+    const view = getViewFlag(args);
+    if (view === "timeline" || view === "map") params.view = view;
+    await openDashboardView("trips/table", params);
+  } else {
+    await openDashboardView(serviceRoutesViewForRoute(getViewFlag(args), route.routeId), params);
+  }
+};
+
+const commandTrips = async (args: Args) => {
+  ensureOutputMode(args);
+  const routeId = getFlagString(args.flags, "route-id") || getFlagString(args.flags, "route") || getFlagString(args.flags, "id");
+  const serviceId = getFlagString(args.flags, "service-id") || getFlagString(args.flags, "service");
+  const tripId = getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "trip") || getPositionalId(args);
+  const compareRaw = getFlagString(args.flags, "compare");
+
+  if (wantsDataOutput(args.flags)) {
+    const ds = await readDatasetState();
+
+    // --compare trip1,trip2,... — side-by-side stop times
+    if (compareRaw) {
+      const tripIds = compareRaw.split(",").map((s) => s.trim()).filter(Boolean);
+      if (tripIds.length === 0) {
+        console.log("Provide comma-separated trip IDs: --compare trip1,trip2");
+        return;
+      }
+      if (tripIds.length > MAX_COMPARE_TRIPS) {
+        console.log(`Maximum ${MAX_COMPARE_TRIPS} trips can be compared.`);
+        return;
+      }
+      const allRows: Record<string, unknown>[] = [];
+      for (const tid of tripIds) {
+        const rows = await queryRows(
+          ds.dbPath,
+          `SELECT st.stop_sequence, st.stop_id, s.stop_name, st.arrival_time, st.departure_time
+           FROM stop_times st LEFT JOIN stops s ON s.stop_id = st.stop_id
+           WHERE st.trip_id = ${sqlString(tid)} ORDER BY st.stop_sequence`,
+        );
+        if (rows.length === 0) { console.log(`No stop_times for trip "${tid}".`); return; }
+        for (const row of rows) {
+          const key = Number(row.stop_sequence);
+          if (!allRows[key]) allRows[key] = { stop_sequence: row.stop_sequence, stop_id: row.stop_id, stop_name: row.stop_name };
+          (allRows[key] as any)[`${tid}_arr`] = row.arrival_time;
+          (allRows[key] as any)[`${tid}_dep`] = row.departure_time;
+        }
+      }
+      printOrNone(Object.values(allRows).filter(Boolean).sort((a: any, b: any) => Number(a.stop_sequence) - Number(b.stop_sequence)) as Record<string, unknown>[], args);
+      return;
+    }
+
+    const filters: string[] = [];
+    if (routeId) filters.push(`t.route_id = ${sqlString(routeId)}`);
+    if (serviceId) filters.push(`t.service_id = ${sqlString(serviceId)}`);
+    if (tripId) filters.push(`t.trip_id = ${sqlString(tripId)}`);
+    const where = filters.length > 0 ? ` WHERE ${filters.join(" AND ")}` : "";
+
+    if (tripId && !routeId) {
+      const rows = await queryRows(
+        ds.dbPath,
+        `SELECT st.stop_sequence, st.stop_id, s.stop_name, st.arrival_time, st.departure_time
+         FROM stop_times st LEFT JOIN stops s ON s.stop_id = st.stop_id
+         WHERE st.trip_id = ${sqlString(tripId)} ORDER BY st.stop_sequence`,
+      );
+      printOrNone(rows, args);
+    } else {
+      const rows = await queryRows(
+        ds.dbPath,
+        `SELECT t.trip_id, t.route_id, t.service_id, t.trip_headsign, t.direction_id, t.shape_id,
+                COUNT(st.stop_id) AS stop_count
+         FROM trips t LEFT JOIN stop_times st ON st.trip_id = t.trip_id
+         ${where}
+         GROUP BY t.trip_id, t.route_id, t.service_id, t.trip_headsign, t.direction_id, t.shape_id
+         ORDER BY t.route_id, t.service_id, t.trip_id`,
+      );
+      printOrNone(rows, args);
+    }
+    return;
+  }
+
+  // Dashboard mode
+  const params = dashboardParamsFromFlags(args);
+  if (routeId) { params.selectedRouteId = routeId; params.cliSelectedRoute = routeId; params.routeId = routeId; }
+  if (tripId && !compareRaw) params.selectedTripId = tripId;
+  if (serviceId) params.selectedServiceId = serviceId;
+  const view = getViewFlag(args);
+  if (view === "timeline" || view === "map") params.view = view;
+  if (compareRaw) {
+    const allIds = compareRaw.split(",").map((s) => s.trim()).filter(Boolean);
+    if (tripId && !allIds.includes(tripId)) allIds.unshift(tripId);
+    params.compareTripIds = allIds.join(",");
+  }
+  await openDashboardView("trips/table", params);
+};
+
+const commandTrip = async (args: Args) => {
+  ensureOutputMode(args);
+  const tripId = getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "id") || getPositionalId(args);
+  if (!tripId) throw new Error("Trip ID is required. Usage: gtfs-viz trip <trip-id>");
+  const compareRaw = getFlagString(args.flags, "compare");
+
+  if (wantsDataOutput(args.flags)) {
+    const ds = await readDatasetState();
+    const view = getViewFlag(args);
+
+    // --compare: side-by-side with other trips
+    if (compareRaw) {
+      const otherIds = compareRaw.split(",").map((s) => s.trim()).filter(Boolean);
+      const allIds = [tripId, ...otherIds];
+      const allRows: Record<string, unknown>[] = [];
+      for (const tid of allIds) {
+        const rows = await queryRows(
+          ds.dbPath,
+          `SELECT st.stop_sequence, st.stop_id, s.stop_name, st.arrival_time, st.departure_time
+           FROM stop_times st LEFT JOIN stops s ON s.stop_id = st.stop_id
+           WHERE st.trip_id = ${sqlString(tid)} ORDER BY st.stop_sequence`,
+        );
+        for (const row of rows) {
+          const key = Number(row.stop_sequence);
+          if (!allRows[key]) allRows[key] = { stop_sequence: row.stop_sequence, stop_id: row.stop_id, stop_name: row.stop_name };
+          (allRows[key] as any)[`${tid}_arr`] = row.arrival_time;
+          (allRows[key] as any)[`${tid}_dep`] = row.departure_time;
+        }
+      }
+      printOrNone(Object.values(allRows).filter(Boolean).sort((a: any, b: any) => Number(a.stop_sequence) - Number(b.stop_sequence)) as Record<string, unknown>[], args);
+      return;
+    }
+
+    if (view === "info") {
+      const rows = await queryRows(ds.dbPath, `SELECT t.* FROM trips t WHERE t.trip_id = ${sqlString(tripId)}`);
+      printOrNone(rows, args);
+    } else {
+      const rows = await queryRows(
+        ds.dbPath,
+        `SELECT st.stop_sequence, st.stop_id, s.stop_name, st.arrival_time, st.departure_time, s.stop_lat, s.stop_lon
+         FROM stop_times st LEFT JOIN stops s ON s.stop_id = st.stop_id
+         WHERE st.trip_id = ${sqlString(tripId)} ORDER BY st.stop_sequence`,
+      );
+      printOrNone(rows, args);
+    }
+    return;
+  }
+
+  // Dashboard mode
+  const ds = await readDatasetState();
+  const tripRows = await queryRows(ds.dbPath, `SELECT route_id, service_id FROM trips WHERE trip_id = ${sqlString(tripId)} LIMIT 1`);
+  if (tripRows.length === 0) { console.log(`No trip found with ID "${tripId}".`); return; }
+  const params = dashboardParamsFromFlags(args);
+  const resolvedRoute = String(tripRows[0].route_id);
+  params.selectedRouteId = resolvedRoute;
+  params.cliSelectedRoute = resolvedRoute;
+  params.routeId = resolvedRoute;
+  if (tripRows[0].service_id) params.selectedServiceId = String(tripRows[0].service_id);
+  const view = getViewFlag(args);
+  if (view === "timeline" || view === "map") params.view = view;
+  if (compareRaw) {
+    const allIds = compareRaw.split(",").map((s) => s.trim()).filter(Boolean);
+    if (!allIds.includes(tripId)) allIds.unshift(tripId);
+    params.compareTripIds = allIds.join(",");
+  } else {
+    params.selectedTripId = tripId;
+  }
+  await openDashboardView("trips/table", params);
+};
+
+const commandCalendar = async (args: Args) => {
+  ensureOutputMode(args);
+  const serviceId = getFlagString(args.flags, "service-id") || getFlagString(args.flags, "service") || getFlagString(args.flags, "id") || getPositionalId(args);
+  const routeId = getFlagString(args.flags, "route-id") || getFlagString(args.flags, "route");
+
+  if (wantsDataOutput(args.flags)) {
+    const ds = await readDatasetState();
+    if (serviceId) {
+      // Show calendar + dates for a specific service
+      const cal = await queryRows(ds.dbPath, `SELECT * FROM calendar WHERE service_id = ${sqlString(serviceId)}`);
+      if (cal.length > 0) {
+        console.log("Calendar:");
+        printOrNone(cal, args);
+      }
+      const dates = await queryRows(ds.dbPath, `SELECT * FROM calendar_dates WHERE service_id = ${sqlString(serviceId)} ORDER BY date`);
+      if (dates.length > 0) {
+        console.log("\nCalendar Dates:");
+        printOrNone(dates, args);
+      }
+      if (cal.length === 0 && dates.length === 0) console.log(`No calendar data for service "${serviceId}".`);
+    } else {
+      // List services with trip counts
+      const filters: string[] = [];
+      if (routeId) filters.push(`t.route_id = ${sqlString(routeId)}`);
+      const where = filters.length > 0 ? `WHERE ${filters.join(" AND ")}` : "";
+      const rows = await queryRows(
+        ds.dbPath,
+        `SELECT c.service_id, c.monday, c.tuesday, c.wednesday, c.thursday, c.friday, c.saturday, c.sunday,
+                c.start_date, c.end_date, COUNT(DISTINCT t.trip_id) AS trip_count
+         FROM calendar c
+         LEFT JOIN trips t ON t.service_id = c.service_id ${where ? `AND ${filters.join(" AND ")}` : ""}
+         GROUP BY c.service_id, c.monday, c.tuesday, c.wednesday, c.thursday, c.friday, c.saturday, c.sunday, c.start_date, c.end_date
+         ORDER BY trip_count DESC`,
+      );
+      printOrNone(rows, args);
+    }
+    return;
+  }
+  // Dashboard — open service view
+  const params = dashboardParamsFromFlags(args);
+  if (routeId) { params.selectedRouteId = routeId; params.cliSelectedRoute = routeId; params.routeId = routeId; }
+  if (serviceId) params.selectedServiceId = serviceId;
+  await openDashboardView("routes/service", params);
+};
+
+const commandShapes = async (args: Args) => {
+  ensureOutputMode(args);
+  const shapeId = getFlagString(args.flags, "shape-id") || getFlagString(args.flags, "shape") || getFlagString(args.flags, "id") || getPositionalId(args);
+  const routeId = getFlagString(args.flags, "route-id") || getFlagString(args.flags, "route");
+
+  if (!wantsDataOutput(args.flags)) {
+    const params = dashboardParamsFromFlags(args);
+    if (routeId) { params.selectedRouteId = routeId; params.cliSelectedRoute = routeId; params.routeId = routeId; }
+    await openDashboardView("routes/map", params);
+    return;
+  }
+  const ds = await readDatasetState();
+  if (shapeId) {
+    const rows = await queryRows(
+      ds.dbPath,
+      `SELECT shape_pt_sequence, shape_pt_lat, shape_pt_lon, shape_dist_traveled
+       FROM shapes WHERE shape_id = ${sqlString(shapeId)} ORDER BY shape_pt_sequence`,
+    );
+    printOrNone(rows, args);
+  } else {
+    const filters: string[] = [];
+    if (routeId) filters.push(`t.route_id = ${sqlString(routeId)}`);
+    const joinClause = filters.length > 0 ? `JOIN trips t ON t.shape_id = s.shape_id WHERE ${filters.join(" AND ")}` : "";
+    const rows = await queryRows(
+      ds.dbPath,
+      `SELECT s.shape_id, COUNT(*) AS point_count, MIN(s.shape_pt_lat) AS min_lat, MAX(s.shape_pt_lat) AS max_lat,
+              MIN(s.shape_pt_lon) AS min_lon, MAX(s.shape_pt_lon) AS max_lon
+       FROM shapes s ${joinClause}
+       GROUP BY s.shape_id ORDER BY s.shape_id`,
+    );
+    printOrNone(rows, args);
+  }
 };
 
 const commandStatus = async () => {
@@ -1733,6 +1989,15 @@ const commandEditTable = async (args: Args) => {
   } else if (table === "stops" || table === "stop" || table === "EditStopTable") {
     const rows = await queryRows(ds.dbPath, "SELECT * FROM EditStopTable");
     printResult({ columns: rows.length > 0 ? Object.keys(rows[0]) : [], rows }, args.flags);
+  } else if (table === "stop_times" || table === "stop-times" || table === "EditStopTimesTable") {
+    const rows = await queryRows(ds.dbPath, "SELECT * FROM EditStopTimesTable");
+    printResult({ columns: rows.length > 0 ? Object.keys(rows[0]) : [], rows }, args.flags);
+  } else if (table === "calendar" || table === "EditCalendarTable") {
+    const rows = await queryRows(ds.dbPath, "SELECT * FROM EditCalendarTable");
+    printResult({ columns: rows.length > 0 ? Object.keys(rows[0]) : [], rows }, args.flags);
+  } else if (table === "trips" || table === "EditTripsTable") {
+    const rows = await queryRows(ds.dbPath, "SELECT * FROM EditTripsTable");
+    printResult({ columns: rows.length > 0 ? Object.keys(rows[0]) : [], rows }, args.flags);
   } else if (!table) {
     console.log("EditPathwayTable:");
     const pathwayRows = await queryRows(ds.dbPath, "SELECT * FROM EditPathwayTable");
@@ -1754,15 +2019,24 @@ const commandEditTable = async (args: Args) => {
     );
     console.log("\nEditStopTable:");
     const stopRows = await queryRows(ds.dbPath, "SELECT * FROM EditStopTable");
-    printResult(
-      {
-        columns: stopRows.length > 0 ? Object.keys(stopRows[0]) : [],
-        rows: stopRows,
-      },
-      args.flags,
-    );
+    printResult({ columns: stopRows.length > 0 ? Object.keys(stopRows[0]) : [], rows: stopRows }, args.flags);
+    try {
+      console.log("\nEditStopTimesTable:");
+      const stRows = await queryRows(ds.dbPath, "SELECT * FROM EditStopTimesTable");
+      printResult({ columns: stRows.length > 0 ? Object.keys(stRows[0]) : [], rows: stRows }, args.flags);
+    } catch { /* table may not exist */ }
+    try {
+      console.log("\nEditCalendarTable:");
+      const calRows = await queryRows(ds.dbPath, "SELECT * FROM EditCalendarTable");
+      printResult({ columns: calRows.length > 0 ? Object.keys(calRows[0]) : [], rows: calRows }, args.flags);
+    } catch { /* table may not exist */ }
+    try {
+      console.log("\nEditTripsTable:");
+      const tripRows = await queryRows(ds.dbPath, "SELECT * FROM EditTripsTable");
+      printResult({ columns: tripRows.length > 0 ? Object.keys(tripRows[0]) : [], rows: tripRows }, args.flags);
+    } catch { /* table may not exist */ }
   } else {
-    throw new Error("edit_table accepts: pathways, routes, stops, or no argument for all");
+    throw new Error("edit_table accepts: pathways, routes, stops, stop_times, calendar, trips, or no argument for all");
   }
 };
 
@@ -2344,6 +2618,22 @@ const main = async () => {
   }
   if (args.command === "route") {
     await commandRoute(args);
+    return;
+  }
+  if (args.command === "trips") {
+    await commandTrips(args);
+    return;
+  }
+  if (args.command === "trip") {
+    await commandTrip(args);
+    return;
+  }
+  if (args.command === "calendar" || args.command === "services") {
+    await commandCalendar(args);
+    return;
+  }
+  if (args.command === "shapes") {
+    await commandShapes(args);
     return;
   }
   if (args.command === "skill-path") {

--- a/packages/cli/src/output/print.ts
+++ b/packages/cli/src/output/print.ts
@@ -195,7 +195,47 @@ const commandHelp: Record<string, string> = {
     --stop-id <id>          Resolve a standalone stop
     --data                  Print stop data instead`,
 
-  edit_table: `gtfs-viz edit_table [pathways|routes|stops] [flags]
+  calendar: `gtfs-viz calendar [<service-id>] [flags]
+
+  List services or show calendar data for a service. Opens dashboard by default.
+
+  Filters:
+    --service-id <id>       Service ID
+    --service <id>          Alias for --service-id
+    --route-id <id>         Filter by route ID
+    --route <id>            Alias for --route-id
+
+  Output:
+    (default)               Open service view in dashboard
+    --data                  Print rows in terminal
+    --format json           JSON output
+
+  Examples:
+    gtfs-viz calendar --data                        List all services
+    gtfs-viz calendar --route R1 --data             Services for route R1
+    gtfs-viz calendar SAT-1 --data                  Calendar for service SAT-1`,
+
+  shapes: `gtfs-viz shapes [<shape-id>] [flags]
+
+  List shapes or show shape points. Opens route map by default.
+
+  Filters:
+    --shape-id <id>         Shape ID
+    --shape <id>            Alias for --shape-id
+    --route-id <id>         Filter by route ID
+    --route <id>            Alias for --route-id
+
+  Output:
+    (default)               Open route map in dashboard
+    --data                  Print rows in terminal
+    --format json           JSON output
+
+  Examples:
+    gtfs-viz shapes --data                          List all shapes
+    gtfs-viz shapes --route R1 --data               Shapes for route R1
+    gtfs-viz shapes shape-123 --data                Points for shape-123`,
+
+  edit_table: `gtfs-viz edit_table [table] [flags]
 
   Show edit tracking tables.
 
@@ -203,6 +243,9 @@ const commandHelp: Record<string, string> = {
     pathways              Show EditPathwayTable
     routes                Show EditRouteTable
     stops                 Show EditStopTable
+    stop_times            Show EditStopTimesTable
+    calendar              Show EditCalendarTable
+    trips                 Show EditTripsTable
     (none)                Show all
 
   Flags:
@@ -387,6 +430,69 @@ const commandHelp: Record<string, string> = {
     table                   Tabular view
     service                 Trip/service schedule`,
 
+  trips: `gtfs-viz trips [<trip-id>] [flags]
+
+  List trips or show a single trip's stop times. Opens dashboard by default.
+
+  Filters:
+    --route-id <id>         Filter by route ID
+    --route <id>            Alias for --route-id
+    --service-id <id>       Filter by service ID
+    --service <id>          Alias for --service-id
+    --trip-id <id>          Show stop times for a specific trip
+    --trip <id>             Alias for --trip-id
+
+  Compare:
+    --compare <t1,t2,...>   Compare trips side-by-side (max 5)
+
+  Views (dashboard mode):
+    --view timetable        Stop times table (default)
+    --view timeline         Time-based horizontal chart
+    --view map              Stops on a map
+
+  Output:
+    (default)               Open trips view in dashboard
+    --data                  Print rows in terminal
+    --format json           JSON output
+
+  Examples:
+    gtfs-viz trips --data                           List all trips
+    gtfs-viz trips --route R1 --data                Trips for route R1
+    gtfs-viz trips --route R1 --service SAT --data  Trips for route+service
+    gtfs-viz trips trip-123 --data                  Stop times for trip-123
+    gtfs-viz trips --compare t1,t2 --data           Compare stop times
+    gtfs-viz trips --compare t1,t2,t3               Compare trips in dashboard
+    gtfs-viz trips --compare t1,t2 --view map       Compare on map`,
+
+  trip: `gtfs-viz trip <trip-id> [flags]
+
+  Show trip stop times in the dashboard, or print trip data.
+
+  Arguments:
+    <trip-id>               Trip ID (positional, required)
+
+  Flags:
+    --data                  Print stop times in terminal
+    --format json           JSON output
+    --view <view>           Dashboard view or data mode
+    --compare <t1,t2,...>   Compare with other trips (comma-separated)
+
+  Views:
+    timetable               Stop times table (default)
+    timeline                Time-based horizontal chart
+    map                     Stops on a map
+    info                    Trip metadata (with --data)
+
+  Examples:
+    gtfs-viz trip trip-123                              Open in dashboard
+    gtfs-viz trip trip-123 --view timeline               Open timeline view
+    gtfs-viz trip trip-123 --view map                    Open map view
+    gtfs-viz trip trip-123 --compare trip-456            Compare two trips
+    gtfs-viz trip trip-123 --compare trip-456 --view map Compare on map
+    gtfs-viz trip trip-123 --data                        Print stop times
+    gtfs-viz trip trip-123 --data --view info            Print trip metadata
+    gtfs-viz trip trip-123 --compare trip-456 --data     Compare stop times`,
+
   query: `gtfs-viz query [flags]
 
   Run SQL or a named query against the local DuckDB database.
@@ -482,9 +588,13 @@ Data:
   stations [filters]                 Browse/lookup stations
   stops [filters]                    Browse/lookup stops
   routes [filters]                   Browse/lookup routes
+  trips [filters]                    Browse/lookup trips and stop times
+  trip <trip-id>                     View trip stop times
+  calendar [service-id]              Browse services/calendar
+  shapes [shape-id]                  Browse route shapes
 
 Edit:
-  edit_table [pathways|routes|stops] Show edit tracking tables
+  edit_table [table]                 Show edit tracking tables
   export [--output --no-stops --no-pathways --no-routes --force]
 
 Query:
@@ -511,6 +621,8 @@ export const printExamples = () => {
   gtfs-viz stops --name "Albany"
   gtfs-viz routes --type Bus
   gtfs-viz route "Red Line"
+  gtfs-viz trips --route R1 --data
+  gtfs-viz trip trip-123 --data
 
 Lookup & dashboard:
   gtfs-viz station "Park Street"

--- a/packages/cli/src/server/http-server.ts
+++ b/packages/cli/src/server/http-server.ts
@@ -310,6 +310,21 @@ export const createServer = (
         return;
       }
 
+      // Redirect any page without CLI params to include them so the app detects CLI mode
+      const isHtmlPage = !url.pathname.startsWith("/__gtfs_viz/") && !url.pathname.startsWith("/assets/") && !url.pathname.match(/\.\w{2,4}$/);
+      if (isHtmlPage && !url.searchParams.has("cliSession")) {
+        const targetPath = url.pathname === "/" ? "/routes/table" : url.pathname;
+        const redirectUrl = new URL(url.toString());
+        redirectUrl.pathname = targetPath;
+        redirectUrl.searchParams.set("gtfsSource", "/__gtfs_viz/feed.zip");
+        redirectUrl.searchParams.set("cliSession", sessionId);
+        redirectUrl.searchParams.set("cliApi", "/__gtfs_viz/api");
+        redirectUrl.searchParams.set("cliView", targetPath.slice(1));
+        res.writeHead(302, { Location: redirectUrl.pathname + redirectUrl.search });
+        res.end();
+        return;
+      }
+
       await serveStatic(res, url.pathname);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/duckdb-extension/sql/gtfs.sql
+++ b/packages/duckdb-extension/sql/gtfs.sql
@@ -46,6 +46,16 @@ CREATE OR REPLACE MACRO wheelchair_to_emoji(wheelchair_boarding) AS (
   END
 );
 
+-- gtfs_time_to_seconds: Convert GTFS time string (HH:MM:SS, supports >24h) to total seconds
+CREATE OR REPLACE MACRO gtfs_time_to_seconds(time_str) AS (
+  CASE
+    WHEN NULLIF(time_str, '') IS NULL THEN NULL
+    ELSE COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 1) AS INTEGER), 0) * 3600
+       + COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 2) AS INTEGER), 0) * 60
+       + COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 3) AS INTEGER), 0)
+  END
+);
+
 -- Edit tracking tables (no data dependency)
 CREATE TABLE IF NOT EXISTS EditStopTable (
     row_id TEXT NOT NULL,

--- a/packages/duckdb-extension/src/include/gtfs_sql.hpp
+++ b/packages/duckdb-extension/src/include/gtfs_sql.hpp
@@ -130,6 +130,50 @@ CREATE TABLE IF NOT EXISTS EditRouteTable (
 );
 ALTER TABLE EditRouteTable ADD COLUMN IF NOT EXISTS shape_points_json TEXT;
 
+CREATE TABLE IF NOT EXISTS EditStopTimesTable (
+    row_id TEXT NOT NULL,
+    trip_id TEXT NOT NULL,
+    stop_sequence INTEGER,
+    stop_id TEXT,
+    arrival_time TEXT,
+    departure_time TEXT,
+    stop_headsign TEXT,
+    pickup_type INTEGER,
+    drop_off_type INTEGER,
+    shape_dist_traveled DOUBLE,
+    status TEXT
+);
+
+CREATE TABLE IF NOT EXISTS EditCalendarTable (
+    row_id TEXT NOT NULL,
+    service_id TEXT NOT NULL,
+    monday INTEGER,
+    tuesday INTEGER,
+    wednesday INTEGER,
+    thursday INTEGER,
+    friday INTEGER,
+    saturday INTEGER,
+    sunday INTEGER,
+    start_date TEXT,
+    end_date TEXT,
+    status TEXT
+);
+
+CREATE TABLE IF NOT EXISTS EditTripsTable (
+    row_id TEXT NOT NULL,
+    route_id TEXT NOT NULL,
+    service_id TEXT NOT NULL,
+    trip_id TEXT NOT NULL,
+    trip_headsign TEXT,
+    trip_short_name TEXT,
+    direction_id INTEGER,
+    block_id TEXT,
+    shape_id TEXT,
+    wheelchair_accessible INTEGER,
+    bikes_allowed INTEGER,
+    status TEXT
+);
+
 )SQL";
 
 // SQL executed after GTFS data is loaded (stops + pathways tables must exist).
@@ -219,19 +263,61 @@ FROM (
   WHERE NOT EXISTS (SELECT 1 FROM EditRouteTable edt WHERE edt.route_id = r.route_id AND edt.status IN ('edit', 'deleted', 'new edit'))
 ) combined;
 
+CREATE OR REPLACE VIEW CalendarView AS
+SELECT row_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date, status
+FROM (
+  SELECT edt.row_id, edt.service_id, edt.monday, edt.tuesday, edt.wednesday, edt.thursday,
+         edt.friday, edt.saturday, edt.sunday, edt.start_date, edt.end_date, edt.status
+  FROM EditCalendarTable edt WHERE edt.status IN ('new', 'edit', 'new edit')
+  UNION ALL
+  SELECT CAST(c.row_id AS TEXT) AS row_id, c.service_id, c.monday, c.tuesday, c.wednesday, c.thursday,
+         c.friday, c.saturday, c.sunday, c.start_date, c.end_date, '' AS status
+  FROM calendar c
+  WHERE NOT EXISTS (SELECT 1 FROM EditCalendarTable edt WHERE edt.service_id = c.service_id AND edt.status = 'deleted')
+    AND NOT EXISTS (SELECT 1 FROM EditCalendarTable edt WHERE edt.service_id = c.service_id AND edt.status IN ('edit', 'new edit'))
+) combined;
+
 CREATE OR REPLACE VIEW TripsView AS
-SELECT t.*
-FROM trips t
-WHERE NOT EXISTS (
-  SELECT 1 FROM EditRouteTable edt
-  WHERE edt.route_id = t.route_id AND edt.status = 'deleted'
-);
+SELECT row_id, route_id, service_id, trip_id, trip_headsign, trip_short_name,
+       direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, status
+FROM (
+  SELECT edt.row_id, edt.route_id, edt.service_id, edt.trip_id, edt.trip_headsign,
+         edt.trip_short_name, edt.direction_id, edt.block_id, edt.shape_id,
+         edt.wheelchair_accessible, edt.bikes_allowed, edt.status
+  FROM EditTripsTable edt WHERE edt.status IN ('new', 'edit', 'new edit')
+  UNION ALL
+  SELECT CAST(t.row_id AS TEXT) AS row_id, t.route_id, t.service_id, t.trip_id, t.trip_headsign,
+         t.trip_short_name, t.direction_id, t.block_id, t.shape_id,
+         t.wheelchair_accessible, t.bikes_allowed, '' AS status
+  FROM trips t
+  WHERE NOT EXISTS (SELECT 1 FROM EditRouteTable edt WHERE edt.route_id = t.route_id AND edt.status = 'deleted')
+    AND NOT EXISTS (SELECT 1 FROM EditTripsTable edt WHERE edt.trip_id = t.trip_id AND edt.status = 'deleted')
+    AND NOT EXISTS (SELECT 1 FROM EditTripsTable edt WHERE edt.trip_id = t.trip_id AND edt.status IN ('edit', 'new edit'))
+) combined;
+
+CREATE OR REPLACE VIEW StopTimesView AS
+SELECT row_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time,
+       stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, status
+FROM (
+  SELECT edt.row_id, edt.trip_id, edt.stop_sequence, edt.stop_id,
+         edt.arrival_time, edt.departure_time, edt.stop_headsign,
+         edt.pickup_type, edt.drop_off_type, edt.shape_dist_traveled, edt.status
+  FROM EditStopTimesTable edt WHERE edt.status IN ('new', 'edit', 'new edit')
+  UNION ALL
+  SELECT CAST(st.row_id AS TEXT) AS row_id, st.trip_id, st.stop_sequence, st.stop_id,
+         st.arrival_time, st.departure_time, st.stop_headsign,
+         st.pickup_type, st.drop_off_type, st.shape_dist_traveled, '' AS status
+  FROM stop_times st
+  WHERE NOT EXISTS (SELECT 1 FROM EditStopTimesTable edt WHERE edt.row_id = CAST(st.row_id AS TEXT) AND edt.status = 'deleted')
+    AND NOT EXISTS (SELECT 1 FROM EditStopTimesTable edt WHERE edt.row_id = CAST(st.row_id AS TEXT) AND edt.status = 'edit')
+    AND NOT EXISTS (SELECT 1 FROM EditStopTimesTable edt WHERE edt.trip_id = st.trip_id AND edt.status = 'new edit')
+) combined;
 
 CREATE OR REPLACE VIEW RouteStopsView AS
 WITH route_stop_refs AS (
   SELECT t.route_id, st.stop_id, MIN(st.stop_sequence) AS stop_sequence
   FROM TripsView t
-  JOIN stop_times st ON st.trip_id = t.trip_id
+  JOIN StopTimesView st ON st.trip_id = t.trip_id
   WHERE t.route_id IS NOT NULL AND t.route_id != ''
     AND st.stop_id IS NOT NULL AND st.stop_id != ''
   GROUP BY t.route_id, st.stop_id
@@ -368,11 +454,81 @@ CREATE OR REPLACE MACRO get_routes_table_data() AS TABLE (
   ORDER BY COALESCE(r.route_sort_order, TRY_CAST(r.row_id AS INTEGER), 2147483647), r.route_name, r.route_id
 );
 
+CREATE OR REPLACE MACRO get_trips_table_data() AS TABLE (
+  WITH parsed_stop_times AS (
+    SELECT trip_id,
+           CASE WHEN NULLIF(departure_time, '') IS NULL THEN NULL
+             ELSE COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 1) AS INTEGER), 0) * 3600
+                + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 2) AS INTEGER), 0) * 60
+                + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 3) AS INTEGER), 0)
+           END AS departure_seconds,
+           CASE WHEN NULLIF(arrival_time, '') IS NULL THEN NULL
+             ELSE COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 1) AS INTEGER), 0) * 3600
+                + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 2) AS INTEGER), 0) * 60
+                + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 3) AS INTEGER), 0)
+           END AS arrival_seconds
+    FROM StopTimesView
+    WHERE trip_id IS NOT NULL AND trip_id != ''
+  ),
+  trip_times AS (
+    SELECT trip_id,
+           MIN(departure_seconds) AS first_departure_seconds,
+           MAX(arrival_seconds) AS last_arrival_seconds
+    FROM parsed_stop_times
+    GROUP BY trip_id
+  )
+  SELECT t.trip_id, t.route_id, t.service_id, t.trip_headsign,
+         t.trip_short_name, t.direction_id, t.block_id, t.shape_id,
+         r.route_name, r.route_type_name, r.route_color_hex,
+         tt.first_departure_seconds, tt.last_arrival_seconds
+  FROM TripsView t
+  LEFT JOIN RoutesView r ON r.route_id = t.route_id
+  LEFT JOIN trip_times tt ON tt.trip_id = t.trip_id
+  ORDER BY COALESCE(tt.first_departure_seconds, 2147483647), t.trip_id
+);
+
+-- ── Calendar table data macro ────────────────────────────────────────────────
+CREATE OR REPLACE MACRO get_calendar_table_data() AS TABLE (
+  SELECT cv.service_id, cv.monday, cv.tuesday, cv.wednesday, cv.thursday,
+         cv.friday, cv.saturday, cv.sunday, cv.start_date, cv.end_date, cv.status
+  FROM CalendarView cv
+  ORDER BY cv.service_id
+);
+
 -- ── Materialized tables ─────────────────────────────────────────────────────
 
 CREATE OR REPLACE TABLE StopsTable AS SELECT * FROM get_stops_table_data();
 CREATE OR REPLACE TABLE StationsTable AS SELECT * FROM get_stations_table_data();
 CREATE OR REPLACE TABLE RoutesTable AS SELECT * FROM get_routes_table_data();
+CREATE OR REPLACE TABLE TripsTable AS SELECT * FROM get_trips_table_data();
+CREATE OR REPLACE TABLE CalendarTable AS SELECT * FROM get_calendar_table_data();
+
+CREATE OR REPLACE MACRO get_trips_time_bounds() AS TABLE (
+  SELECT
+    GREATEST(0, CAST(FLOOR(MIN(first_departure_seconds) / 300.0) * 300 AS INTEGER)) AS min_time,
+    CAST(CEIL(MAX(last_arrival_seconds) / 300.0) * 300 AS INTEGER) AS max_time
+  FROM TripsTable
+  WHERE first_departure_seconds IS NOT NULL OR last_arrival_seconds IS NOT NULL
+);
+
+CREATE OR REPLACE MACRO get_trip_map_bounds(p_trip_id) AS TABLE (
+  WITH trip_stops AS (
+    SELECT s.stop_lon, s.stop_lat
+    FROM StopTimesView st
+    JOIN StopsView s ON s.stop_id = st.stop_id
+    WHERE st.trip_id = p_trip_id AND s.stop_lon IS NOT NULL AND s.stop_lat IS NOT NULL
+  ),
+  b AS (
+    SELECT MIN(stop_lon) AS min_lon, MAX(stop_lon) AS max_lon,
+           MIN(stop_lat) AS min_lat, MAX(stop_lat) AS max_lat
+    FROM trip_stops
+  )
+  SELECT min_lon, max_lon, min_lat, max_lat,
+         (min_lon + max_lon) / 2.0 AS center_lon,
+         (min_lat + max_lat) / 2.0 AS center_lat,
+         fit_zoom(min_lon, max_lon, min_lat, max_lat) AS zoom
+  FROM b WHERE min_lon IS NOT NULL
+);
 
 CREATE OR REPLACE MACRO get_gtfs_data_availability() AS TABLE (
   WITH counts AS (
@@ -380,12 +536,14 @@ CREATE OR REPLACE MACRO get_gtfs_data_availability() AS TABLE (
       (SELECT COUNT(*) FROM StationsTable) AS stations,
       (SELECT COUNT(*) FROM StopsTable) AS stops,
       (SELECT COUNT(*) FROM PathwaysView) AS pathways,
-      (SELECT COUNT(*) FROM RoutesTable) AS routes
+      (SELECT COUNT(*) FROM RoutesTable) AS routes,
+      (SELECT COUNT(*) FROM TripsTable) AS trips
   )
-  SELECT stations, stops, pathways, routes,
+  SELECT stations, stops, pathways, routes, trips,
          stations > 0 AS has_stations,
          stops > 0 AS has_stops,
-         routes > 0 AS has_routes
+         routes > 0 AS has_routes,
+         trips > 0 AS has_trips
   FROM counts
 );
 
@@ -428,6 +586,11 @@ CREATE INDEX IF NOT EXISTS idx_trips_trip_id ON trips(trip_id);
 CREATE INDEX IF NOT EXISTS idx_trips_shape_id ON trips(shape_id);
 CREATE INDEX IF NOT EXISTS idx_stop_times_trip_id ON stop_times(trip_id);
 CREATE INDEX IF NOT EXISTS idx_stop_times_stop_id ON stop_times(stop_id);
+CREATE INDEX IF NOT EXISTS idx_edit_stop_times_trip_id ON EditStopTimesTable(trip_id);
+CREATE INDEX IF NOT EXISTS idx_edit_stop_times_row_id ON EditStopTimesTable(row_id);
+CREATE INDEX IF NOT EXISTS idx_edit_calendar_service_id ON EditCalendarTable(service_id);
+CREATE INDEX IF NOT EXISTS idx_edit_trips_trip_id ON EditTripsTable(trip_id);
+CREATE INDEX IF NOT EXISTS idx_edit_trips_route_id ON EditTripsTable(route_id);
 CREATE INDEX IF NOT EXISTS idx_shapes_shape_id ON shapes(shape_id);
 CREATE INDEX IF NOT EXISTS idx_calendar_service_id ON calendar(service_id);
 CREATE INDEX IF NOT EXISTS idx_calendar_dates_service_id ON calendar_dates(service_id);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtfs-viz/web",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "Lightweight GTFS data visualizer and editor — web app",
   "license": "MIT",
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
+    "date-fns": "^4.4.0",
     "deck.gl": "8.9.34",
     "elkjs": "^0.11.0",
     "jszip": "^3.10.1",
@@ -55,6 +56,7 @@
     "pako": "^1.0.11",
     "papaparse": "^5.4.1",
     "react": "^18.3.1",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.5.0",

--- a/packages/web/src/client/Export/components/CalendarTable.tsx
+++ b/packages/web/src/client/Export/components/CalendarTable.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BiMap } from "react-icons/bi";
+import { executeQuery } from "@/lib/duckdb/QueryHelper";
+import { useExportTable } from "../hooks/useExportTable";
+import EditeTables from "./TableComponent";
+
+const CalendarTable = ({ FileTypes, setFileTypes }: { FileTypes: any; setFileTypes: any }) => {
+  const table = useExportTable({
+    editTableName: "EditCalendarTable",
+    sourceTableName: "calendar",
+    fileTypeKey: "calendar",
+    itemIdKey: "service_id",
+    setFileTypes,
+    invalidateKeys: ["fetchServiceRouteServicesData"],
+  });
+
+  // Map service_id → route_id for navigation
+  const { data: serviceRouteMap = new Map<string, string>() } = useQuery({
+    queryKey: ["serviceRouteMap"],
+    queryFn: async () => {
+      const m = new Map<string, string>();
+      const rows = await executeQuery(table.conn, "SELECT DISTINCT service_id, route_id FROM TripsTable WHERE service_id IS NOT NULL AND route_id IS NOT NULL");
+      for (const r of rows) m.set(String(r.service_id), String(r.route_id));
+      const newCals = await executeQuery(table.conn, "SELECT service_id FROM CalendarTable WHERE status IN ('new', 'new edit')");
+      if (newCals.length > 0) {
+        const firstRoute = await executeQuery(table.conn, "SELECT DISTINCT route_id FROM TripsTable WHERE route_id IS NOT NULL LIMIT 1");
+        if (firstRoute.length > 0) {
+          const rid = String(firstRoute[0].route_id);
+          for (const c of newCals) { if (!m.has(String(c.service_id))) m.set(String(c.service_id), rid); }
+        }
+      }
+      return m;
+    },
+    enabled: !!table.conn && table.initialized,
+    staleTime: 30_000,
+  });
+
+  const columns = useMemo(() => [
+    { accessorKey: "service_id", header: "Service ID" },
+    { accessorKey: "monday", header: "Mon" },
+    { accessorKey: "tuesday", header: "Tue" },
+    { accessorKey: "wednesday", header: "Wed" },
+    { accessorKey: "thursday", header: "Thu" },
+    { accessorKey: "friday", header: "Fri" },
+    { accessorKey: "saturday", header: "Sat" },
+    { accessorKey: "sunday", header: "Sun" },
+    { accessorKey: "start_date", header: "Start" },
+    { accessorKey: "end_date", header: "End" },
+    {
+      accessorKey: "status", header: "Change Type",
+      cell: ({ row }: any) => {
+        const s = row.original.status;
+        if (s === "deleted") return <Badge variant="destructive">Deleted</Badge>;
+        if (s === "new") return <Badge variant="default">New</Badge>;
+        if (s === "edit" || s === "new edit") return <Badge variant="secondary">Modified</Badge>;
+        return <Badge variant="outline">Unknown</Badge>;
+      },
+    },
+  ], []);
+
+  return (
+    <EditeTables
+      FileTypes={FileTypes} hasData={table.hasData} isLoading={table.isLoading} isError={table.isError} error={table.error}
+      tableData={table.tableData} clickInfo={table.clickInfo} setClickInfo={table.setClickInfo} columns={columns}
+      handleButtonClick={table.handleButtonClick} setIsExpanded={table.setIsExpanded} isExpanded={table.isExpanded}
+      mutation={table.mutation} originalDataMap={table.originalDataMap} fileTypeKey="calendar" itemIdKey="service_id"
+      title="calendar.txt" emptyTitle="calendar.txt"
+      getOriginalDataKey={(item: any) => item?.service_id}
+      renderSelectionActions={({ clickInfo: ci }: any) => {
+        if (!ci?.service_id || ci?.status === "deleted") return null;
+        const rid = serviceRouteMap.get(String(ci.service_id));
+        return rid ? (
+          <Button asChild variant="secondary" size="sm">
+            <Link to="/routes/service" search={{ selectedRouteId: rid, selectedServiceId: String(ci.service_id) }}>
+              <BiMap className="mr-2 h-4 w-4" />View
+            </Link>
+          </Button>
+        ) : (
+          <Button variant="secondary" size="sm" disabled title="No route found — add a trip first">
+            <BiMap className="mr-2 h-4 w-4" />View
+          </Button>
+        );
+      }}
+    />
+  );
+};
+
+export default CalendarTable;

--- a/packages/web/src/client/Export/components/PathwaysTable.tsx
+++ b/packages/web/src/client/Export/components/PathwaysTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { BiMap } from "react-icons/bi";
@@ -6,13 +6,13 @@ import { Button } from "@/components/ui/button";
 import { useDuckDB } from "@/context/duckdb.client";
 import { logger } from "@/lib/logger";
 import { fetchTableData } from "@/lib/duckdb/DataFetching/fetchGTFSData";
+import { fetchOriginalPathways, fetchStopMetadataForPathways } from "@/lib/duckdb/DataFetching/fetchExportData";
 import { mutationExportFn } from "@/lib/duckdb/DataEditing/editingFn";
 import {
   createEditPathwayTable,
   createEditStopTable,
   recreatePathwaysView,
 } from "@/lib/extensions";
-import { formatSqlValue } from "@/lib/duckdb/QueryHelper";
 
 import EditeTables from "./TableComponent";
 
@@ -82,8 +82,8 @@ const PathwaysTable = ({ FileTypes, setFileTypes }) => {
   useEffect(() => {
     const fetchSupportingData = async () => {
       if (!conn || tableData.length === 0) {
-        setOriginalDataMap({});
-        setStopMetadataMap({});
+        setOriginalDataMap((prev) => Object.keys(prev).length > 0 ? {} : prev);
+        setStopMetadataMap((prev) => Object.keys(prev).length > 0 ? {} : prev);
         return;
       }
 
@@ -106,74 +106,22 @@ const PathwaysTable = ({ FileTypes, setFileTypes }) => {
       );
 
       try {
-        const [originalRows, stopRows] = await Promise.all([
-          editedItems.length > 0
-            ? conn
-                .query(
-                  `SELECT * FROM pathways WHERE pathway_id IN (${editedItems
-                    .map((item: any) => formatSqlValue(item.pathway_id))
-                    .join(", ")})`,
-                )
-                .then((result: any) =>
-                  result.toArray().map((row: any) => row.toJSON()),
-                )
-            : Promise.resolve([]),
-          stopIds.length > 0
-            ? conn
-                .query(`
-                  SELECT
-                    edt.stop_id,
-                    edt.stop_name,
-                    edt.parent_station,
-                    edt.location_type_name
-                  FROM EditStopTable edt
-                  WHERE edt.stop_id IN (${stopIds.map((stopId) => formatSqlValue(stopId)).join(", ")})
-                    AND edt.status IN ('new', 'edit', 'new edit')
-
-                  UNION ALL
-
-                  SELECT
-                    st.stop_id,
-                    st.stop_name,
-                    st.parent_station,
-                    st.location_type_name
-                  FROM stops st
-                  WHERE st.stop_id IN (${stopIds.map((stopId) => formatSqlValue(stopId)).join(", ")})
-                    AND NOT EXISTS (
-                      SELECT 1
-                      FROM EditStopTable edt
-                      WHERE edt.stop_id = st.stop_id
-                        AND edt.status IN ('new', 'edit', 'new edit')
-                    )
-                `)
-                .then((result: any) =>
-                  result.toArray().map((row: any) => row.toJSON()),
-                )
-            : Promise.resolve([]),
+        const [origMap, stopMap] = await Promise.all([
+          fetchOriginalPathways(conn, editedItems.map((item: any) => item.pathway_id)),
+          fetchStopMetadataForPathways(conn, stopIds as string[]),
         ]);
-
-        setOriginalDataMap(
-          originalRows.reduce((acc: Record<string, any>, row: any) => {
-            acc[row.pathway_id] = row;
-            return acc;
-          }, {}),
-        );
-
-        setStopMetadataMap(
-          stopRows.reduce((acc: Record<string, any>, row: any) => {
-            acc[row.stop_id] = row;
-            return acc;
-          }, {}),
-        );
+        setOriginalDataMap(origMap);
+        setStopMetadataMap(stopMap);
       } catch (supportingDataError) {
         logger.error("Error fetching original pathway export data:", supportingDataError);
-        setOriginalDataMap({});
-        setStopMetadataMap({});
+        setOriginalDataMap((prev) => Object.keys(prev).length > 0 ? {} : prev);
+        setStopMetadataMap((prev) => Object.keys(prev).length > 0 ? {} : prev);
       }
     };
 
     fetchSupportingData();
-  }, [conn, tableData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conn, tableData.length]);
 
   const mutation = useMutation({
     mutationFn: async (mutateType: "row" | "table") => {
@@ -200,16 +148,14 @@ const PathwaysTable = ({ FileTypes, setFileTypes }) => {
 
   const hasData = useMemo(() => tableData.length > 0, [tableData]);
 
+  const hasDataRef = useRef(hasData);
+  const setFileTypesRef = useRef(setFileTypes);
+  setFileTypesRef.current = setFileTypes;
   useEffect(() => {
-    setFileTypes((prev) => {
-      const nextValue = hasData;
-      if (prev.pathways === nextValue) {
-        return prev;
-      }
-
-      return { ...prev, pathways: nextValue };
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (hasDataRef.current !== hasData) {
+      hasDataRef.current = hasData;
+      setFileTypesRef.current((prev: any) => ({ ...prev, pathways: hasData }));
+    }
   }, [hasData]);
 
   const handleButtonClick = () => {

--- a/packages/web/src/client/Export/components/RoutesTable.tsx
+++ b/packages/web/src/client/Export/components/RoutesTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { PathLayer } from "@deck.gl/layers";
@@ -7,11 +7,12 @@ import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { BiInfoCircle, BiGitCompare } from "react-icons/bi";
+import { safeHexToRgb } from "@/components/colorUtil";
 
 import { fetchTableData } from "@/lib/duckdb/DataFetching/fetchGTFSData";
+import { fetchOriginalRows, fetchOriginalRouteShapes } from "@/lib/duckdb/DataFetching/fetchExportData";
 import { mutationExportFn } from "@/lib/duckdb/DataEditing/editingFn";
 import { refreshRoutesTables } from "@/lib/extensions";
-import { formatSqlValue } from "@/lib/duckdb/QueryHelper";
 import { parseRouteLineValue } from "@/components/forms/RouteLineInput/routeLine";
 import MapContainer from "@/components/maps/MapContainer";
 import DeckglMap from "@/components/maps/DeckglMap.lazy";
@@ -106,17 +107,6 @@ function ShapeMiniMap({
   );
 }
 
-const hexToRgb = (value: string | undefined): number[] => {
-  const normalized = (value || "#4f46e5").replace("#", "");
-  const full =
-    normalized.length === 3
-      ? normalized.split("").map((c) => c + c).join("")
-      : normalized.padEnd(6, "0").slice(0, 6);
-  const parsed = Number.parseInt(full, 16);
-  if (!Number.isFinite(parsed)) return [79, 70, 229, 255];
-  return [(parsed >> 16) & 255, (parsed >> 8) & 255, parsed & 255, 255];
-};
-
 const RoutesTable = ({ FileTypes, setFileTypes }: any) => {
   const duckDB = useDuckDB();
   const conn = duckDB?.conn;
@@ -153,64 +143,13 @@ const RoutesTable = ({ FileTypes, setFileTypes }: any) => {
       }
 
       try {
-        const routeIds = editedItems.map((item: any) => formatSqlValue(item.route_id)).join(", ");
-
-        const [routeResult, shapeResult] = await Promise.all([
-          conn.query(`SELECT * FROM routes WHERE route_id IN (${routeIds})`),
-          conn.query(`
-            WITH shape_ranked AS (
-              SELECT t.route_id, t.shape_id, COUNT(*) as pt_count,
-                ROW_NUMBER() OVER (PARTITION BY t.route_id ORDER BY COUNT(*) DESC) as rn
-              FROM (
-                SELECT DISTINCT route_id, shape_id
-                FROM trips
-                WHERE route_id IN (${routeIds}) AND shape_id IS NOT NULL AND shape_id != ''
-              ) t
-              JOIN shapes s ON s.shape_id = t.shape_id
-              GROUP BY t.route_id, t.shape_id
-            )
-            SELECT sr.route_id, s.shape_pt_lat, s.shape_pt_lon, s.shape_pt_sequence
-            FROM shapes s
-            JOIN shape_ranked sr ON s.shape_id = sr.shape_id
-            WHERE sr.rn = 1
-            ORDER BY sr.route_id, s.shape_pt_sequence
-          `).catch(() => null),
+        const ids = editedItems.map((item: any) => String(item.route_id));
+        const [dataMap, shapeMap] = await Promise.all([
+          fetchOriginalRows(conn, "routes", "route_id", ids),
+          fetchOriginalRouteShapes(conn, ids),
         ]);
-
-        const routeRows = routeResult.toArray().map((row: any) => row.toJSON());
-        const dataMap: Record<string, any> = {};
-        routeRows.forEach((row: any) => {
-          dataMap[row.route_id] = row;
-        });
-
-        setOriginalDataMap((prev) => {
-          const prevKeys = Object.keys(prev).sort().join(",");
-          const newKeys = Object.keys(dataMap).sort().join(",");
-          if (prevKeys === newKeys) {
-            const hasChanges = Object.keys(dataMap).some(
-              (key) => JSON.stringify(prev[key]) !== JSON.stringify(dataMap[key]),
-            );
-            if (!hasChanges) return prev;
-          }
-          return dataMap;
-        });
-
-        if (shapeResult) {
-          const shapeRows = shapeResult.toArray().map((row: any) => row.toJSON());
-          const shapeMap: Record<string, { lat: number; lon: number }[]> = {};
-          shapeRows.forEach((row: any) => {
-            const routeId = row.route_id;
-            if (!shapeMap[routeId]) shapeMap[routeId] = [];
-            const lat = Number(row.shape_pt_lat);
-            const lon = Number(row.shape_pt_lon);
-            if (Number.isFinite(lat) && Number.isFinite(lon)) {
-              shapeMap[routeId].push({ lat, lon });
-            }
-          });
-          setOriginalShapeMap(shapeMap);
-        } else {
-          setOriginalShapeMap({});
-        }
+        setOriginalDataMap(dataMap);
+        setOriginalShapeMap(shapeMap);
       } catch (err) {
         logger.error("Error fetching original route data for export table:", err);
         setOriginalDataMap((prev) => (Object.keys(prev).length > 0 ? {} : prev));
@@ -251,12 +190,14 @@ const RoutesTable = ({ FileTypes, setFileTypes }: any) => {
 
   const hasData = useMemo(() => tableData.length > 0, [tableData]);
 
+  const hasDataRef = useRef(hasData);
+  const setFileTypesRef = useRef(setFileTypes);
+  setFileTypesRef.current = setFileTypes;
   useEffect(() => {
-    setFileTypes((prev: any) => {
-      if (prev.routes === hasData) return prev;
-      return { ...prev, routes: hasData };
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (hasDataRef.current !== hasData) {
+      hasDataRef.current = hasData;
+      setFileTypesRef.current((prev: any) => ({ ...prev, routes: hasData }));
+    }
   }, [hasData]);
 
   const handleButtonClick = () => {
@@ -339,7 +280,7 @@ const RoutesTable = ({ FileTypes, setFileTypes }: any) => {
     const routeId = row.route_id;
     const editedPoints = parseRouteLineValue(row.shape_points_json);
     const originalPoints = originalShapeMap[routeId] || [];
-    const routeColor = hexToRgb(row.route_color);
+    const routeColor = [...safeHexToRgb(row.route_color), 255];
 
     return (
       <TableRow className="bg-muted/30 border-l-4 border-l-blue-500">

--- a/packages/web/src/client/Export/components/StopTimesTable.tsx
+++ b/packages/web/src/client/Export/components/StopTimesTable.tsx
@@ -1,57 +1,473 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
 import { Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { BiMap } from "react-icons/bi";
-import { useExportTable } from "../hooks/useExportTable";
-import EditeTables from "./TableComponent";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { BiCheck, BiChevronDown, BiChevronUp, BiGitCompare, BiMap, BiRefresh, BiUndo, BiX } from "react-icons/bi";
+import { useDuckDB } from "@/context/duckdb.client";
+import { fetchTableData } from "@/lib/duckdb/DataFetching/fetchGTFSData";
+import { fetchOriginalRows } from "@/lib/duckdb/DataFetching/fetchExportData";
+import { mutationExportFn } from "@/lib/duckdb/DataEditing/editingFn";
 
-const StopTimesTable = ({ FileTypes, setFileTypes }: { FileTypes: any; setFileTypes: any }) => {
-  const table = useExportTable({
-    editTableName: "EditStopTimesTable",
-    sourceTableName: "stop_times",
-    fileTypeKey: "stop_times",
-    itemIdKey: "row_id",
-    setFileTypes,
-    invalidateKeys: ["fetchServiceTripStopTimesData", "fetchAllTripsData", "fetchTripsTimeBounds"],
-  });
+type EditRow = {
+  row_id: string;
+  trip_id: string;
+  stop_sequence: number;
+  stop_id: string;
+  arrival_time?: string;
+  departure_time?: string;
+  status: string;
+  [key: string]: any;
+};
 
-  const columns = useMemo(() => [
-    { accessorKey: "trip_id", header: "Trip ID" },
-    { accessorKey: "stop_sequence", header: "#" },
-    { accessorKey: "stop_id", header: "Stop ID" },
-    { accessorKey: "arrival_time", header: "Arrival" },
-    { accessorKey: "departure_time", header: "Departure" },
-    {
-      accessorKey: "status", header: "Change Type",
-      cell: ({ row }: any) => {
-        const s = row.original.status;
-        if (s === "deleted") return <Badge variant="destructive">Deleted</Badge>;
-        if (s === "new") return <Badge variant="default">New</Badge>;
-        if (s === "edit" || s === "new edit") return <Badge variant="secondary">Modified</Badge>;
-        return <Badge variant="outline">Unknown</Badge>;
-      },
-    },
-  ], []);
+type ServiceGroup = {
+  serviceId: string;
+  routeId: string;
+  routeName: string;
+  trips: TripGroup[];
+};
+
+type TripGroup = {
+  tripId: string;
+  headsign: string;
+  rows: EditRow[];
+};
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "deleted") return <Badge variant="destructive">Deleted</Badge>;
+  if (status === "new") return <Badge variant="default">New</Badge>;
+  if (status === "edit" || status === "new edit") return <Badge variant="secondary">Modified</Badge>;
+  return <Badge variant="outline">{status}</Badge>;
+}
+
+// LCS on stop_id to align original vs edited, detecting inserts/shifts
+function diffStopLists(orig: any[], edited: any[]) {
+  const oIds = orig.map((r) => String(r.stop_id));
+  const eIds = edited.map((r) => String(r.stop_id));
+  const m = oIds.length, n = eIds.length;
+
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = oIds[i - 1] === eIds[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+
+  // Backtrack to produce aligned rows
+  type DiffRow = { orig: any | null; edited: any | null; type: "match" | "changed" | "added" | "removed" };
+  const result: DiffRow[] = [];
+  let i = m, j = n;
+  const stack: DiffRow[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oIds[i - 1] === eIds[j - 1]) {
+      const o = orig[i - 1], e = edited[j - 1];
+      const changed = o.arrival_time !== e.arrival_time || o.departure_time !== e.departure_time || o.stop_sequence !== e.stop_sequence;
+      stack.push({ orig: o, edited: e, type: changed ? "changed" : "match" });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      stack.push({ orig: null, edited: edited[j - 1], type: "added" });
+      j--;
+    } else {
+      stack.push({ orig: orig[i - 1], edited: null, type: "removed" });
+      i--;
+    }
+  }
+  stack.reverse();
+  return stack;
+}
+
+function CompareView({ tripId, editedRows, originalMap }: {
+  tripId: string;
+  editedRows: EditRow[];
+  originalMap: Record<string, any>;
+}) {
+  const origRows = Object.values(originalMap)
+    .filter((r: any) => r.trip_id === tripId)
+    .sort((a: any, b: any) => (a.stop_sequence ?? 0) - (b.stop_sequence ?? 0));
+
+  const editedSorted = [...editedRows].sort((a, b) => (a.stop_sequence ?? 0) - (b.stop_sequence ?? 0));
+
+  const diffRows = diffStopLists(origRows, editedSorted);
+
+  const cellClass = (origVal: any, editVal: any) => {
+    const o = origVal == null || origVal === "" ? null : String(origVal);
+    const e = editVal == null || editVal === "" ? null : String(editVal);
+    return o !== e ? "font-medium" : "text-muted-foreground";
+  };
+
+  const fields: Array<{ key: string; label: string }> = [
+    { key: "stop_sequence", label: "#" },
+    { key: "stop_id", label: "Stop ID" },
+    { key: "arrival_time", label: "Arrival" },
+    { key: "departure_time", label: "Departure" },
+  ];
+
+  const renderCell = (row: any | null, field: string) => row?.[field] ?? "—";
 
   return (
-    <EditeTables
-      FileTypes={FileTypes} hasData={table.hasData} isLoading={table.isLoading} isError={table.isError} error={table.error}
-      tableData={table.tableData} clickInfo={table.clickInfo} setClickInfo={table.setClickInfo} columns={columns}
-      handleButtonClick={table.handleButtonClick} setIsExpanded={table.setIsExpanded} isExpanded={table.isExpanded}
-      mutation={table.mutation} originalDataMap={table.originalDataMap} fileTypeKey="stop_times" itemIdKey="row_id"
-      title="stop_times.txt" emptyTitle="stop_times.txt"
-      getOriginalDataKey={(item: any) => String(item?.row_id)}
-      renderSelectionActions={({ clickInfo: ci }: any) =>
-        ci?.trip_id && ci?.status !== "deleted" ? (
-          <Button asChild variant="secondary" size="sm">
-            <Link to="/trips/table" search={{ selectedTripId: ci.trip_id }}>
-              <BiMap className="mr-2 h-4 w-4" />View Trip
+    <div className="rounded-md border overflow-hidden">
+      <div className="overflow-auto max-h-[50vh]">
+        <table className="w-full text-xs border-collapse">
+          <thead className="bg-muted sticky top-0 z-10">
+            <tr>
+              {/* Original side */}
+              <th className="px-2 py-1.5 text-left font-semibold text-red-700 dark:text-red-400 border-r w-6">
+              </th>
+              {fields.map((f) => (
+                <th key={`o-${f.key}`} className="px-2 py-1.5 text-left font-medium border-r last:border-r-2 last:border-r-border">
+                  {f.label}
+                </th>
+              ))}
+              {/* Edited side */}
+              <th className="px-2 py-1.5 text-left font-semibold text-green-700 dark:text-green-400 w-6">
+              </th>
+              {fields.map((f) => (
+                <th key={`e-${f.key}`} className="px-2 py-1.5 text-left font-medium">
+                  {f.label}
+                </th>
+              ))}
+            </tr>
+            <tr>
+              <th colSpan={fields.length + 1} className="px-2 py-0.5 text-[10px] font-semibold text-red-600 dark:text-red-400 bg-red-50/50 dark:bg-red-950/20 border-r-2 border-r-border text-center">
+                Original
+              </th>
+              <th colSpan={fields.length + 1} className="px-2 py-0.5 text-[10px] font-semibold text-green-600 dark:text-green-400 bg-green-50/50 dark:bg-green-950/20 text-center">
+                Edited
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {diffRows.map((d, i) => {
+              if (d.type === "removed") {
+                return (
+                  <tr key={i} className="border-t">
+                    <td className="px-1 py-1 text-center text-red-500 border-r">
+                      <span className="text-[10px] font-bold">-</span>
+                    </td>
+                    {fields.map((f) => (
+                      <td key={f.key} className="px-2 py-1 bg-red-50 dark:bg-red-950/20 text-red-600 line-through border-r last:border-r-2 last:border-r-border">
+                        {renderCell(d.orig, f.key)}
+                      </td>
+                    ))}
+                    {/* Empty edited side */}
+                    <td className="px-1 py-1 border-r-0" />
+                    {fields.map((f) => (
+                      <td key={f.key} className="px-2 py-1 bg-muted/30" />
+                    ))}
+                  </tr>
+                );
+              }
+
+              if (d.type === "added") {
+                return (
+                  <tr key={i} className="border-t">
+                    {/* Empty original side */}
+                    <td className="px-1 py-1 border-r" />
+                    {fields.map((f) => (
+                      <td key={f.key} className="px-2 py-1 bg-muted/30 border-r last:border-r-2 last:border-r-border" />
+                    ))}
+                    <td className="px-1 py-1 text-center text-green-500">
+                      <span className="text-[10px] font-bold">+</span>
+                    </td>
+                    {fields.map((f) => (
+                      <td key={f.key} className="px-2 py-1 bg-green-50 dark:bg-green-950/20 text-green-600 font-medium">
+                        {renderCell(d.edited, f.key)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              }
+
+              // match or changed
+              const isChanged = d.type === "changed";
+              return (
+                <tr key={i} className={`border-t ${isChanged ? "bg-amber-50/30 dark:bg-amber-950/10" : ""}`}>
+                  <td className="px-1 py-1 text-center border-r">
+                    {isChanged && <span className="text-[10px] font-bold text-amber-500">~</span>}
+                  </td>
+                  {fields.map((f) => (
+                    <td key={f.key} className={`px-2 py-1 border-r last:border-r-2 last:border-r-border ${
+                      isChanged ? cellClass(d.orig?.[f.key], d.edited?.[f.key]) === "font-medium"
+                        ? "text-red-500 line-through" : "text-muted-foreground"
+                      : "text-muted-foreground"
+                    }`}>
+                      {renderCell(d.orig, f.key)}
+                    </td>
+                  ))}
+                  <td className="px-1 py-1 text-center">
+                    {isChanged && <span className="text-[10px] font-bold text-amber-500">~</span>}
+                  </td>
+                  {fields.map((f) => (
+                    <td key={f.key} className={`px-2 py-1 ${
+                      isChanged ? cellClass(d.orig?.[f.key], d.edited?.[f.key]) === "font-medium"
+                        ? "text-green-600 font-medium" : "text-muted-foreground"
+                      : "text-muted-foreground"
+                    }`}>
+                      {renderCell(d.edited, f.key)}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function TripSection({ trip, originalMap, allOriginalRows, onRevert }: {
+  trip: TripGroup;
+  originalMap: Record<string, any>;
+  allOriginalRows: any[];
+  onRevert: (tripId: string) => void;
+}) {
+  const [showCompare, setShowCompare] = useState(false);
+
+  const changeCount = trip.rows.filter((r) => r.status !== "unchanged").length;
+  const newCount = trip.rows.filter((r) => r.status === "new").length;
+  const editCount = trip.rows.filter((r) => r.status === "edit" || r.status === "new edit").length;
+  const deleteCount = trip.rows.filter((r) => r.status === "deleted").length;
+
+  return (
+    <div className="rounded-md border p-2 space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Link to="/trips/table" search={{ selectedTripId: trip.tripId }}
+          className="font-medium text-sm hover:text-primary transition-colors truncate max-w-[200px]">
+          {trip.tripId}
+        </Link>
+        {trip.headsign && <span className="text-xs text-muted-foreground truncate max-w-[150px]">{trip.headsign}</span>}
+        <div className="flex gap-1">
+          {newCount > 0 && <Badge variant="default" className="text-[10px] h-5">{newCount} new</Badge>}
+          {editCount > 0 && <Badge variant="secondary" className="text-[10px] h-5">{editCount} modified</Badge>}
+          {deleteCount > 0 && <Badge variant="destructive" className="text-[10px] h-5">{deleteCount} deleted</Badge>}
+        </div>
+        <div className="ml-auto flex gap-1">
+          <Button variant={showCompare ? "default" : "outline"} size="sm" className="h-7 text-xs"
+            onClick={() => setShowCompare(!showCompare)}>
+            <BiGitCompare className="mr-1 h-3 w-3" />{showCompare ? "Hide" : "Compare"}
+          </Button>
+          <Button variant="outline" size="sm" className="h-7 text-xs" asChild>
+            <Link to="/trips/table" search={{ selectedTripId: trip.tripId }}>
+              <BiMap className="mr-1 h-3 w-3" />View
             </Link>
           </Button>
-        ) : null
-      }
-    />
+        </div>
+      </div>
+      {showCompare && (
+        <CompareView tripId={trip.tripId} editedRows={trip.rows} originalMap={originalMap} />
+      )}
+    </div>
+  );
+}
+
+const StopTimesTable = ({ FileTypes, setFileTypes }: { FileTypes: any; setFileTypes: any }) => {
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const initialized = duckDB?.initialized ?? false;
+  const queryClient = useQueryClient();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [clickInfo, setClickInfo] = useState<any>();
+
+  // Fetch edit table
+  const { data: tableData = [], isLoading, isError, error } = useQuery({
+    queryKey: ["EditStopTimesTable"],
+    queryFn: () => fetchTableData({ conn, table: "EditStopTimesTable" }),
+    enabled: !!conn && initialized,
+  });
+
+  // Fetch trip metadata (service_id, route info, headsign) for grouping
+  const tripIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const r of tableData) if (r.trip_id) ids.add(String(r.trip_id));
+    return Array.from(ids);
+  }, [tableData]);
+
+  const { data: tripMeta = {} } = useQuery({
+    queryKey: ["stopTimesExportTripMeta", tripIds],
+    queryFn: async () => {
+      if (!conn || tripIds.length === 0) return {};
+      const idList = tripIds.map((id) => `'${id.replace(/'/g, "''")}'`).join(",");
+      const result = await conn.query(`
+        SELECT t.trip_id, t.service_id, t.trip_headsign,
+               r.route_id, r.route_short_name, r.route_long_name
+        FROM trips t
+        LEFT JOIN routes r ON t.route_id = r.route_id
+        WHERE t.trip_id IN (${idList})
+      `);
+      const rows = result.toArray().map((r: any) => r.toJSON());
+      const map: Record<string, any> = {};
+      for (const r of rows) map[String(r.trip_id)] = r;
+      return map;
+    },
+    enabled: !!conn && initialized && tripIds.length > 0,
+  });
+
+  // Fetch original rows for comparison
+  const [originalMap, setOriginalMap] = useState<Record<string, any>>({});
+  useEffect(() => {
+    async function fetchOriginal() {
+      if (!conn || tableData.length === 0) { setOriginalMap({}); return; }
+      const edited = tableData.filter((r: any) => r.status === "edit" || r.status === "new edit");
+      if (edited.length === 0) { setOriginalMap({}); return; }
+      const ids = edited.map((r: any) => String(r.row_id));
+      const map = await fetchOriginalRows(conn, "stop_times", "row_id", ids);
+      setOriginalMap(map);
+    }
+    fetchOriginal();
+  }, [conn, tableData.length]);
+
+  // Also fetch ALL original stop_times for compare (deleted ones won't be in edit table)
+  const { data: allOriginalByTrip = {} } = useQuery({
+    queryKey: ["stopTimesExportOriginals", tripIds],
+    queryFn: async () => {
+      if (!conn || tripIds.length === 0) return {};
+      const idList = tripIds.map((id) => `'${id.replace(/'/g, "''")}'`).join(",");
+      const result = await conn.query(`SELECT rowid as row_id, * FROM stop_times WHERE trip_id IN (${idList}) ORDER BY trip_id, stop_sequence`);
+      const rows = result.toArray().map((r: any) => r.toJSON());
+      const map: Record<string, any> = {};
+      for (const r of rows) map[String(r.row_id)] = r;
+      return map;
+    },
+    enabled: !!conn && initialized && tripIds.length > 0,
+  });
+
+  const hasData = tableData.length > 0;
+
+  // Sync hasData with FileTypes
+  useEffect(() => {
+    setFileTypes((prev: any) => {
+      if (prev.stop_times !== hasData) return { ...prev, stop_times: hasData };
+      return prev;
+    });
+  }, [hasData, setFileTypes]);
+
+  // Group by service_id
+  const serviceGroups = useMemo<ServiceGroup[]>(() => {
+    const byService = new Map<string, Map<string, EditRow[]>>();
+    for (const row of tableData) {
+      const tid = String(row.trip_id);
+      const meta = tripMeta[tid];
+      const sid = meta?.service_id || "unknown";
+      if (!byService.has(sid)) byService.set(sid, new Map());
+      const tripMap = byService.get(sid)!;
+      if (!tripMap.has(tid)) tripMap.set(tid, []);
+      tripMap.get(tid)!.push(row);
+    }
+
+    return Array.from(byService.entries()).map(([serviceId, tripMap]) => {
+      const trips: TripGroup[] = Array.from(tripMap.entries()).map(([tripId, rows]) => {
+        const meta = tripMeta[tripId];
+        return { tripId, headsign: meta?.trip_headsign || "", rows };
+      });
+      const firstMeta = tripMeta[trips[0]?.tripId];
+      const routeName = firstMeta?.route_short_name || firstMeta?.route_long_name || firstMeta?.route_id || "";
+      return { serviceId, routeId: firstMeta?.route_id || "", routeName, trips };
+    }).sort((a, b) => a.serviceId.localeCompare(b.serviceId));
+  }, [tableData, tripMeta]);
+
+  const mutation = useMutation({
+    mutationFn: async (mutateType: string) =>
+      mutationExportFn({
+        conn,
+        mutateType,
+        SelectStation: undefined,
+        selectedRow: clickInfo,
+        TableName: "EditStopTimesTable",
+        tableName: "EditStopTimesTable",
+        rowIdField: "row_id",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["EditStopTimesTable"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceTripStopTimesData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchTripsTimeBounds"] });
+      setClickInfo(undefined);
+    },
+  });
+
+  const handleButtonClick = () => {
+    setFileTypes((prev: any) => ({ ...prev, stop_times: !prev.stop_times }));
+  };
+
+  if (isLoading) return <div className="border rounded p-4 animate-pulse h-16" />;
+  if (isError) return <div className="text-red-500 p-2">Error: {(error as any)?.message}</div>;
+
+  const buttonClasses = !hasData
+    ? "flex items-center rounded-sm justify-center w-12 h-12 bg-stone-300 text-stone-400 cursor-not-allowed dark:bg-stone-800"
+    : FileTypes.stop_times
+      ? "flex items-center justify-center w-12 h-12 bg-green-500 hover:bg-green-600 rounded-sm"
+      : "flex items-center justify-center w-12 h-12 bg-red-500 hover:bg-red-600 rounded-sm";
+
+  const triggerClasses = !hasData
+    ? "flex w-full justify-between items-center px-4 py-2.5 bg-stone-300 text-stone-500 dark:bg-stone-700 dark:text-stone-400 rounded-sm cursor-not-allowed"
+    : FileTypes.stop_times
+      ? "flex w-full justify-between items-center px-4 py-2.5 bg-stone-200 dark:bg-stone-700 hover:bg-stone-100 dark:hover:bg-stone-800 rounded-sm cursor-pointer transition-colors"
+      : "flex w-full justify-between items-center px-4 py-2.5 bg-stone-300 dark:bg-stone-600 hover:bg-stone-200 dark:hover:bg-stone-500 rounded-sm cursor-pointer transition-colors";
+
+  const totalEdits = tableData.length;
+  const editedTrips = tripIds.length;
+
+  return (
+    <Collapsible open={hasData && isExpanded} onOpenChange={(open) => { if (hasData) setIsExpanded(open); }} className="border rounded p-2">
+      <div className="flex gap-2">
+        <button onClick={handleButtonClick} disabled={!hasData} className={buttonClasses}>
+          {FileTypes.stop_times ? <BiCheck size={24} /> : <BiX size={24} />}
+        </button>
+        {hasData ? (
+          <CollapsibleTrigger asChild>
+            <button type="button" className={triggerClasses}>
+              <div className="flex items-center w-full">
+                <span className="flex items-center">
+                  {isExpanded ? <BiChevronUp size={16} /> : <BiChevronDown size={16} />}
+                  <span className="ml-1 text-lg font-bold">stop_times.txt</span>
+                </span>
+                <span className="ml-3 text-sm text-muted-foreground">
+                  {totalEdits} edit{totalEdits !== 1 ? "s" : ""} across {editedTrips} trip{editedTrips !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </button>
+          </CollapsibleTrigger>
+        ) : (
+          <div className={triggerClasses} aria-disabled="true">
+            <span className="text-lg font-bold">stop_times.txt</span>
+          </div>
+        )}
+      </div>
+      {hasData && (
+        <CollapsibleContent className="mt-2 w-full">
+          <div className="space-y-3 rounded-md border shadow-sm p-3">
+            <div className="flex gap-2 flex-wrap">
+              <Button variant="outline" size="sm" onClick={() => mutation.mutate("table")}>
+                <BiRefresh className="mr-1 h-4 w-4" />Revert All Changes
+              </Button>
+            </div>
+
+            {serviceGroups.map((sg) => (
+              <div key={sg.serviceId} className="space-y-2">
+                <div className="flex items-center gap-2 border-b pb-1">
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Service</span>
+                  <span className="text-sm font-bold">{sg.serviceId}</span>
+                  {sg.routeName && <span className="text-xs text-muted-foreground">({sg.routeName})</span>}
+                  <Badge variant="outline" className="text-[10px] h-5 ml-auto">
+                    {sg.trips.length} trip{sg.trips.length !== 1 ? "s" : ""}
+                  </Badge>
+                </div>
+                {sg.trips.map((trip) => (
+                  <TripSection
+                    key={trip.tripId}
+                    trip={trip}
+                    originalMap={{ ...originalMap, ...allOriginalByTrip }}
+                    allOriginalRows={[]}
+                    onRevert={() => {}}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </CollapsibleContent>
+      )}
+    </Collapsible>
   );
 };
 

--- a/packages/web/src/client/Export/components/StopTimesTable.tsx
+++ b/packages/web/src/client/Export/components/StopTimesTable.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BiMap } from "react-icons/bi";
+import { useExportTable } from "../hooks/useExportTable";
+import EditeTables from "./TableComponent";
+
+const StopTimesTable = ({ FileTypes, setFileTypes }: { FileTypes: any; setFileTypes: any }) => {
+  const table = useExportTable({
+    editTableName: "EditStopTimesTable",
+    sourceTableName: "stop_times",
+    fileTypeKey: "stop_times",
+    itemIdKey: "row_id",
+    setFileTypes,
+    invalidateKeys: ["fetchServiceTripStopTimesData", "fetchAllTripsData", "fetchTripsTimeBounds"],
+  });
+
+  const columns = useMemo(() => [
+    { accessorKey: "trip_id", header: "Trip ID" },
+    { accessorKey: "stop_sequence", header: "#" },
+    { accessorKey: "stop_id", header: "Stop ID" },
+    { accessorKey: "arrival_time", header: "Arrival" },
+    { accessorKey: "departure_time", header: "Departure" },
+    {
+      accessorKey: "status", header: "Change Type",
+      cell: ({ row }: any) => {
+        const s = row.original.status;
+        if (s === "deleted") return <Badge variant="destructive">Deleted</Badge>;
+        if (s === "new") return <Badge variant="default">New</Badge>;
+        if (s === "edit" || s === "new edit") return <Badge variant="secondary">Modified</Badge>;
+        return <Badge variant="outline">Unknown</Badge>;
+      },
+    },
+  ], []);
+
+  return (
+    <EditeTables
+      FileTypes={FileTypes} hasData={table.hasData} isLoading={table.isLoading} isError={table.isError} error={table.error}
+      tableData={table.tableData} clickInfo={table.clickInfo} setClickInfo={table.setClickInfo} columns={columns}
+      handleButtonClick={table.handleButtonClick} setIsExpanded={table.setIsExpanded} isExpanded={table.isExpanded}
+      mutation={table.mutation} originalDataMap={table.originalDataMap} fileTypeKey="stop_times" itemIdKey="row_id"
+      title="stop_times.txt" emptyTitle="stop_times.txt"
+      getOriginalDataKey={(item: any) => String(item?.row_id)}
+      renderSelectionActions={({ clickInfo: ci }: any) =>
+        ci?.trip_id && ci?.status !== "deleted" ? (
+          <Button asChild variant="secondary" size="sm">
+            <Link to="/trips/table" search={{ selectedTripId: ci.trip_id }}>
+              <BiMap className="mr-2 h-4 w-4" />View Trip
+            </Link>
+          </Button>
+        ) : null
+      }
+    />
+  );
+};
+
+export default StopTimesTable;

--- a/packages/web/src/client/Export/components/StopsTable.tsx
+++ b/packages/web/src/client/Export/components/StopsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter, useRouterState } from "@tanstack/react-router";
 import { useDuckDB } from "@/context/duckdb.client";
@@ -143,12 +143,14 @@ const StopsTable = ({ FileTypes, setFileTypes }) => {
 
   const hasData = useMemo(() => tableData.length > 0, [tableData]);
 
+  const hasDataRef = useRef(hasData);
+  const setFileTypesRef = useRef(setFileTypes);
+  setFileTypesRef.current = setFileTypes;
   useEffect(() => {
-    setFileTypes((prev) => {
-      if (prev.stops === hasData) return prev;
-      return { ...prev, stops: hasData };
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (hasDataRef.current !== hasData) {
+      hasDataRef.current = hasData;
+      setFileTypesRef.current((prev: any) => ({ ...prev, stops: hasData }));
+    }
   }, [hasData]);
 
   const handleButtonClick = () => {

--- a/packages/web/src/client/Export/components/TableComponent.tsx
+++ b/packages/web/src/client/Export/components/TableComponent.tsx
@@ -18,19 +18,7 @@ import {
   SelectTrigger,
   SelectContent,
 } from "@/components/ui/select";
-import {
-  BiChevronUp,
-  BiChevronDown,
-  BiCheck,
-  BiRefresh,
-  BiUndo,
-  BiX,
-  BiChevronRight,
-  BiChevronLeft,
-  BiChevronsRight,
-  BiChevronsLeft,
-  BiRightArrow,
-} from "react-icons/bi";
+import { BiChevronUp, BiChevronDown, BiCheck, BiRefresh, BiUndo, BiX, BiChevronRight, BiChevronLeft, BiChevronsRight, BiChevronsLeft, BiRightArrow } from "react-icons/bi";
 import { Badge } from "@/components/ui/badge";
 
 function EditeTables(props) {

--- a/packages/web/src/client/Export/components/TripsEditTable.tsx
+++ b/packages/web/src/client/Export/components/TripsEditTable.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BiMap } from "react-icons/bi";
+import { useExportTable } from "../hooks/useExportTable";
+import EditeTables from "./TableComponent";
+
+const TripsEditTable = ({ FileTypes, setFileTypes }: { FileTypes: any; setFileTypes: any }) => {
+  const table = useExportTable({
+    editTableName: "EditTripsTable",
+    sourceTableName: "trips",
+    fileTypeKey: "trips",
+    itemIdKey: "trip_id",
+    setFileTypes,
+    invalidateKeys: ["fetchAllTripsData", "fetchServiceRouteTripsForServiceData"],
+  });
+
+  const columns = useMemo(() => [
+    { accessorKey: "trip_id", header: "Trip ID" },
+    { accessorKey: "route_id", header: "Route" },
+    { accessorKey: "service_id", header: "Service" },
+    { accessorKey: "trip_headsign", header: "Headsign" },
+    { accessorKey: "direction_id", header: "Dir" },
+    {
+      accessorKey: "status", header: "Change Type",
+      cell: ({ row }: any) => {
+        const s = row.original.status;
+        if (s === "deleted") return <Badge variant="destructive">Deleted</Badge>;
+        if (s === "new") return <Badge variant="default">New</Badge>;
+        if (s === "edit" || s === "new edit") return <Badge variant="secondary">Modified</Badge>;
+        return <Badge variant="outline">Unknown</Badge>;
+      },
+    },
+  ], []);
+
+  return (
+    <EditeTables
+      FileTypes={FileTypes} hasData={table.hasData} isLoading={table.isLoading} isError={table.isError} error={table.error}
+      tableData={table.tableData} clickInfo={table.clickInfo} setClickInfo={table.setClickInfo} columns={columns}
+      handleButtonClick={table.handleButtonClick} setIsExpanded={table.setIsExpanded} isExpanded={table.isExpanded}
+      mutation={table.mutation} originalDataMap={table.originalDataMap} fileTypeKey="trips" itemIdKey="trip_id"
+      title="trips.txt" emptyTitle="trips.txt"
+      getOriginalDataKey={(item: any) => item?.trip_id}
+      renderSelectionActions={({ clickInfo: ci }: any) =>
+        ci?.trip_id && ci?.status !== "deleted" ? (
+          <div className="flex gap-1">
+            <Button asChild variant="secondary" size="sm">
+              <Link to="/trips/table" search={{ selectedTripId: ci.trip_id }}>
+                <BiMap className="mr-2 h-4 w-4" />View Trip
+              </Link>
+            </Button>
+            {ci?.route_id && ci?.service_id && (
+              <Button asChild variant="outline" size="sm">
+                <Link to="/routes/service" search={{ selectedRouteId: ci.route_id, selectedServiceId: ci.service_id }}>
+                  View in Route
+                </Link>
+              </Button>
+            )}
+          </div>
+        ) : null
+      }
+    />
+  );
+};
+
+export default TripsEditTable;

--- a/packages/web/src/client/Export/hooks/useExportTable.ts
+++ b/packages/web/src/client/Export/hooks/useExportTable.ts
@@ -1,0 +1,120 @@
+import { useState, useEffect, useRef } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useDuckDB } from "@/context/duckdb.client";
+import { fetchTableData } from "@/lib/duckdb/DataFetching/fetchGTFSData";
+import { fetchOriginalRows } from "@/lib/duckdb/DataFetching/fetchExportData";
+import { mutationExportFn } from "@/lib/duckdb/DataEditing/editingFn";
+
+interface UseExportTableConfig {
+  editTableName: string;
+  sourceTableName: string;
+  fileTypeKey: string;
+  itemIdKey: string;
+  setFileTypes: (fn: (prev: any) => any) => void;
+  invalidateKeys?: string[];
+  enabled?: boolean;
+  onMutationSuccess?: () => void | Promise<void>;
+}
+
+export function useExportTable({
+  editTableName,
+  sourceTableName,
+  fileTypeKey,
+  itemIdKey,
+  setFileTypes,
+  invalidateKeys = [],
+  enabled = true,
+  onMutationSuccess,
+}: UseExportTableConfig) {
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const initialized = duckDB?.initialized ?? false;
+  const queryClient = useQueryClient();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [clickInfo, setClickInfo] = useState<any>();
+  const [originalDataMap, setOriginalDataMap] = useState<Record<string, any>>({});
+
+  const { data: tableData = [], isLoading, isError, error } = useQuery({
+    queryKey: [editTableName],
+    queryFn: () => fetchTableData({ conn, table: editTableName }),
+    enabled: !!conn && initialized && enabled,
+  });
+
+  const hasData = tableData.length > 0;
+
+  // Sync hasData → fileTypes (with ref guard to prevent infinite loops)
+  const hasDataRef = useRef(hasData);
+  const setFileTypesRef = useRef(setFileTypes);
+  setFileTypesRef.current = setFileTypes;
+  useEffect(() => {
+    if (hasDataRef.current !== hasData) {
+      hasDataRef.current = hasData;
+      setFileTypesRef.current((prev: any) => ({ ...prev, [fileTypeKey]: hasData }));
+    }
+  }, [hasData, fileTypeKey]);
+
+  // Fetch original data for diff comparison
+  useEffect(() => {
+    async function fetchOriginal() {
+      if (!conn || !tableData || tableData.length === 0) {
+        setOriginalDataMap((prev) => (Object.keys(prev).length > 0 ? {} : prev));
+        return;
+      }
+      const edited = tableData.filter(
+        (item: any) => item.status === "edit" || item.status === "new edit",
+      );
+      if (edited.length === 0) {
+        setOriginalDataMap((prev) => (Object.keys(prev).length > 0 ? {} : prev));
+        return;
+      }
+      const ids = edited.map((item: any) => String(item[itemIdKey]));
+      const map = await fetchOriginalRows(conn, sourceTableName, itemIdKey, ids);
+      setOriginalDataMap(map);
+    }
+    fetchOriginal();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conn, tableData.length, itemIdKey, sourceTableName]);
+
+  const mutation = useMutation({
+    mutationFn: async (mutateType: string) =>
+      mutationExportFn({
+        conn,
+        mutateType,
+        SelectStation: undefined,
+        selectedRow: clickInfo,
+        TableName: editTableName,
+        tableName: editTableName,
+        rowIdField: itemIdKey,
+      }),
+    onSuccess: async () => {
+      await onMutationSuccess?.();
+      queryClient.invalidateQueries({ queryKey: [editTableName] });
+      for (const key of invalidateKeys) {
+        queryClient.invalidateQueries({ queryKey: [key] });
+      }
+      setClickInfo(undefined);
+    },
+  });
+
+  const handleButtonClick = () => {
+    setFileTypes((prev: any) => ({ ...prev, [fileTypeKey]: !prev[fileTypeKey] }));
+  };
+
+  return {
+    conn,
+    initialized,
+    queryClient,
+    tableData,
+    isLoading,
+    isError,
+    error,
+    hasData,
+    isExpanded,
+    setIsExpanded,
+    clickInfo,
+    setClickInfo,
+    originalDataMap,
+    mutation,
+    handleButtonClick,
+  };
+}

--- a/packages/web/src/client/Export/index.tsx
+++ b/packages/web/src/client/Export/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDuckDB } from "@/context/duckdb.client";
 
-import { BiDownload } from 'react-icons/bi';
+import { BiDownload } from "react-icons/bi";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 
@@ -12,6 +12,9 @@ import { exportingData } from "@/lib/duckdb/DataExporting/exportingData";
 import StopsTable from "./components/StopsTable"
 import PathwaysTable from "./components/PathwaysTable";
 import RoutesTable from "./components/RoutesTable";
+import StopTimesTable from "./components/StopTimesTable";
+import CalendarTable from "./components/CalendarTable";
+import TripsEditTable from "./components/TripsEditTable";
 
 function Export() {
   const [FileTypes, setFileTypes] = useState({});
@@ -92,6 +95,9 @@ function Export() {
       <StopsTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
       <PathwaysTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
       <RoutesTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
+      <StopTimesTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
+      <CalendarTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
+      <TripsEditTable setFileTypes={setFileTypes} FileTypes={FileTypes} />
     </div>
   )
 }

--- a/packages/web/src/client/Header/index.tsx
+++ b/packages/web/src/client/Header/index.tsx
@@ -1,6 +1,7 @@
 import { Link, useRouter, useRouterState } from "@tanstack/react-router";
 import { useDuckDB } from "@/context/duckdb.client";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { logger } from "@/lib/logger";
 import { BiImport, BiMap, BiTable, BiMenu } from "react-icons/bi";
 import { Button } from "@/components/ui/button";
 import ThemeSwitcher from "@/components/ui/ThemeSwitcher";
@@ -28,6 +29,7 @@ function Header() {
   const isCliLaunch = duckDB?.isCliLaunch ?? false;
 
   const isRoutesActive = currentPath.startsWith("/routes");
+  const isTripsActive = currentPath.startsWith("/trips");
   const isStationsActive = currentPath.startsWith("/stations");
   const isStopsActive = currentPath.startsWith("/stops");
   const isExportActive = currentPath.startsWith("/export");
@@ -43,7 +45,7 @@ function Header() {
       try {
         await duckDB.resetDb();
       } catch (error) {
-        console.error("Error resetting database:", error);
+        logger.error("Error resetting database:", error);
       }
     }
 
@@ -66,59 +68,69 @@ function Header() {
     setMobileMenuOpen(false);
   };
 
-  const stationsViews = [
-    { id: "map", label: "Map", icon: BiMap, path: "/stations/map" },
-    { id: "table", label: "Table", icon: BiTable, path: "/stations/table" },
-  ];
-
-  const stopsViews = [
-    { id: "map", label: "Map", icon: BiMap, path: "/stops/map" },
-    { id: "table", label: "Table", icon: BiTable, path: "/stops/table" },
-  ];
-
-  const routesViews = [
-    ...(hasShapes ? [{ id: "map", label: "Map", icon: BiMap, path: "/routes/map" }] : []),
-    { id: "table", label: "Table", icon: BiTable, path: "/routes/table" },
-  ];
-
-  const navigationGroups = [
-    {
-      id: "routes",
-      label: "Routes",
-      icon: "🚌",
-      enabled: hasRoutes,
-      active: isRoutesActive,
-      defaultPath: hasShapes ? "/routes/map" : "/routes/table",
-      disabledText: "No routes in the file",
-      views: routesViews,
-      search: { selectedRouteId: currentSearch?.selectedRouteId },
-    },
-    {
-      id: "stations",
-      label: "Stations",
-      icon: "🚉",
-      enabled: hasStations,
-      active: isStationsActive,
-      defaultPath: "/stations/map",
-      disabledText: "No stations in the file",
-      views: stationsViews,
-      search: { selectedStationId: currentSearch?.selectedStationId },
-    },
-    {
-      id: "stops",
-      label: "Stops",
-      icon: "🚏",
-      enabled: hasStops,
-      active: isStopsActive,
-      defaultPath: "/stops/map",
-      disabledText: "No stops in the file",
-      views: stopsViews,
-      search: { selectedStopId: currentSearch?.selectedStopId },
-    },
-  ];
-
-  void hasTrips;
-  void hasStopTimes;
+  const navigationGroups = useMemo(() => {
+    const stationsViews = [
+      { id: "map", label: "Map", icon: Map, path: "/stations/map" },
+      { id: "table", label: "Table", icon: BiTable, path: "/stations/table" },
+    ];
+    const stopsViews = [
+      { id: "map", label: "Map", icon: Map, path: "/stops/map" },
+      { id: "table", label: "Table", icon: BiTable, path: "/stops/table" },
+    ];
+    const routesViews = [
+      ...(hasShapes ? [{ id: "map", label: "Map", icon: Map, path: "/routes/map" }] : []),
+      { id: "table", label: "Table", icon: BiTable, path: "/routes/table" },
+    ];
+    return [
+      {
+        id: "routes",
+        label: "Routes",
+        icon: "🚌",
+        enabled: hasRoutes,
+        active: isRoutesActive,
+        defaultPath: hasShapes ? "/routes/map" : "/routes/table",
+        disabledText: "No routes in the file",
+        views: routesViews,
+        search: { selectedRouteId: currentSearch?.selectedRouteId },
+      },
+      {
+        id: "trips",
+        label: "Trips",
+        icon: "🚍",
+        enabled: hasTrips,
+        active: isTripsActive,
+        defaultPath: "/trips/table",
+        disabledText: "No trips in the file",
+        views: [],
+        search: { selectedTripId: currentSearch?.selectedTripId },
+      },
+      {
+        id: "stations",
+        label: "Stations",
+        icon: "🚉",
+        enabled: hasStations,
+        active: isStationsActive,
+        defaultPath: "/stations/map",
+        disabledText: "No stations in the file",
+        views: stationsViews,
+        search: { selectedStationId: currentSearch?.selectedStationId },
+      },
+      {
+        id: "stops",
+        label: "Stops",
+        icon: "🚏",
+        enabled: hasStops,
+        active: isStopsActive,
+        defaultPath: "/stops/map",
+        disabledText: "No stops in the file",
+        views: stopsViews,
+        search: { selectedStopId: currentSearch?.selectedStopId },
+      },
+    ];
+  }, [hasShapes, hasRoutes, hasTrips, hasStopTimes, hasStations, hasStops,
+      isRoutesActive, isTripsActive, isStationsActive, isStopsActive,
+      currentSearch?.selectedRouteId, currentSearch?.selectedTripId,
+      currentSearch?.selectedStationId, currentSearch?.selectedStopId]);
 
   return (
     <>
@@ -191,7 +203,7 @@ function Header() {
                       </Tooltip>
                     </TooltipProvider>
 
-                    {group.enabled && (
+                    {group.enabled && group.views.length > 0 && (
                       <div className="ml-6 mt-1 flex flex-col gap-1">
                         {group.views.map((view) => {
                           const ViewIcon = view.icon;
@@ -318,7 +330,7 @@ function Header() {
                       )}
                     </Tooltip>
 
-                    {group.enabled && (
+                    {group.enabled && group.views.length > 0 && (
                       <div className="invisible absolute left-0 top-full z-50 pt-2 opacity-0 transition-opacity group-hover:visible group-hover:opacity-100">
                         <ul className="grid w-[200px] gap-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-lg">
                           {group.views.map((view) => {

--- a/packages/web/src/client/Header/index.tsx
+++ b/packages/web/src/client/Header/index.tsx
@@ -70,15 +70,15 @@ function Header() {
 
   const navigationGroups = useMemo(() => {
     const stationsViews = [
-      { id: "map", label: "Map", icon: Map, path: "/stations/map" },
+      { id: "map", label: "Map", icon: BiMap, path: "/stations/map" },
       { id: "table", label: "Table", icon: BiTable, path: "/stations/table" },
     ];
     const stopsViews = [
-      { id: "map", label: "Map", icon: Map, path: "/stops/map" },
+      { id: "map", label: "Map", icon: BiMap, path: "/stops/map" },
       { id: "table", label: "Table", icon: BiTable, path: "/stops/table" },
     ];
     const routesViews = [
-      ...(hasShapes ? [{ id: "map", label: "Map", icon: Map, path: "/routes/map" }] : []),
+      ...(hasShapes ? [{ id: "map", label: "Map", icon: BiMap, path: "/routes/map" }] : []),
       { id: "table", label: "Table", icon: BiTable, path: "/routes/table" },
     ];
     return [

--- a/packages/web/src/client/Intro/FileImporter/UploadFile.tsx
+++ b/packages/web/src/client/Intro/FileImporter/UploadFile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { BiUpload } from 'react-icons/bi';
+import { BiUpload } from "react-icons/bi";
 import { Button } from "@/components/ui/button";
 
 interface UploadFileProps {

--- a/packages/web/src/client/Routes/AllRoutes/Header/index.tsx
+++ b/packages/web/src/client/Routes/AllRoutes/Header/index.tsx
@@ -10,7 +10,7 @@ interface HeaderProps {
   RouteIdData: Array<{ label: string; value: string; color?: string }>;
   RouteIdDropdown: string;
   setRouteIdDropdown: (value: string) => void;
-  RouteNameData: Array<{ label: string; value?: string }>;
+  RouteNameData: Array<{ label: string; value?: string; searchLabel?: string }>;
   RouteNameDropDown: string;
   setRouteNameDropDown: (value: string) => void;
   RouteTypeData: Array<{ label: string; value: string; color?: string }>;
@@ -81,7 +81,7 @@ const Header: React.FC<HeaderProps> = (props) => {
         <div className="col-span-1">
           {RouteNameData ? (
             <Combobox
-              Selections={RouteNameData.map((item) => item.label)}
+              options={RouteNameData.map((item) => ({ value: item.value || item.label, label: item.label, searchLabel: item.searchLabel }))}
               Message="Route Name"
               value={RouteNameDropDown}
               setValue={(val) => setRouteNameDropDown(val || "")}

--- a/packages/web/src/client/Routes/AllRoutes/RoutesMap/Components/MapSection.tsx
+++ b/packages/web/src/client/Routes/AllRoutes/RoutesMap/Components/MapSection.tsx
@@ -6,22 +6,7 @@ import { getHighlightColor } from "@/components/style";
 import { useThemeContext } from "@/context/theme.client";
 import { getRouteTypeColor } from "@/client/Routes/routeTypeColors";
 import { useDuckDB } from "@/context/duckdb.client";
-
-const hexToRgb = (value: string | undefined) => {
-  const normalized = (value || "#4f46e5").replace("#", "");
-  const full =
-    normalized.length === 3
-      ? normalized
-          .split("")
-          .map((char) => char + char)
-          .join("")
-      : normalized.padEnd(6, "0").slice(0, 6);
-  const n = Number.parseInt(full, 16);
-  if (!Number.isFinite(n)) return [79, 70, 229];
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
-};
-
-const withAlpha = (color: number[], alpha: number) => [color[0], color[1], color[2], alpha];
+import { safeHexToRgb, withAlpha } from "@/components/colorUtil";
 
 const DEFAULT_VIEW_STATE = {
   longitude: -98.5795,
@@ -208,7 +193,7 @@ function MapSection({
           getPath: (row: any) => row.path,
           getColor: (row: any) => {
             const routeId = String(row.route_id);
-            const color = hexToRgb(getRouteTypeColor(row.route_type_name));
+            const color = safeHexToRgb(getRouteTypeColor(row.route_type_name));
             if (!activeRouteId || activeRouteId === routeId) return withAlpha(color, 255);
             return withAlpha(color, 110);
           },
@@ -229,7 +214,7 @@ function MapSection({
         new ScatterplotLayer({
           id: "routes-stop-view",
           data: fallbackStops,
-          getFillColor: (row: any) => hexToRgb(getRouteTypeColor(row.route_type_name)),
+          getFillColor: (row: any) => safeHexToRgb(getRouteTypeColor(row.route_type_name)),
           getPosition: (row: any) => [Number(row.stop_lon), Number(row.stop_lat)],
           pickable: true,
           getLineWidth: 0.025,

--- a/packages/web/src/client/Routes/AllRoutes/RoutesMap/index.tsx
+++ b/packages/web/src/client/Routes/AllRoutes/RoutesMap/index.tsx
@@ -11,7 +11,7 @@ import { EditIndicator } from "@/components/ui/EditIndicator";
 import MapSection from "./Components/MapSection";
 import { getRouteTypeColor, getRouteTypeLegendItems } from "@/client/Routes/routeTypeColors";
 import { useDuckDB } from "@/context/duckdb.client";
-import { fetchRouteMapBounds } from "@/lib/duckdb/DataFetching/fetchRouteData";
+import { fetchRouteMapBounds, fetchFitZoom } from "@/lib/duckdb/DataFetching/fetchRouteData";
 
 function RoutesMap({
   routes,
@@ -95,9 +95,7 @@ function RoutesMap({
     }
     if (count === 0) return;
     try {
-      const result = await conn.query(`SELECT fit_zoom(${minLon}, ${maxLon}, ${minLat}, ${maxLat}) AS zoom`);
-      const row = result.toArray()[0];
-      const zoom = Number(row?.zoom ?? row?.toJSON?.()?.zoom ?? 10);
+      const zoom = await fetchFitZoom(conn, minLon, maxLon, minLat, maxLat);
       setViewState((prev: any) => ({
         ...prev,
         longitude: (minLon + maxLon) / 2,

--- a/packages/web/src/client/Routes/SelectedRoutes/RouteService/CalendarForm.tsx
+++ b/packages/web/src/client/Routes/SelectedRoutes/RouteService/CalendarForm.tsx
@@ -1,0 +1,263 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { format } from "date-fns";
+import { parseGtfsDate, toGtfsDate } from "@/lib/gtfsDateUtils";
+import { FormActions } from "@/components/forms/shared/FormActions";
+
+function DatePickerField({ label, value, onChange, fromDate, toDate }: {
+  label: string; value: Date | undefined; onChange: (d: Date | undefined) => void;
+  fromDate?: Date; toDate?: Date;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" className="w-full justify-start text-left font-normal h-10">
+            {value ? format(value, "MMM d, yyyy") : <span className="text-muted-foreground">Pick date</span>}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={value}
+            onSelect={(d) => { onChange(d); setOpen(false); }}
+            startMonth={fromDate}
+            endMonth={toDate}
+            disabled={(d) => {
+              if (fromDate && d < fromDate) return true;
+              if (toDate && d > toDate) return true;
+              return false;
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+// Safe number conversion that handles Arrow BigNum, BigInt, and regular values
+const safeNum = (v: any): number => {
+  if (v == null) return 0;
+  try { return Number(v); } catch { return typeof v === "bigint" ? Number(v) : 0; }
+};
+
+export function CalendarForm({ initialData, onSave, onCancel, isPending }: {
+  initialData?: any;
+  onSave: (data: any) => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  // Derive weekdays from exception dates when no regular calendar exists
+  const hasCalendar = initialData && (initialData.start_date || safeNum(initialData.monday) || safeNum(initialData.tuesday) || safeNum(initialData.wednesday) || safeNum(initialData.thursday) || safeNum(initialData.friday) || safeNum(initialData.saturday) || safeNum(initialData.sunday));
+  const exceptionDays = (() => {
+    if (hasCalendar || !initialData?.added_exception_dates) return null;
+    const daySet = new Set<number>();
+    const dates = String(initialData.added_exception_dates).split(",");
+    for (const d of dates) {
+      const parsed = parseGtfsDate(d.trim());
+      if (parsed) daySet.add(parsed.getDay());
+    }
+    // JS getDay(): 0=Sun,1=Mon,...,6=Sat → map to GTFS order
+    return {
+      monday: daySet.has(1) ? 1 : 0,
+      tuesday: daySet.has(2) ? 1 : 0,
+      wednesday: daySet.has(3) ? 1 : 0,
+      thursday: daySet.has(4) ? 1 : 0,
+      friday: daySet.has(5) ? 1 : 0,
+      saturday: daySet.has(6) ? 1 : 0,
+      sunday: daySet.has(0) ? 1 : 0,
+    };
+  })();
+
+  const [serviceId, setServiceId] = useState(String(initialData?.service_id ?? ""));
+  const [startDate, setStartDate] = useState<Date | undefined>(
+    parseGtfsDate(initialData?.start_date) ?? parseGtfsDate(initialData?.first_exception_date)
+  );
+  const [endDate, setEndDate] = useState<Date | undefined>(
+    parseGtfsDate(initialData?.end_date) ?? parseGtfsDate(initialData?.last_exception_date)
+  );
+  const [days, setDays] = useState({
+    monday: safeNum(initialData?.monday) ? 1 : (exceptionDays?.monday ?? 0),
+    tuesday: safeNum(initialData?.tuesday) ? 1 : (exceptionDays?.tuesday ?? 0),
+    wednesday: safeNum(initialData?.wednesday) ? 1 : (exceptionDays?.wednesday ?? 0),
+    thursday: safeNum(initialData?.thursday) ? 1 : (exceptionDays?.thursday ?? 0),
+    friday: safeNum(initialData?.friday) ? 1 : (exceptionDays?.friday ?? 0),
+    saturday: safeNum(initialData?.saturday) ? 1 : (exceptionDays?.saturday ?? 0),
+    sunday: safeNum(initialData?.sunday) ? 1 : (exceptionDays?.sunday ?? 0),
+  });
+
+  const dayLabels = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] as const;
+  const dateError = startDate && endDate && startDate > endDate ? "End date must be after start date" : "";
+
+  // Exception dates (editable)
+  const [addedDates, setAddedDates] = useState<string[]>(() =>
+    String(initialData?.added_exception_dates || "").split(",").filter(Boolean).map((d) => d.trim())
+  );
+  const [removedDates, setRemovedDates] = useState<string[]>(() =>
+    String(initialData?.removed_exception_dates || "").split(",").filter(Boolean).map((d) => d.trim())
+  );
+  const [addExDateOpen, setAddExDateOpen] = useState(false);
+  const [addExDateType, setAddExDateType] = useState<"added" | "removed">("added");
+  const formatExDate = (d: string) => {
+    const parsed = parseGtfsDate(d);
+    return parsed ? format(parsed, "MMM d, yyyy") : d;
+  };
+
+  // Track changes for edit mode
+  const origDays = initialData ? {
+    monday: safeNum(initialData.monday) ? 1 : (exceptionDays?.monday ?? 0),
+    tuesday: safeNum(initialData.tuesday) ? 1 : (exceptionDays?.tuesday ?? 0),
+    wednesday: safeNum(initialData.wednesday) ? 1 : (exceptionDays?.wednesday ?? 0),
+    thursday: safeNum(initialData.thursday) ? 1 : (exceptionDays?.thursday ?? 0),
+    friday: safeNum(initialData.friday) ? 1 : (exceptionDays?.friday ?? 0),
+    saturday: safeNum(initialData.saturday) ? 1 : (exceptionDays?.saturday ?? 0),
+    sunday: safeNum(initialData.sunday) ? 1 : (exceptionDays?.sunday ?? 0),
+  } : null;
+  const origStartDate = initialData ? (parseGtfsDate(initialData.start_date) ?? parseGtfsDate(initialData.first_exception_date)) : undefined;
+  const origEndDate = initialData ? (parseGtfsDate(initialData.end_date) ?? parseGtfsDate(initialData.last_exception_date)) : undefined;
+
+  const origAddedDates = String(initialData?.added_exception_dates || "").split(",").filter(Boolean).map((d) => d.trim());
+  const origRemovedDates = String(initialData?.removed_exception_dates || "").split(",").filter(Boolean).map((d) => d.trim());
+  const exDatesChanged = addedDates.join(",") !== origAddedDates.join(",") || removedDates.join(",") !== origRemovedDates.join(",");
+
+  const hasChanges = initialData
+    ? (dayLabels.some((d) => days[d] !== (origDays?.[d] ?? 0)) ||
+       startDate?.getTime() !== origStartDate?.getTime() ||
+       endDate?.getTime() !== origEndDate?.getTime() ||
+       exDatesChanged)
+    : !!serviceId;
+
+  return (
+    <FormActions
+      isBusy={isPending}
+      isValid={!!serviceId && !dateError}
+      hasChanges={hasChanges}
+      onSave={() => onSave({
+        service_id: serviceId, ...days,
+        start_date: startDate ? toGtfsDate(startDate) : "",
+        end_date: endDate ? toGtfsDate(endDate) : "",
+        added_exception_dates: addedDates.join(","),
+        removed_exception_dates: removedDates.join(","),
+      })}
+      onCancel={onCancel}
+      saveLabel={initialData ? "Save" : "Add Service"}
+      busyLabel={initialData ? "Saving..." : "Adding..."}
+    >
+    <div className="space-y-4">
+      {!hasCalendar && initialData && (
+        <div className="text-xs text-yellow-800 dark:text-yellow-200 p-2 border border-yellow-300 rounded-md bg-yellow-50 dark:bg-yellow-900/20">
+          This service uses exception dates only. Days and dates are derived from exception dates.
+        </div>
+      )}
+      <div className="space-y-2">
+        <Label>Service ID</Label>
+        <Input value={serviceId} onChange={(e) => setServiceId(e.target.value)} placeholder="service_id" disabled={!!initialData} />
+      </div>
+      <div className="space-y-2">
+        <Label>Service Days</Label>
+        <div className="flex flex-wrap gap-3">
+          {dayLabels.map((day) => {
+            const changed = initialData && days[day] !== (origDays?.[day] ?? 0);
+            return (
+              <label key={day} className={`flex items-center gap-1.5 text-sm cursor-pointer ${changed ? "text-amber-600 dark:text-amber-400 font-medium" : ""}`}>
+                <Checkbox checked={days[day] === 1} onCheckedChange={(checked) => setDays((prev) => ({ ...prev, [day]: checked ? 1 : 0 }))} />
+                {day.charAt(0).toUpperCase() + day.slice(1, 3)}
+                {changed && <span className="text-[10px]">*</span>}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label>Date Range</Label>
+          {initialData && (startDate?.getTime() !== origStartDate?.getTime() || endDate?.getTime() !== origEndDate?.getTime()) && (
+            <span className="text-[10px] text-amber-600 dark:text-amber-400">modified</span>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <DatePickerField label="Start" value={startDate} onChange={setStartDate} toDate={endDate} />
+          <DatePickerField label="End" value={endDate} onChange={setEndDate} fromDate={startDate} />
+        </div>
+        {dateError && <p className="text-xs text-red-500">{dateError}</p>}
+      </div>
+
+      {/* Exception dates (editable) */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label>Exception Dates</Label>
+          {exDatesChanged && initialData && <span className="text-[10px] text-amber-600 dark:text-amber-400">modified</span>}
+        </div>
+        <div className="rounded-md border p-3 space-y-3 text-xs">
+          {/* Added dates */}
+          <div className="space-y-1">
+            <div className="font-medium text-green-700 dark:text-green-400">Added ({addedDates.length})</div>
+            {addedDates.length > 0 && (
+              <div className="flex flex-wrap gap-1 max-h-32 overflow-y-auto">
+                {addedDates.map((d, i) => (
+                  <span key={`a-${i}`} className="inline-flex items-center gap-1 rounded bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800 px-1.5 py-0.5">
+                    {formatExDate(d)}
+                    <button type="button" className="text-green-600 hover:text-red-500 transition-colors"
+                      onClick={() => setAddedDates((prev) => prev.filter((_, j) => j !== i))}>×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          {/* Removed dates */}
+          <div className="space-y-1">
+            <div className="font-medium text-red-700 dark:text-red-400">Removed ({removedDates.length})</div>
+            {removedDates.length > 0 && (
+              <div className="flex flex-wrap gap-1 max-h-32 overflow-y-auto">
+                {removedDates.map((d, i) => (
+                  <span key={`r-${i}`} className="inline-flex items-center gap-1 rounded bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 px-1.5 py-0.5">
+                    {formatExDate(d)}
+                    <button type="button" className="text-red-600 hover:text-red-800 transition-colors"
+                      onClick={() => setRemovedDates((prev) => prev.filter((_, j) => j !== i))}>×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          {/* Add exception date */}
+          <div className="flex items-center gap-2 pt-1 border-t">
+            <select className="rounded border bg-background px-2 py-1 text-xs"
+              value={addExDateType} onChange={(e) => setAddExDateType(e.target.value as "added" | "removed")}>
+              <option value="added">Add date</option>
+              <option value="removed">Remove date</option>
+            </select>
+            <Popover open={addExDateOpen} onOpenChange={setAddExDateOpen}>
+              <PopoverTrigger asChild>
+                <Button type="button" variant="outline" size="sm" className="h-7 text-[10px]">
+                  Pick date
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar mode="single" selected={undefined}
+                  onSelect={(d) => {
+                    if (!d) return;
+                    const gtfs = toGtfsDate(d);
+                    if (addExDateType === "added") {
+                      if (!addedDates.includes(gtfs)) setAddedDates((prev) => [...prev, gtfs].sort());
+                    } else {
+                      if (!removedDates.includes(gtfs)) setRemovedDates((prev) => [...prev, gtfs].sort());
+                    }
+                    setAddExDateOpen(false);
+                  }} />
+              </PopoverContent>
+            </Popover>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    </FormActions>
+  );
+}

--- a/packages/web/src/client/Routes/SelectedRoutes/RouteService/TripForm.tsx
+++ b/packages/web/src/client/Routes/SelectedRoutes/RouteService/TripForm.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useDuckDB } from "@/context/duckdb.client";
+import { checkTripIdExists } from "@/lib/duckdb/DataFetching/fetchRouteData";
+import { executeQuery } from "@/lib/duckdb/QueryHelper";
+import { BiChevronDown, BiChevronRight } from "react-icons/bi";
+import { PointsMapEditor } from "@/components/maps/PointsMapEditor";
+import { FormActions } from "@/components/forms/shared/FormActions";
+
+export function TripForm({ routeId, serviceId, onSave, onCancel, isPending, routeStops = [], initialData }: {
+  routeId: string;
+  serviceId: string;
+  onSave: (data: any) => void;
+  onCancel: () => void;
+  isPending: boolean;
+  routeStops?: Array<{ stop_id: string; stop_name?: string; stop_lat: number; stop_lon: number; location_type_name?: string }>;
+  initialData?: any;
+}) {
+  const isEdit = !!initialData;
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const [tripId, setTripId] = useState(initialData?.trip_id || "");
+  const [headsign, setHeadsign] = useState(initialData?.trip_headsign || "");
+  const [directionId, setDirectionId] = useState<string>(initialData?.direction_id != null ? String(initialData.direction_id) : "");
+  const existingShapeId = initialData?.shape_id || "";
+  const [shapeId, setShapeId] = useState(existingShapeId);
+  const [shapeEnabled, setShapeEnabled] = useState(!!existingShapeId);
+  const [shapeOpen, setShapeOpen] = useState(false);
+  const [shapePoints, setShapePoints] = useState<Array<{ lat: number; lon: number }>>([]);
+
+  // Load existing shape points when editing a trip with a shape
+  const { data: existingShapePoints } = useQuery({
+    queryKey: ["shapePoints", existingShapeId],
+    queryFn: async () => {
+      const esc = existingShapeId.replace(/'/g, "''");
+      const rows = await executeQuery(conn, `SELECT shape_pt_lat, shape_pt_lon FROM shapes WHERE shape_id = '${esc}' ORDER BY shape_pt_sequence`);
+      return rows.map((r: any) => ({ lat: Number(r.shape_pt_lat), lon: Number(r.shape_pt_lon) })).filter((p: any) => Number.isFinite(p.lat) && Number.isFinite(p.lon));
+    },
+    enabled: !!conn && !!existingShapeId && isEdit,
+    staleTime: Infinity,
+  });
+
+  // Populate shape points from loaded data
+  const shapePointsLoaded = useRef(false);
+  useEffect(() => {
+    if (existingShapePoints && existingShapePoints.length > 0 && !shapePointsLoaded.current) {
+      shapePointsLoaded.current = true;
+      setShapePoints(existingShapePoints);
+    }
+  }, [existingShapePoints]);
+
+  const { data: tripIdExists = false } = useQuery({
+    queryKey: ["tripIdExists", tripId],
+    queryFn: () => checkTripIdExists(conn, tripId),
+    enabled: !!conn && tripId.trim().length > 0 && tripId !== initialData?.trip_id,
+    staleTime: 5000,
+  });
+
+  const shapeChanged = shapeEnabled && (
+    shapeId !== existingShapeId ||
+    shapePoints.length !== (existingShapePoints?.length || 0) ||
+    shapePoints.some((p, i) => {
+      const o = existingShapePoints?.[i];
+      return !o || p.lat !== o.lat || p.lon !== o.lon;
+    })
+  );
+
+  const hasTripChanges = isEdit
+    ? (headsign !== (initialData?.trip_headsign || "") ||
+       directionId !== (initialData?.direction_id != null ? String(initialData.direction_id) : "") ||
+       shapeChanged)
+    : !!tripId;
+
+  return (
+    <FormActions
+      isBusy={isPending}
+      isValid={!!tripId && !tripIdExists}
+      hasChanges={hasTripChanges}
+      onSave={() => onSave({
+        trip_id: tripId, route_id: routeId, service_id: serviceId,
+        trip_headsign: headsign || undefined,
+        direction_id: directionId ? parseInt(directionId) : undefined,
+        shape_id: (shapeEnabled && shapeId) ? shapeId : undefined,
+      })}
+      onCancel={onCancel}
+      saveLabel={isEdit ? "Save" : "Add Trip"}
+      busyLabel={isEdit ? "Saving..." : "Adding..."}
+    >
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Trip ID</Label>
+        <Input value={tripId} onChange={(e) => setTripId(e.target.value)} placeholder="Enter trip ID"
+          className={tripIdExists ? "border-destructive" : ""} disabled={isEdit} />
+        {tripIdExists && <p className="text-xs text-destructive">Trip ID already exists</p>}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <Label className="text-muted-foreground">Route</Label>
+          <Input value={routeId} disabled />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-muted-foreground">Service</Label>
+          <Input value={serviceId} disabled />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Headsign</Label>
+        <Input value={headsign} onChange={(e) => setHeadsign(e.target.value)} placeholder="Trip headsign" />
+      </div>
+      <div className="space-y-2">
+        <Label>Direction</Label>
+        <Input value={directionId} onChange={(e) => setDirectionId(e.target.value)} placeholder="0 or 1" type="number" />
+      </div>
+
+      {/* Shape section */}
+      <div className={`rounded-md border p-3 space-y-3 transition-colors ${shapeEnabled ? "border-primary/30 bg-primary/5" : ""}`}>
+        <div className="flex items-center justify-between">
+          <button type="button" onClick={() => {
+              if (shapeEnabled && shapeOpen) {
+                setShapeEnabled(false); setShapeOpen(false);
+                if (!isEdit) { setShapeId(""); setShapePoints([]); }
+              } else {
+                setShapeEnabled(true); setShapeOpen(true);
+              }
+            }}
+            className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
+            {shapeEnabled && shapeOpen ? <BiChevronDown className="h-4 w-4" /> : <BiChevronRight className="h-4 w-4" />}
+            <span>Shape{isEdit && existingShapeId ? ` (${existingShapeId})` : ""}</span>
+          </button>
+          <Switch checked={shapeEnabled} onCheckedChange={(checked) => { setShapeEnabled(checked); if (checked) setShapeOpen(true); else { setShapeOpen(false); if (!isEdit) { setShapeId(""); setShapePoints([]); } } }} />
+        </div>
+        {shapeEnabled && shapeOpen && (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label>Shape ID</Label>
+              <Input value={shapeId} onChange={(e) => setShapeId(e.target.value)} placeholder="Enter shape ID" disabled={isEdit} />
+            </div>
+            <PointsMapEditor points={shapePoints} onUpdatePoints={setShapePoints} contextStops={routeStops}
+              originalPoints={isEdit && existingShapePoints ? existingShapePoints : undefined} />
+          </div>
+        )}
+      </div>
+
+    </div>
+    </FormActions>
+  );
+}

--- a/packages/web/src/client/Routes/SelectedRoutes/RouteService/index.tsx
+++ b/packages/web/src/client/Routes/SelectedRoutes/RouteService/index.tsx
@@ -1,17 +1,31 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ColumnDef } from "@tanstack/react-table";
-import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { logger } from "@/lib/logger";
 import TableComponent from "@/components/table";
 import Combobox from "@/components/ui/combobox";
 import { Slider } from "@/components/ui/slider";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BiGitCompare, BiPlus, BiX } from "react-icons/bi";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { BiInfoCircle, BiPencil, BiPlus, BiTrash, BiX } from "react-icons/bi";
 import { useDuckDB } from "@/context/duckdb.client";
 import {
   fetchServiceRouteTripsForServiceData,
-  fetchServiceTripStopTimesData,
+  saveCalendarEdit,
+  saveTripEdit,
+  fetchEditedCalendarStatuses,
+  fetchEditedTripStatusesForRoute,
+  fetchRouteStopsForShape,
+  deleteServiceCascade,
+  deleteTripCascade,
 } from "@/lib/duckdb/DataFetching/fetchRouteData";
+import { EditIndicator } from "@/components/ui/EditIndicator";
+import FormPopup from "@/components/ui/formpopup";
+import { CalendarForm } from "./CalendarForm";
+import { TripForm } from "./TripForm";
+import { secondsValue, formatTripTime, formatTimeRange } from "@/lib/tripUtils";
+import { serviceDays, gtfsDateToDay, dayToDisplay, serviceInDateRange } from "@/lib/gtfsDateUtils";
 
 type RouteServiceRow = {
   route_id: string;
@@ -55,145 +69,71 @@ type RouteTrip = {
   last_arrival_seconds?: number;
 };
 
-type TripStopTime = {
-  trip_id: string;
-  stop_sequence?: number;
-  arrival_time?: string;
-  departure_time?: string;
-  stop_id?: string;
-  stop_name?: string;
-  station_name?: string;
-  location_type_name?: string;
-  stop_headsign?: string;
-  pickup_type?: number;
-  drop_off_type?: number;
-};
-
-const dayLabels = [
-  ["monday", "Mon"],
-  ["tuesday", "Tue"],
-  ["wednesday", "Wed"],
-  ["thursday", "Thu"],
-  ["friday", "Fri"],
-  ["saturday", "Sat"],
-  ["sunday", "Sun"],
-] as const;
-
-const normalizeGtfsDate = (value?: string) =>
-  String(value || "").replace(/-/g, "").trim();
-
-const serviceDays = (service: RouteServiceRow) => {
-  const days = dayLabels
-    .filter(([key]) => Number(service[key] || 0) === 1)
-    .map(([, label]) => label);
-  return days.length > 0 ? days.join(", ") : "Dates only";
-};
-
-const gtfsDateToDay = (dateStr?: string) => {
-  const normalized = normalizeGtfsDate(dateStr);
-  if (!normalized || normalized.length !== 8) return undefined;
-  const y = parseInt(normalized.substring(0, 4));
-  const m = parseInt(normalized.substring(4, 6)) - 1;
-  const d = parseInt(normalized.substring(6, 8));
-  const ts = Date.UTC(y, m, d);
-  return Number.isFinite(ts) ? Math.floor(ts / 86400000) : undefined;
-};
-
-const dayToDisplay = (dayNum: number) => {
-  const date = new Date(dayNum * 86400000);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit", timeZone: "UTC" });
-};
-
-const serviceInDateRange = (service: RouteServiceRow, range: [number, number]) => {
-  const startDay = gtfsDateToDay(service.start_date);
-  const endDay = gtfsDateToDay(service.end_date);
-  if (startDay === undefined && endDay === undefined) return true;
-  const sStart = startDay ?? endDay!;
-  const sEnd = endDay ?? startDay!;
-  return sStart <= range[1] && sEnd >= range[0];
-};
-
-const secondsValue = (value?: number | string) => {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : undefined;
-};
-
-const formatTripTime = (value?: number | string) => {
-  const s = secondsValue(value);
-  if (s === undefined) return "";
-  return `${Math.floor(s / 3600)}:${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}`;
-};
-
-const formatTimeRange = (v: [number, number]) => `${formatTripTime(v[0])} - ${formatTripTime(v[1])}`;
-
-const STATION_ROUTE_TYPES = new Set(["Subway, Metro", "Rail", "Tram, Streetcar, Light rail", "Monorail", "Funicular"]);
-const defaultStopView = (rt?: string): "stops" | "stations" => rt && STATION_ROUTE_TYPES.has(rt) ? "stations" : "stops";
-
-const TRIP_COLORS = ["bg-primary", "bg-orange-500", "bg-violet-500", "bg-teal-500", "bg-rose-500"];
-const TRIP_LINE_COLORS = ["#3b82f6", "#f97316", "#8b5cf6", "#14b8a6", "#f43f5e"];
-
-function SelectedBar({ label, value, detail, onClear }: { label: string; value: string; detail?: string; onClear: () => void }) {
-  return (
-    <div
-      className="flex min-w-0 items-center gap-2 rounded-md border bg-primary/5 px-3 py-2 cursor-pointer hover:bg-primary/10 transition-colors"
-      onClick={onClear} role="button" tabIndex={0}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onClear(); }}
-    >
-      <BiX className="h-4 w-4 shrink-0 text-muted-foreground" />
-      <span className="shrink-0 text-xs font-medium uppercase text-muted-foreground">{label}</span>
-      <span className="truncate text-sm font-semibold">{value}</span>
-      {detail ? <span className="hidden truncate text-xs text-muted-foreground sm:inline">{detail}</span> : null}
-    </div>
-  );
-}
-
 function RouteService({
-  routeId, services, selectedServiceId, selectedTripId, initialCompareTripIds, routeTypeName, hasStopTimes = true, onSelectionChange,
+  routeId, services: servicesProp, selectedServiceId, routeTypeName: _routeTypeName, hasStopTimes = true, onSelectionChange,
 }: {
   routeId: string; services: RouteServiceRow[]; selectedServiceId?: string;
-  selectedTripId?: string; initialCompareTripIds?: string; routeTypeName?: string; hasStopTimes?: boolean;
-  onSelectionChange?: (serviceId?: string, tripId?: string) => void;
+  routeTypeName?: string; hasStopTimes?: boolean;
+  onSelectionChange?: (serviceId?: string) => void;
 }) {
   const { conn, initialized } = useDuckDB();
-  const [serviceFilterId, setServiceFilterId] = useState("");
+  const queryClient = useQueryClient();
+
+  const services = servicesProp;
+  const [selectedTripId, setSelectedTripIdLocal] = useState<string | undefined>();
+  const [serviceFilterId, setServiceFilterId] = useState(selectedServiceId || "");
+  // Local selection state — only set by table click, not by URL param
+  const [activeServiceId, setActiveServiceId] = useState<string | undefined>();
+
+  // Sync serviceFilterId with selectedServiceId prop (e.g. navigating from trips page)
+  useEffect(() => {
+    setServiceFilterId(selectedServiceId || "");
+  }, [selectedServiceId]);
   const [tripFilterId, setTripFilterId] = useState("");
   const [headsignFilter, setHeadsignFilter] = useState("");
   const [timeRange, setTimeRange] = useState<[number, number]>([0, 86400]);
-  const [compareTripIds, setCompareTripIds] = useState<string[]>(() => {
-    if (!initialCompareTripIds) return [];
-    return initialCompareTripIds.split(",").map((s) => s.trim()).filter(Boolean)
-      .filter((id) => id !== selectedTripId);
-  });
-  const [isPicking, setIsPicking] = useState(false);
-  const [tripView, setTripView] = useState<"table" | "service">("table");
+  // Calendar/Trip forms
+  const [showCalendarForm, setShowCalendarForm] = useState<false | "new" | "edit">(false);
+  const [showTripForm, setShowTripForm] = useState<false | "new" | "edit">(false);
 
-  const stopView = defaultStopView(routeTypeName);
+  // Edited calendar/trip IDs for indicators (Map<id, status>)
+  const { data: editedCalendarMap = new Map<string, string>() } = useQuery({
+    queryKey: ["editedCalendarMap"],
+    queryFn: () => fetchEditedCalendarStatuses(conn),
+    enabled: !!conn && !!initialized,
+    staleTime: 1000,
+  });
+
+  const { data: editedTripMap = new Map<string, string>() } = useQuery({
+    queryKey: ["editedTripMapForRoute", routeId],
+    queryFn: () => fetchEditedTripStatusesForRoute(conn),
+    enabled: !!conn && !!initialized,
+    staleTime: 5000,
+  });
 
   const serviceRows = useMemo(() => services.map((s) => ({ ...s, service_days: serviceDays(s) })), [services]);
   const selectedService = useMemo(() => {
-    if (!selectedServiceId) return undefined;
-    return serviceRows.find((s) => String(s.service_id) === String(selectedServiceId));
-  }, [selectedServiceId, serviceRows]);
+    if (!activeServiceId) return undefined;
+    return serviceRows.find((s) => String(s.service_id) === String(activeServiceId));
+  }, [activeServiceId, serviceRows]);
 
   const dateBounds = useMemo<[number, number] | undefined>(() => {
-    const days = services.flatMap((s) => [gtfsDateToDay(s.start_date), gtfsDateToDay(s.end_date)]).filter((d): d is number => d !== undefined);
-    if (days.length === 0) return undefined;
-    return [Math.min(...days), Math.max(...days)];
+    let min = Infinity;
+    let max = -Infinity;
+    for (const s of services) {
+      const start = gtfsDateToDay(s.start_date);
+      const end = gtfsDateToDay(s.end_date);
+      if (start !== undefined) { if (start < min) min = start; if (start > max) max = start; }
+      if (end !== undefined) { if (end < min) min = end; if (end > max) max = end; }
+    }
+    return min === Infinity ? undefined : [min, max];
   }, [services]);
-  const [dateRange, setDateRange] = useState<[number, number] | undefined>(undefined);
-  useEffect(() => { if (dateBounds && !dateRange) setDateRange(dateBounds); }, [dateBounds]);
+  const [dateRange, setDateRange] = useState<[number, number] | undefined>(() => dateBounds);
 
-  const initialCompareApplied = useRef(false);
   useEffect(() => {
     setTripFilterId("");
     setHeadsignFilter("");
-    setIsPicking(false);
-    // Preserve initial compare trip IDs on first mount; clear on subsequent service changes
-    if (initialCompareApplied.current) {
-      setCompareTripIds([]);
-    }
-    initialCompareApplied.current = true;
-  }, [selectedServiceId]);
+  }, [activeServiceId]);
 
   const servicesByDate = useMemo(() => {
     if (!dateRange || !dateBounds) return serviceRows;
@@ -209,50 +149,26 @@ function RouteService({
   const serviceOptions = useMemo(() => servicesByDate.map((s) => ({ value: String(s.service_id), label: String(s.service_id) })), [servicesByDate]);
 
   const handleServiceSelect = (service?: RouteServiceRow) => {
+    setActiveServiceId(service?.service_id);
     setServiceFilterId(service?.service_id || "");
-    onSelectionChange?.(service?.service_id, undefined);
+    onSelectionChange?.(service?.service_id);
+    setSelectedTripIdLocal(undefined);
   };
   const handleServiceDropdownChange = (value?: string) => {
     handleServiceSelect(value ? servicesByDate.find((s) => String(s.service_id) === String(value)) : undefined);
   };
 
   const { data: serviceTrips = [], error: serviceTripsError, isLoading: serviceTripsLoading } = useQuery({
-    queryKey: ["fetchServiceRouteTripsForServiceData", routeId, selectedServiceId],
-    queryFn: async () => fetchServiceRouteTripsForServiceData(conn, routeId, selectedServiceId!),
-    enabled: !!conn && !!routeId && !!selectedServiceId && initialized, retry: false,
+    queryKey: ["fetchServiceRouteTripsForServiceData", routeId, activeServiceId],
+    queryFn: async () => fetchServiceRouteTripsForServiceData(conn, routeId, activeServiceId!),
+    enabled: !!conn && !!routeId && !!activeServiceId && initialized, retry: false,
   });
 
-  const selectedTrip = useMemo(() => {
-    if (!selectedTripId) return undefined;
-    return serviceTrips.find((t: RouteTrip) => String(t.trip_id) === String(selectedTripId));
-  }, [selectedTripId, serviceTrips]);
-
-  const { data: stopTimes = [], error: stopTimesError, isLoading: stopTimesLoading } = useQuery({
-    queryKey: ["fetchServiceTripStopTimesData", selectedTripId],
-    queryFn: async () => fetchServiceTripStopTimesData(conn, selectedTripId!),
-    enabled: !!conn && !!selectedTripId && initialized, retry: false,
-  });
-
-  // Compare trips data
-  const compareTrips = useMemo(() =>
-    compareTripIds
-      .map((id) => serviceTrips.find((t: RouteTrip) => String(t.trip_id) === id))
-      .filter(Boolean) as RouteTrip[],
-  [compareTripIds, serviceTrips]);
-
-  const { data: compareStopTimesMap = {}, isLoading: compareLoading } = useQuery({
-    queryKey: ["fetchCompareStopTimes", compareTripIds],
-    queryFn: async () => {
-      const entries = await Promise.all(
-        compareTripIds.map(async (id) => [id, await fetchServiceTripStopTimesData(conn, id)] as const),
-      );
-      return Object.fromEntries(entries) as Record<string, TripStopTime[]>;
-    },
-    enabled: !!conn && compareTripIds.length > 0 && initialized, retry: false,
-  });
-
-  const maxCompareSlots = Math.min(4, Math.max(0, serviceTrips.length - 1));
-  const allSelectedIds = new Set([selectedTripId, ...compareTripIds].filter(Boolean));
+  const tripById = useMemo(() => {
+    const m = new Map<string, RouteTrip>();
+    for (const t of serviceTrips) m.set(String(t.trip_id), t);
+    return m;
+  }, [serviceTrips]);
 
   const headsignOptions = useMemo(() => {
     const set = new Set<string>();
@@ -261,9 +177,16 @@ function RouteService({
   }, [serviceTrips]);
 
   const tripTimeBounds = useMemo<[number, number]>(() => {
-    const vals = serviceTrips.flatMap((t: RouteTrip) => [secondsValue(t.first_departure_seconds), secondsValue(t.last_arrival_seconds)]).filter((v): v is number => v !== undefined);
-    if (vals.length === 0) return [0, 86400];
-    return [Math.max(0, Math.floor(Math.min(...vals) / 300) * 300), Math.ceil(Math.max(...vals) / 300) * 300];
+    let min = Infinity;
+    let max = -Infinity;
+    for (const t of serviceTrips) {
+      const dep = secondsValue(t.first_departure_seconds);
+      const arr = secondsValue(t.last_arrival_seconds);
+      if (dep !== undefined) { if (dep < min) min = dep; if (dep > max) max = dep; }
+      if (arr !== undefined) { if (arr < min) min = arr; if (arr > max) max = arr; }
+    }
+    if (min === Infinity) return [0, 86400] as [number, number];
+    return [Math.max(0, Math.floor(min / 300) * 300), Math.ceil(max / 300) * 300] as [number, number];
   }, [serviceTrips]);
 
   const sliderBounds = useMemo<[number, number]>(() => {
@@ -271,7 +194,14 @@ function RouteService({
     return [Math.max(0, tripTimeBounds[0] - 300), tripTimeBounds[1] + 300];
   }, [tripTimeBounds]);
 
-  useEffect(() => { setTimeRange(tripTimeBounds); }, [selectedServiceId, tripTimeBounds[0], tripTimeBounds[1]]);
+  // Reset timeRange when service or bounds change (derived state via ref tracking)
+  const prevServiceRef = useRef(activeServiceId);
+  const prevBoundsRef = useRef(tripTimeBounds);
+  if (prevServiceRef.current !== activeServiceId || prevBoundsRef.current[0] !== tripTimeBounds[0] || prevBoundsRef.current[1] !== tripTimeBounds[1]) {
+    prevServiceRef.current = activeServiceId;
+    prevBoundsRef.current = tripTimeBounds;
+    setTimeRange(tripTimeBounds);
+  }
 
   const filteredTrips = useMemo(() => serviceTrips.filter((trip: RouteTrip) => {
     if (tripFilterId && String(trip.trip_id) !== String(tripFilterId)) return false;
@@ -285,91 +215,172 @@ function RouteService({
   const tripOptions = useMemo(() => serviceTrips.map((t: RouteTrip) => ({ value: String(t.trip_id), label: String(t.trip_id) })), [serviceTrips]);
 
   const handleTripSelect = (trip?: RouteTrip) => {
+    setSelectedTripIdLocal(trip?.trip_id);
     setTripFilterId(trip?.trip_id || "");
-    setCompareTripIds([]); setIsPicking(false);
-    onSelectionChange?.(selectedServiceId, trip?.trip_id);
   };
-  const handleTripDropdownChange = (v?: string) => handleTripSelect(v ? serviceTrips.find((t: RouteTrip) => String(t.trip_id) === String(v)) : undefined);
+  const handleTripDropdownChange = (v?: string) => handleTripSelect(v ? tripById.get(v) : undefined);
 
-  const startPicking = () => {
-    setTripFilterId(""); setHeadsignFilter(""); setTimeRange(tripTimeBounds); setIsPicking(true);
+  // Route stops for shape drawing in service form
+  const { data: routeStopsForShape = [] } = useQuery({
+    queryKey: ["routeStopsForShape", routeId],
+    queryFn: () => fetchRouteStopsForShape(conn, routeId),
+    enabled: !!conn && !!initialized && showTripForm !== false,
+    staleTime: Infinity,
+  });
+
+  // Calendar save mutation
+  const calendarMutation = useMutation({
+    mutationFn: async (data: any) => saveCalendarEdit(conn, data, data._isNew),
+    onSuccess: () => {
+      setShowCalendarForm(false);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteServicesData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditCalendarTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedCalendarMap"] });
+    },
+  });
+
+  // Calendar delete — tracks pending state manually since we navigate before mutation
+  const [isDeleting, setIsDeleting] = useState(false);
+  const handleDeleteService = async (serviceId: string) => {
+    onSelectionChange?.(undefined);
+    setActiveServiceId(undefined);
+    setSelectedTripIdLocal(undefined);
+    setServiceFilterId("");
+    setIsDeleting(true);
+    try {
+      await deleteServiceCascade(conn, serviceId, routeId);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteServicesData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditCalendarTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedCalendarMap"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteTripsForServiceData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditTripsTable"] });
+      queryClient.invalidateQueries({ queryKey: ["EditStopTimesTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMap"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMapForRoute"] });
+    } catch (err) {
+      logger.error("Service delete failed:", err);
+    } finally {
+      setIsDeleting(false);
+    }
   };
-  const cancelPicking = () => setIsPicking(false);
+
+  // Trip add mutation — auto-select the new trip after creation
+  const tripAddMutation = useMutation({
+    mutationFn: async (data: any) => {
+      await saveTripEdit(conn, data, true);
+      return data;
+    },
+    onSuccess: () => {
+      setShowTripForm(false);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteTripsForServiceData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditTripsTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMapForRoute"] });
+    },
+  });
+
+  // Trip edit mutation
+  const tripEditMutation = useMutation({
+    mutationFn: async (data: any) => {
+      await saveTripEdit(conn, data, false);
+      return data;
+    },
+    onSuccess: () => {
+      setShowTripForm(false);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteTripsForServiceData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditTripsTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMapForRoute"] });
+    },
+  });
+
+  // Trip delete — deletes stop times then trip
+  const [isDeletingTrip, setIsDeletingTrip] = useState(false);
+  const handleDeleteTrip = async (tripId: string) => {
+    setIsDeletingTrip(true);
+    try {
+      await deleteTripCascade(conn, tripId);
+      setSelectedTripIdLocal(undefined);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceRouteTripsForServiceData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["EditTripsTable"] });
+      queryClient.invalidateQueries({ queryKey: ["EditStopTimesTable"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMap"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMapForRoute"] });
+    } catch (err) {
+      logger.error("Trip delete failed:", err);
+    } finally {
+      setIsDeletingTrip(false);
+    }
+  };
 
   const hasDateFilter = dateRange && dateBounds && (dateRange[0] !== dateBounds[0] || dateRange[1] !== dateBounds[1]);
   const hasServiceFilters = Boolean(serviceFilterId || hasDateFilter);
 
   const serviceColumns = useMemo<ColumnDef<RouteServiceRow>[]>(() => [
-    { accessorKey: "service_id", header: "Service ID" }, { accessorKey: "service_days", header: "Days" },
+    { accessorKey: "service_id", header: "Service ID", cell: ({ row }: any) => (
+      <div className="flex items-center gap-2">
+        <EditIndicator status={editedCalendarMap.get(row.original.service_id)} className="h-4 w-4" />
+        <span>{row.original.service_id}</span>
+      </div>
+    ) }, { accessorKey: "service_days", header: "Days" },
     { accessorKey: "start_date", header: "Start" }, { accessorKey: "end_date", header: "End" },
     { accessorKey: "trip_count", header: "Trips" }, { accessorKey: "shape_count", header: "Shapes" },
     { accessorKey: "added_dates", header: "Added Dates" }, { accessorKey: "removed_dates", header: "Removed Dates" },
     { accessorKey: "first_exception_date", header: "First Exception" }, { accessorKey: "last_exception_date", header: "Last Exception" },
-  ], []);
+  ], [editedCalendarMap]);
 
   const tripColumns = useMemo<ColumnDef<RouteTrip>[]>(() => [
-    { accessorKey: "trip_id", header: "Trip ID" }, { accessorKey: "trip_headsign", header: "Headsign" },
-    { accessorKey: "first_departure_time", header: "First Departure", cell: ({ row }) => formatTripTime(row.original.first_departure_seconds) || row.original.first_departure_time || "" },
-    { accessorKey: "last_arrival_time", header: "Last Arrival", cell: ({ row }) => formatTripTime(row.original.last_arrival_seconds) || row.original.last_arrival_time || "" },
+    { accessorKey: "trip_id", header: "Trip ID", cell: ({ row }: any) => (
+      <div className="flex items-center gap-2">
+        <EditIndicator status={editedTripMap.get(row.original.trip_id)} className="h-4 w-4" />
+        <span>{row.original.trip_id}</span>
+      </div>
+    ) }, { accessorKey: "trip_headsign", header: "Headsign" },
+    { accessorKey: "first_departure_time", header: "First Departure", cell: ({ row }: any) => formatTripTime(row.original.first_departure_seconds) || row.original.first_departure_time || "" },
+    { accessorKey: "last_arrival_time", header: "Last Arrival", cell: ({ row }: any) => formatTripTime(row.original.last_arrival_seconds) || row.original.last_arrival_time || "" },
     { accessorKey: "direction_id", header: "Direction" }, { accessorKey: "shape_id", header: "Shape" }, { accessorKey: "block_id", header: "Block" },
-  ], []);
+  ], [editedTripMap]);
 
   return (
     <div className="space-y-4">
-      {/* Selected bars */}
-      {selectedService ? (
-        <SelectedBar label="Service" value={selectedService.service_id}
-          detail={`${selectedService.service_days} • ${selectedService.trip_count || 0} trips`}
-          onClear={() => handleServiceSelect(undefined)} />
-      ) : null}
-
-      {selectedTrip ? (
-        <div className="flex items-center gap-2">
-          <div className="flex-1">
-            <SelectedBar label="Trip" value={selectedTrip.trip_id}
-              detail={selectedTrip.trip_headsign || `${formatTripTime(selectedTrip.first_departure_seconds)} → ${formatTripTime(selectedTrip.last_arrival_seconds)}`}
-              onClear={() => handleTripSelect(undefined)} />
+      {isDeleting && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-6 text-sm text-destructive flex flex-col items-center gap-3">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-destructive border-t-transparent" />
+          <span>Deleting service and associated trips...</span>
+        </div>
+      )}
+      {isDeleting ? null : <>
+      {/* Service selected */}
+      {selectedService && !isDeleting ? (
+        <div className="flex min-w-0 items-center gap-2 rounded-md border bg-primary/5 px-3 py-2">
+          <button onClick={() => handleServiceSelect(undefined)} className="text-muted-foreground hover:text-foreground shrink-0">
+            <BiX className="h-4 w-4" />
+          </button>
+          <EditIndicator status={editedCalendarMap.get(selectedService.service_id)} className="h-5 w-5" />
+          <span className="shrink-0 text-xs font-medium uppercase text-muted-foreground">Service</span>
+          <span className="truncate text-sm font-semibold">{selectedService.service_id}</span>
+          <span className="hidden truncate text-xs text-muted-foreground sm:inline">{selectedService.service_days} {"\u2022"} {selectedService.trip_count || 0} trips</span>
+          <div className="ml-auto flex items-center gap-1.5 shrink-0">
+            <Button variant="outline" size="sm" className="h-7 text-xs" onClick={() => setShowCalendarForm("edit")}>
+              <BiPencil className="mr-1 h-3 w-3" />Edit
+            </Button>
+            <Button variant="destructive" size="sm" className="h-7 text-xs"
+              onClick={() => { if (activeServiceId) handleDeleteService(activeServiceId); }}>
+              <BiTrash className="mr-1 h-3 w-3" />Delete
+            </Button>
           </div>
-          {!isPicking && compareTrips.length < maxCompareSlots && (
-            <div className="flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-2 text-xs font-medium cursor-pointer hover:bg-muted transition-colors"
-              onClick={startPicking} role="button" tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") startPicking(); }}>
-              {compareTrips.length > 0 ? <BiPlus className="h-4 w-4" /> : <BiGitCompare className="h-4 w-4" />}
-              <span className="hidden sm:inline">{compareTrips.length > 0 ? "Add" : "Compare"}</span>
-            </div>
-          )}
-          {isPicking && (
-            <div className="flex shrink-0 items-center gap-1.5 rounded-md border bg-primary/10 border-primary/50 px-3 py-2 text-xs font-medium cursor-pointer hover:bg-primary/20 transition-colors"
-              onClick={cancelPicking} role="button" tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") cancelPicking(); }}>
-              <BiX className="h-4 w-4" />
-              <span className="hidden sm:inline">Cancel</span>
-            </div>
-          )}
         </div>
       ) : null}
 
-      {/* Compare trips chips */}
-      {compareTrips.length > 0 && !isPicking ? (
-        <div className="flex flex-wrap items-center gap-2">
-          {compareTrips.map((ct, idx) => (
-            <div key={ct.trip_id}
-              className="flex items-center gap-1.5 rounded-md border bg-primary/5 px-2.5 py-1.5 text-xs cursor-pointer hover:bg-primary/10 transition-colors"
-              onClick={() => setCompareTripIds((prev) => prev.filter((id) => id !== ct.trip_id))}
-              role="button" tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setCompareTripIds((prev) => prev.filter((id) => id !== ct.trip_id)); }}>
-              <BiX className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className={`h-2 w-2 rounded-full shrink-0 ${TRIP_COLORS[(idx + 1) % TRIP_COLORS.length]}`} />
-              <span className="font-medium truncate">{ct.trip_id}</span>
-              {ct.trip_headsign ? <span className="text-muted-foreground truncate">{ct.trip_headsign}</span> : null}
-            </div>
-          ))}
-        </div>
-      ) : null}
 
       {/* Filter area */}
-      {!selectedService ? (
-        <div className="grid grid-cols-1 gap-2 rounded-md border p-3 md:grid-cols-2">
+      {!selectedService && !isDeleting ? (
+        <div className="grid grid-cols-1 gap-2 rounded-md border p-3 md:grid-cols-3">
+          <Button variant="outline" size="sm" className="h-10" onClick={() => setShowCalendarForm("new")}>
+            <BiPlus className="mr-1 h-4 w-4" />Add Service
+          </Button>
           <Combobox options={serviceOptions} Message="Service ID" value={serviceFilterId} setValue={handleServiceDropdownChange} />
           {dateBounds ? (
             <div className="grid gap-2 px-1">
@@ -382,28 +393,11 @@ function RouteService({
             </div>
           ) : null}
         </div>
-      ) : selectedTrip && hasStopTimes && !isPicking ? (
-        <div className="space-y-2">
-          <Tabs value={tripView} onValueChange={(v) => setTripView(v as "table" | "service")}>
-            <TabsList className="h-8">
-              <TabsTrigger value="table" className="text-xs px-3 py-1">Table</TabsTrigger>
-              <TabsTrigger value="service" className="text-xs px-3 py-1">Service</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-md border p-3 text-sm">
-            <div>
-              <span className="text-xs text-muted-foreground">Time</span>
-              <div className="font-medium">{formatTripTime(selectedTrip.first_departure_seconds) || selectedTrip.first_departure_time || "—"} → {formatTripTime(selectedTrip.last_arrival_seconds) || selectedTrip.last_arrival_time || "—"}</div>
-            </div>
-            {selectedTrip.trip_headsign ? <div><span className="text-xs text-muted-foreground">Headsign</span><div className="font-medium">{selectedTrip.trip_headsign}</div></div> : null}
-            <div>
-              <span className="text-xs text-muted-foreground">{stopView === "stations" ? "Stations" : "Stops"}</span>
-              <div className="font-medium">{stopTimes.length}</div>
-            </div>
-          </div>
-        </div>
-      ) : hasStopTimes ? (
+      ) : hasStopTimes && !isDeletingTrip ? (
         <div className="grid grid-cols-1 gap-2 rounded-md border p-3 sm:grid-cols-2 lg:grid-cols-3">
+          <Button variant="outline" size="sm" className="h-10" onClick={() => setShowTripForm("new")}>
+            <BiPlus className="mr-1 h-4 w-4" />Add Trip
+          </Button>
           <Combobox options={tripOptions} Message="Trip ID" value={tripFilterId} setValue={handleTripDropdownChange} />
           {headsignOptions.length > 1 && <Combobox options={headsignOptions} Message="Headsign" value={headsignFilter} setValue={(v) => setHeadsignFilter(v || "")} />}
           <div className="grid gap-2 px-1">
@@ -418,13 +412,13 @@ function RouteService({
       ) : null}
 
       {/* Service table */}
-      {!selectedService ? (
+      {!selectedService && !isDeleting ? (
         <TableComponent key="all-services" data={filteredServices} columns={serviceColumns}
           ClickInfo={undefined} setClickInfo={hasStopTimes ? handleServiceSelect : undefined} selectionKey="service_id"
           hasActiveFilters={hasServiceFilters} onSortingChange={undefined} clearSortingTrigger={undefined}
           onClearFilters={() => { setServiceFilterId(""); setDateRange(dateBounds); handleServiceSelect(undefined); }}>
           {hasStopTimes ? (
-            <div className="text-sm text-muted-foreground p-3 border rounded-md bg-muted/30">Select a service row to show trips</div>
+            <div className="text-sm text-muted-foreground p-3 border rounded-md bg-muted/30">Select a service to show trips</div>
           ) : (
             <div className="text-sm text-yellow-800 dark:text-yellow-200 p-3 border border-yellow-300 rounded-md bg-yellow-50 dark:bg-yellow-900/20">
               stop_times.txt not imported — trip selection disabled
@@ -436,274 +430,86 @@ function RouteService({
       {selectedService && hasStopTimes && serviceTripsLoading ? <Skeleton className="h-64 w-full" /> : null}
       {selectedService && hasStopTimes && serviceTripsError ? <div className="rounded-md border p-3 text-sm text-muted-foreground">Error loading service trips.</div> : null}
 
-      {/* Trip table — initial selection or compare picking */}
-      {selectedService && hasStopTimes && !serviceTripsLoading && !serviceTripsError && (!selectedTrip || isPicking) ? (
+      {/* Trip deleting indicator */}
+      {isDeletingTrip && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive flex items-center gap-3">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-destructive border-t-transparent" />
+          <span>Deleting trip and stop times...</span>
+        </div>
+      )}
+
+      {/* Trip table */}
+      {selectedService && hasStopTimes && !serviceTripsLoading && !serviceTripsError && !isDeletingTrip ? (
         <TableComponent
-          key={isPicking ? `pick-${selectedServiceId}` : selectedServiceId}
-          data={isPicking ? filteredTrips.filter((t: RouteTrip) => !allSelectedIds.has(String(t.trip_id))) : filteredTrips}
+          key={activeServiceId}
+          data={filteredTrips}
           columns={tripColumns}
-          ClickInfo={undefined}
+          ClickInfo={selectedTripId ? { trip_id: selectedTripId } : undefined}
           setClickInfo={(trip: RouteTrip | undefined) => {
-            if (!trip) return;
-            if (isPicking) {
-              setCompareTripIds((prev) => [...prev, String(trip.trip_id)]);
-              setIsPicking(false);
-            } else {
-              handleTripSelect(trip);
-            }
+            if (!trip) { setSelectedTripIdLocal(undefined); return; }
+            setSelectedTripIdLocal(selectedTripId === String(trip.trip_id) ? undefined : String(trip.trip_id));
           }}
           selectionKey="trip_id" onSortingChange={undefined} clearSortingTrigger={undefined}
           hasActiveFilters={Boolean(tripFilterId || headsignFilter || timeRange[0] !== tripTimeBounds[0] || timeRange[1] !== tripTimeBounds[1])}
-          onClearFilters={() => { setTripFilterId(""); setHeadsignFilter(""); setTimeRange(tripTimeBounds); if (!isPicking) handleTripSelect(undefined); }}>
-          <div className="text-sm text-muted-foreground p-3 border rounded-md bg-muted/30">
-            {isPicking ? "Select a trip to compare with" : "Select a trip row to show its route"}
-          </div>
+          onClearFilters={() => { setTripFilterId(""); setHeadsignFilter(""); setTimeRange(tripTimeBounds); setSelectedTripIdLocal(undefined); }}>
+          {selectedTripId ? (
+            <div className="flex items-center gap-2 p-3 border rounded-md bg-primary/5">
+              <Button asChild variant="outline" size="sm">
+                <Link to="/trips/table" search={{ selectedTripId }}>
+                  <BiInfoCircle className="mr-1 h-4 w-4" />View Trip
+                </Link>
+              </Button>
+              <Button variant="outline" size="sm"
+                onClick={() => setShowTripForm("edit")}>
+                <BiPencil className="mr-1 h-4 w-4" />Edit
+              </Button>
+              <Button variant="destructive" size="sm"
+                onClick={() => handleDeleteTrip(selectedTripId)}>
+                <BiTrash className="mr-1 h-4 w-4" />Delete
+              </Button>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground p-3 border rounded-md bg-muted/30">
+              Select a trip
+            </div>
+          )}
         </TableComponent>
       ) : null}
 
-      {/* Stop times / service diagram */}
-      {selectedTrip && hasStopTimes && !isPicking && (
-        <div>
-          {stopTimesLoading ? <Skeleton className="h-64 w-full" /> : stopTimesError ? (
-            <div className="rounded-md border p-3 text-sm text-muted-foreground">Error loading trip route.</div>
-          ) : tripView === "service" ? (
-            compareLoading && compareTrips.length > 0 ? <Skeleton className="h-64 w-full" /> : (
-              <TripServiceDiagram
-                trips={[{ trip: selectedTrip, stopTimes }, ...compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] }))]}
-                view={stopView} />
-            )
-          ) : compareTrips.length > 0 ? (
-            compareLoading ? <Skeleton className="h-64 w-full" /> : (
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <TripStopPanel trip={selectedTrip} stopTimes={stopTimes} view={stopView} />
-                {compareTrips.map((ct) => (
-                  <TripStopPanel key={ct.trip_id} trip={ct} stopTimes={compareStopTimesMap[ct.trip_id] || []} view={stopView} />
-                ))}
-              </div>
-            )
-          ) : (
-            <TripStopPanel trip={selectedTrip} stopTimes={stopTimes} view={stopView} />
-          )}
-        </div>
+      </>}
+
+      {/* Calendar Form Dialog */}
+      {showCalendarForm && (
+        <FormPopup
+          OpenValue={{ state: true }}
+          setOpenValue={() => setShowCalendarForm(false)}>
+          <h3 className="text-lg font-semibold mb-4">{showCalendarForm === "new" ? "Add Service" : "Edit Service"}</h3>
+          <CalendarForm
+            initialData={showCalendarForm === "edit" ? selectedService : undefined}
+            onSave={(data) => calendarMutation.mutate({ ...data, _isNew: showCalendarForm === "new" })}
+            onCancel={() => setShowCalendarForm(false)}
+            isPending={calendarMutation.isPending}
+          />
+        </FormPopup>
       )}
-    </div>
-  );
-}
 
-// ─── Service Diagram ──────────────────────────────────────────────
-function TripServiceDiagram({ trips, view }: {
-  trips: Array<{ trip: RouteTrip; stopTimes: TripStopTime[] }>;
-  view: "stops" | "stations";
-}) {
-  const getKey = (st: TripStopTime) =>
-    view === "stations" ? (st.station_name || st.stop_name || st.stop_id || "") : (st.stop_id || st.stop_name || "");
-  const getName = (st: TripStopTime) =>
-    view === "stations" ? (st.station_name || st.stop_name || "") : (st.stop_name || "");
-
-  const tripLists = useMemo(() => trips.map(({ stopTimes: st }) => {
-    const raw = st.map((s) => ({ key: getKey(s), name: getName(s), time: s.departure_time || s.arrival_time || "" }));
-    if (view !== "stations") return raw;
-    const deduped: typeof raw = [];
-    for (const s of raw) { if (!deduped.length || deduped[deduped.length - 1].key !== s.key) deduped.push(s); }
-    return deduped;
-  }), [trips, view]);
-
-  const tripSets = useMemo(() => tripLists.map((l) => new Set(l.map((s) => s.key))), [tripLists]);
-
-  const merged = useMemo(() => {
-    const allKeys = new Set<string>();
-    const order: string[] = [];
-    const pointers = tripLists.map(() => 0);
-    const advance = () => {
-      for (let i = 0; i < tripLists.length; i++) {
-        while (pointers[i] < tripLists[i].length && allKeys.has(tripLists[i][pointers[i]].key)) pointers[i]++;
-        if (pointers[i] < tripLists[i].length) {
-          allKeys.add(tripLists[i][pointers[i]].key);
-          order.push(tripLists[i][pointers[i]].key);
-          pointers[i]++;
-          return true;
-        }
-      }
-      return false;
-    };
-    while (advance()) {}
-    return order.map((key) => {
-      const inTrips = tripSets.map((s) => s.has(key));
-      const times = tripLists.map((l) => l.find((s) => s.key === key)?.time || "");
-      const name = tripLists.find((l) => l.find((s) => s.key === key))?.find((s) => s.key === key)?.name || key;
-      return { key, name, inTrips, times, shared: inTrips.every(Boolean) };
-    });
-  }, [tripLists, tripSets]);
-
-  const lineSpacing = 20;
-  const dotR = 5;
-  const rowH = 40;
-  const linesW = trips.length * lineSpacing;
-  const svgH = merged.length * rowH + 24;
-
-  return (
-    <div className="rounded-md border shadow-sm overflow-hidden">
-      {/* Header */}
-      <div className="border-b px-4 py-2 space-y-2">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          {trips.map(({ trip }, idx) => {
-            const color = TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length];
-            const isDown = trip.direction_id === undefined || trip.direction_id === null || trip.direction_id === 0;
-            return (
-              <span key={trip.trip_id} className="flex items-center gap-1.5">
-                <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: color }} />
-                <svg width="10" height="10" viewBox="0 0 10 10" style={{ opacity: 0.7 }}>
-                  {isDown
-                    ? <path d="M5 1v6M2.5 5L5 8l2.5-3" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                    : <path d="M5 9V3M2.5 5L5 2l2.5 3" stroke={color} strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />}
-                </svg>
-                <span className="truncate max-w-[200px] font-medium">{trip.trip_headsign || trip.trip_id}</span>
-              </span>
-            );
-          })}
-        </div>
-      </div>
-      {/* Diagram */}
-      <div className="overflow-auto max-h-[60vh]">
-        <div className="flex">
-          {/* SVG lines area */}
-          <div className="shrink-0" style={{ width: linesW + 8 }}>
-            <svg width={linesW + 8} height={svgH} className="block">
-              {trips.map(({ trip }, idx) => {
-                const color = TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length];
-                const cx = idx * lineSpacing + lineSpacing / 2 + 4;
-                const isDown = trip.direction_id === undefined || trip.direction_id === null || trip.direction_id === 0;
-
-                // Build segments between consecutive served stops
-                const servedStops: Array<{ y: number; shared: boolean }> = [];
-                merged.forEach((stop, i) => {
-                  if (stop.inTrips[idx]) {
-                    servedStops.push({ y: i * rowH + rowH / 2 + 12, shared: stop.shared });
-                  }
-                });
-
-                const isSingle = trips.length === 1;
-
-                return (
-                  <g key={`line-${trip.trip_id}`}>
-                    {servedStops.map((s, si) => {
-                      if (si === 0) return null;
-                      const prev = servedStops[si - 1];
-                      return <line key={si} x1={cx} y1={prev.y} x2={cx} y2={s.y} stroke={color} strokeWidth={2} opacity={0.4} />;
-                    })}
-                    {/* Dots */}
-                    {merged.map((stop, i) => {
-                      if (!stop.inTrips[idx]) return null;
-                      const y = i * rowH + rowH / 2 + 12;
-                      return (
-                        <circle key={i} cx={cx} cy={y} r={dotR}
-                          fill={color} stroke="var(--background)" strokeWidth={2} />
-                      );
-                    })}
-                    {/* Direction arrow */}
-                    <path d={isDown
-                      ? `M${cx - 3.5},${svgH - 10}l3.5,6l3.5,-6`
-                      : `M${cx - 3.5},10l3.5,-6l3.5,6`}
-                      fill={color} opacity={0.6} />
-                  </g>
-                );
-              })}
-            </svg>
-          </div>
-          {/* Stop labels */}
-          <div className="flex-1 min-w-0 pt-3">
-            {merged.map((stop, i) => (
-              <div key={`${stop.key}-${i}`} className="flex flex-col justify-center px-3" style={{ height: rowH }}>
-                <div className="text-sm font-medium leading-tight truncate">{stop.name || stop.key}</div>
-                {stop.times.some((t, idx) => stop.inTrips[idx] && t) && (
-                  <div className="flex flex-wrap gap-x-3 mt-0.5 text-[11px] text-muted-foreground">
-                    {stop.inTrips.map((inThis, idx) => inThis && stop.times[idx] ? (
-                      <span key={idx} className="flex items-center gap-1">
-                        <span className="rounded-full shrink-0" style={{ width: 5, height: 5, backgroundColor: TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length] }} />
-                        {stop.times[idx]}
-                      </span>
-                    ) : null)}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Trip Stop Panel ──────────────────────────────────────────────
-function TripStopPanel({ trip, stopTimes, view }: {
-  trip: RouteTrip; stopTimes: TripStopTime[]; view: "stops" | "stations";
-}) {
-  return (
-    <div>
-      <div className="mb-2 flex items-center gap-2">
-        <span className="text-xs font-medium text-muted-foreground truncate">
-          {trip.trip_id}{trip.trip_headsign ? ` — ${trip.trip_headsign}` : ""}
-          {trip.direction_id !== undefined && trip.direction_id !== null ? (
-            <span className="ml-1 text-muted-foreground/60">(dir {trip.direction_id})</span>
-          ) : null}
-        </span>
-      </div>
-      <TripStopSequence stopTimes={stopTimes} view={view} />
-    </div>
-  );
-}
-
-// ─── Trip Stop Sequence Table ─────────────────────────────────────
-function TripStopSequence({ stopTimes, view }: { stopTimes: TripStopTime[]; view: "stops" | "stations" }) {
-  if (view === "stations") {
-    const grouped: Array<{ station_name: string; sequence: number; stop_count: number; arrival_time: string; departure_time: string }> = [];
-    for (const st of stopTimes) {
-      const name = st.station_name || st.stop_name || "Unknown";
-      const last = grouped[grouped.length - 1];
-      if (last && last.station_name === name) { last.stop_count++; last.departure_time = st.departure_time || last.departure_time; }
-      else grouped.push({ station_name: name, sequence: grouped.length + 1, stop_count: 1, arrival_time: st.arrival_time || "", departure_time: st.departure_time || "" });
-    }
-    return (
-      <div className="rounded-md border shadow-sm overflow-hidden">
-        <div className="overflow-auto max-h-[60vh]">
-          <table className="w-full text-sm">
-            <thead className="sticky top-0 bg-muted z-10">
-              <tr><th className="px-3 py-2 text-left text-xs font-medium">#</th><th className="px-3 py-2 text-left text-xs font-medium">Station</th><th className="px-3 py-2 text-left text-xs font-medium">Arrival</th><th className="px-3 py-2 text-left text-xs font-medium">Departure</th></tr>
-            </thead>
-            <tbody>
-              {grouped.length > 0 ? grouped.map((g, i) => (
-                <tr key={i} className="border-t hover:bg-muted/50">
-                  <td className="px-3 py-2 text-muted-foreground">{g.sequence}</td>
-                  <td className="px-3 py-2 font-medium">{g.station_name}{g.stop_count > 1 ? <span className="ml-1.5 text-xs text-muted-foreground">({g.stop_count} stops)</span> : null}</td>
-                  <td className="px-3 py-2">{g.arrival_time || "—"}</td><td className="px-3 py-2">{g.departure_time || "—"}</td>
-                </tr>
-              )) : <tr><td colSpan={4} className="px-3 py-4 text-center text-muted-foreground">No stop times available</td></tr>}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div className="rounded-md border shadow-sm overflow-hidden">
-      <div className="overflow-auto max-h-[60vh]">
-        <table className="w-full text-sm">
-          <thead className="sticky top-0 bg-muted z-10">
-            <tr><th className="px-3 py-2 text-left text-xs font-medium">#</th><th className="px-3 py-2 text-left text-xs font-medium">Stop</th><th className="px-3 py-2 text-left text-xs font-medium">ID</th><th className="px-3 py-2 text-left text-xs font-medium">Arrival</th><th className="px-3 py-2 text-left text-xs font-medium">Departure</th><th className="px-3 py-2 text-left text-xs font-medium">Station</th></tr>
-          </thead>
-          <tbody>
-            {stopTimes.length > 0 ? stopTimes.map((st, i) => (
-              <tr key={i} className="border-t hover:bg-muted/50">
-                <td className="px-3 py-2 text-muted-foreground">{st.stop_sequence}</td>
-                <td className="px-3 py-2 font-medium">{st.stop_name || "—"}</td>
-                <td className="px-3 py-2 text-muted-foreground text-xs">{st.stop_id || "—"}</td>
-                <td className="px-3 py-2">{st.arrival_time || "—"}</td><td className="px-3 py-2">{st.departure_time || "—"}</td>
-                <td className="px-3 py-2 text-muted-foreground text-xs">{st.station_name || "—"}</td>
-              </tr>
-            )) : <tr><td colSpan={6} className="px-3 py-4 text-center text-muted-foreground">No stop times available</td></tr>}
-          </tbody>
-        </table>
-      </div>
+      {/* Trip Form */}
+      {showTripForm && (
+        <FormPopup
+          OpenValue={{ state: true }}
+          setOpenValue={() => setShowTripForm(false)}>
+          <h3 className="text-lg font-semibold mb-4">{showTripForm === "edit" ? "Edit Trip" : "Add Trip"}</h3>
+          <TripForm
+            routeId={routeId}
+            serviceId={activeServiceId || ""}
+            initialData={showTripForm === "edit" ? tripById.get(selectedTripId!) : undefined}
+            onSave={(data) => showTripForm === "edit" ? tripEditMutation.mutate(data) : tripAddMutation.mutate(data)}
+            onCancel={() => setShowTripForm(false)}
+            isPending={showTripForm === "edit" ? tripEditMutation.isPending : tripAddMutation.isPending}
+            routeStops={routeStopsForShape}
+          />
+        </FormPopup>
+      )}
     </div>
   );
 }

--- a/packages/web/src/client/Routes/routeFilters.ts
+++ b/packages/web/src/client/Routes/routeFilters.ts
@@ -8,11 +8,21 @@ export const routeNameCandidates = (route: any) => {
 export const routeMatchesNameFilter = (route: any, routeName?: string) => {
   const needle = routeName?.trim().toLowerCase();
   if (!needle) return true;
-  return routeNameCandidates(route).some((value) => value.toLowerCase().includes(needle));
+  return routeNameCandidates(route).some((value) => value.toLowerCase() === needle);
 };
 
 export const buildRouteNameOptions = (routes: any[]) => {
-  return Array.from(new Set(routes.flatMap((route) => routeNameCandidates(route))))
-    .sort()
-    .map((name) => ({ label: name, value: name }));
+  // Build unique name options with searchLabel including route_id and all name variants
+  const seen = new Set<string>();
+  const options: Array<{ label: string; value: string; searchLabel: string }> = [];
+  for (const route of routes) {
+    const names = routeNameCandidates(route);
+    for (const name of names) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const searchParts = [name, route.route_id, ...names].filter(Boolean);
+      options.push({ label: name, value: name, searchLabel: searchParts.join(" ") });
+    }
+  }
+  return options.sort((a, b) => a.label.localeCompare(b.label));
 };

--- a/packages/web/src/client/Stations/SelectedStations/index.tsx
+++ b/packages/web/src/client/Stations/SelectedStations/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useDuckDB } from "@/context/duckdb.client";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BiInfoCircle, BiMapAlt, BiGridAlt } from "react-icons/bi";
+import { BiInfoCircle, BiMap, BiGridAlt } from "react-icons/bi";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fetchCheckStationInfo } from "@/lib/duckdb/DataFetching/fetchStationInfoData";
 import { EditIndicator } from "@/components/ui/EditIndicator";
@@ -53,7 +53,7 @@ function SelectedStations({ stationId }: SelectedStationsProps) {
   const ToggleTabs = [
     { value: "StationInfo", label: "Info", icon: <BiInfoCircle /> },
     { value: "StationParts", label: "Parts", icon: <BiGridAlt /> },
-    { value: "StationPathways", label: "Pathways", icon: <BiMapAlt /> },
+    { value: "StationPathways", label: "Pathways", icon: <BiMap /> },
   ];
 
   const TabChange = (e) => {

--- a/packages/web/src/client/Stops/AllStops/StopsMap/index.tsx
+++ b/packages/web/src/client/Stops/AllStops/StopsMap/index.tsx
@@ -53,10 +53,12 @@ function StopsMap({
   const [BoundBox, setBoundBox] = useState<any>();
 
   useEffect(() => {
-    if (viewState || !sqlBounds) return;
-    setViewState(sqlBounds.viewState);
+    if (!sqlBounds) return;
     setBoundBox(sqlBounds.boundBox);
-  }, [sqlBounds, viewState]);
+    if (!viewState) {
+      setViewState(sqlBounds.viewState);
+    }
+  }, [sqlBounds]);
 
   const [initialApplied, setInitialApplied] = useState(false);
   useEffect(() => {
@@ -90,7 +92,11 @@ function StopsMap({
 
   useEffect(() => {
     if (externalViewState) {
-      setViewState(externalViewState);
+      setViewState((prev) => ({
+        ...(prev || {}),
+        ...externalViewState,
+        transitionDuration: 500,
+      }));
     }
   }, [externalViewState]);
 

--- a/packages/web/src/client/Trips/AllTrips/Header.tsx
+++ b/packages/web/src/client/Trips/AllTrips/Header.tsx
@@ -1,0 +1,60 @@
+import { BiReset } from "react-icons/bi";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import Combobox from "@/components/ui/combobox";
+import { MultiSelect } from "@/components/ui/multiselect";
+import { formatTimeRange } from "@/lib/tripUtils";
+
+interface TripsHeaderProps {
+  hasStopTimes: boolean;
+  tripId?: string;
+  routeId?: string;
+  routeType?: string[];
+  availableTripIds: Array<{ value: string; label: string }>;
+  availableRouteIds: Array<{ value: string; label: string; searchLabel?: string; color?: string }>;
+  availableRouteTypes: Array<{ value: string; label: string; color?: string }>;
+  timeRange: [number, number];
+  sliderBounds: [number, number];
+  tripsCount: number;
+  hasActiveFilters: boolean;
+  tableSortingCount: number;
+  updateSearch: (next: Record<string, any>) => void;
+  setTimeRange: (v: [number, number]) => void;
+  clearFilters: () => void;
+  extraButtons?: React.ReactNode;
+}
+
+export function TripsHeader({
+  hasStopTimes, tripId, routeId, routeType,
+  availableTripIds, availableRouteIds, availableRouteTypes,
+  timeRange, sliderBounds, tripsCount,
+  hasActiveFilters, tableSortingCount,
+  updateSearch, setTimeRange, clearFilters, extraButtons,
+}: TripsHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 mt-2">
+      <div className={`grid grid-cols-1 sm:grid-cols-2 ${hasStopTimes ? "lg:grid-cols-4" : "lg:grid-cols-3"} gap-2 mb-1`}>
+        <Combobox options={availableTripIds} Message="Trip ID" value={tripId || ""} setValue={(val) => updateSearch({ tripId: val || undefined })} />
+        <Combobox options={availableRouteIds} Message="Route" value={routeId || ""} setValue={(val) => updateSearch({ routeId: val || undefined })} />
+        <MultiSelect options={availableRouteTypes} onValueChange={(values) => updateSearch({ routeType: values.length ? values : undefined })}
+          defaultValue={routeType || []} placeholder="Route Type" />
+        {hasStopTimes && (
+          <div className="grid gap-2 px-1">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Time Range</span><span>{formatTimeRange(timeRange)}</span>
+            </div>
+            <Slider value={timeRange} min={sliderBounds[0]} max={sliderBounds[1]} step={300} disabled={tripsCount === 0}
+              onValueChange={(v) => setTimeRange([v[0] ?? sliderBounds[0], v[1] ?? sliderBounds[1]] as [number, number])} />
+          </div>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <Button disabled={!hasActiveFilters && tableSortingCount === 0} variant="outline" onClick={clearFilters}
+          className="w-full md:w-auto flex items-center justify-center">
+          <BiReset className="mr-2 h-5 w-5" />Reset
+        </Button>
+        {extraButtons}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/AllTrips/StopEditPanel.tsx
+++ b/packages/web/src/client/Trips/AllTrips/StopEditPanel.tsx
@@ -40,13 +40,14 @@ export function StopEditPanel({
   editStopsRef,
   onEditStopReplace,
 }: StopEditPanelProps) {
-  if (!isEditing) return null;
-
   const isEdit = selectedEditIdx != null;
   const isAdd = !isEdit && (addStopSeqManual != null || addStopId);
-  if (!isEdit && !isAdd) return null;
 
   const sequence = isEdit ? selectedEditIdx! + 1 : addStopSequence;
+
+  if (!isEditing) return null;
+  if (!isEdit && !isAdd) return null;
+
   const maxSequence = isEdit ? editStops.length : editStops.length + 1;
   const label = isEdit ? `Edit Stop #${sequence}` : `Add Stop #${sequence}`;
 
@@ -107,7 +108,7 @@ export function StopEditPanel({
             <div className="w-10 shrink-0">
               <div className="text-[10px] text-muted-foreground mb-0.5">#</div>
               <input type="number" min={1} max={maxSequence} value={sequence}
-                onChange={(e) => handleSequenceChange(parseInt(e.target.value))}
+                onChange={(e) => { const v = parseInt(e.target.value); if (Number.isFinite(v)) handleSequenceChange(v); }}
                 className="flex h-9 w-full rounded-md border border-input bg-background px-1 py-1 text-xs text-center font-medium text-amber-600 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
             </div>
             <div className="flex-1 min-w-0">
@@ -164,7 +165,7 @@ export function StopEditPanel({
         <div className="w-14 shrink-0">
           <div className="text-[10px] text-muted-foreground mb-1">Order</div>
           <input type="number" min={1} max={maxSequence} value={sequence}
-            onChange={(e) => handleSequenceChange(parseInt(e.target.value))}
+            onChange={(e) => { const v = parseInt(e.target.value); if (Number.isFinite(v)) handleSequenceChange(v); }}
             className="flex h-10 w-full rounded-md border border-input bg-background px-2 py-2 text-sm text-center font-medium text-amber-600 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
         </div>
         <div className="flex-1 min-w-[120px]">

--- a/packages/web/src/client/Trips/AllTrips/StopEditPanel.tsx
+++ b/packages/web/src/client/Trips/AllTrips/StopEditPanel.tsx
@@ -1,0 +1,215 @@
+import { BiCrosshair, BiPlus, BiTrash, BiX } from "react-icons/bi";
+import { Button } from "@/components/ui/button";
+import Combobox from "@/components/ui/combobox";
+import { TimeInput } from "@/components/ui/TimeInput";
+import type { EditableStop } from "@/lib/tripUtils";
+
+interface StopEditPanelProps {
+  compact?: boolean;
+  isEditing: boolean;
+  editStops: EditableStop[];
+  selectedEditIdx: number | null;
+  noStops?: boolean;
+  addStopId?: string;
+  addArrival: string;
+  addDeparture: string;
+  addStopSequence: number;
+  addStopSeqManual: number | null;
+  addStopOptions: Array<{ value: string; label: string; searchLabel?: string; color?: string }>;
+  selectedAddStop: any;
+  onPushEdit: (stops: EditableStop[]) => void;
+  onSetSelectedEditIdx: (idx: number | null) => void;
+  onSetAddStopId: (id: string | undefined) => void;
+  onSetAddArrival: (v: string) => void;
+  onSetAddDeparture: (v: string) => void;
+  onSetAddStopSeqManual: (v: number | null) => void;
+  onHandleReorderStop: (fromIdx: number, toPos: number) => void;
+  onHandleAddStopConfirm: () => void;
+  onScrollToStop: (idx: number | null, isPreview?: boolean) => void;
+  editStopsRef: React.RefObject<EditableStop[]>;
+  onEditStopReplace?: (newStopId: string) => void;
+}
+
+export function StopEditPanel({
+  compact, isEditing, editStops, selectedEditIdx, noStops,
+  addStopId, addArrival, addDeparture, addStopSequence, addStopSeqManual,
+  addStopOptions, selectedAddStop,
+  onPushEdit, onSetSelectedEditIdx,
+  onSetAddStopId, onSetAddArrival, onSetAddDeparture, onSetAddStopSeqManual,
+  onHandleReorderStop, onHandleAddStopConfirm, onScrollToStop,
+  editStopsRef,
+  onEditStopReplace,
+}: StopEditPanelProps) {
+  if (!isEditing) return null;
+
+  const isEdit = selectedEditIdx != null;
+  const isAdd = !isEdit && (addStopSeqManual != null || addStopId);
+  if (!isEdit && !isAdd) return null;
+
+  const sequence = isEdit ? selectedEditIdx! + 1 : addStopSequence;
+  const maxSequence = isEdit ? editStops.length : editStops.length + 1;
+  const label = isEdit ? `Edit Stop #${sequence}` : `Add Stop #${sequence}`;
+
+  const handleStopChange = (newId: string | undefined) => {
+    onSetAddStopId(newId);
+    if (isEdit && newId) {
+      onEditStopReplace?.(newId);
+    }
+  };
+
+  const handleArrivalChange = (v: string) => {
+    onSetAddArrival(v);
+    if (isEdit) {
+      onPushEdit(editStops.map((s, i) => (i === selectedEditIdx ? { ...s, arrival_time: v } : s)));
+    }
+  };
+
+  const handleDepartureChange = (v: string) => {
+    onSetAddDeparture(v);
+    if (isEdit) {
+      onPushEdit(editStops.map((s, i) => (i === selectedEditIdx ? { ...s, departure_time: v } : s)));
+    }
+  };
+
+  const handleSequenceChange = (v: number) => {
+    if (isEdit) {
+      if (v >= 1 && v <= editStops.length) onHandleReorderStop(selectedEditIdx!, v);
+    } else {
+      if (v >= 1 && v <= editStops.length + 1) onSetAddStopSeqManual(v);
+    }
+  };
+
+  const handleDelete = () => {
+    onPushEdit(editStopsRef.current!.filter((_, j) => j !== selectedEditIdx).map((s, j) => ({ ...s, stop_sequence: j + 1 })));
+    onSetSelectedEditIdx(null);
+    onSetAddStopId(undefined);
+    onSetAddArrival("");
+    onSetAddDeparture("");
+  };
+
+  const handleClose = () => {
+    onSetAddStopId(undefined);
+    onSetAddArrival("");
+    onSetAddDeparture("");
+    if (isEdit) {
+      onSetSelectedEditIdx(null);
+    } else {
+      onSetAddStopSeqManual(null);
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className="space-y-2 overflow-hidden">
+        <div className="text-[10px] font-medium text-amber-600 dark:text-amber-400">{label}</div>
+        <div className="space-y-1">
+          <div className="flex gap-2">
+            <div className="w-10 shrink-0">
+              <div className="text-[10px] text-muted-foreground mb-0.5">#</div>
+              <input type="number" min={1} max={maxSequence} value={sequence}
+                onChange={(e) => handleSequenceChange(parseInt(e.target.value))}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-1 py-1 text-xs text-center font-medium text-amber-600 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] text-muted-foreground mb-0.5">Stop</div>
+              <Combobox options={addStopOptions} Message="Search stop..." value={addStopId} setValue={handleStopChange} />
+            </div>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <div className="text-[10px] text-muted-foreground mb-0.5">Arrival</div>
+            <TimeInput value={addArrival} onChange={handleArrivalChange} placeholder="HH:MM" />
+          </div>
+          <div>
+            <div className="text-[10px] text-muted-foreground mb-0.5">Departure</div>
+            <TimeInput value={addDeparture} onChange={handleDepartureChange} placeholder="HH:MM" />
+          </div>
+        </div>
+        <div className="flex gap-1 pt-1 border-t">
+          {isEdit ? (<>
+            <Button size="sm" variant="ghost" className="text-xs h-7 text-destructive hover:text-destructive hover:bg-destructive/10" onClick={handleDelete}>
+              <BiTrash className="mr-1 h-3 w-3" />Delete
+            </Button>
+            <Button size="sm" variant="ghost" className="text-xs h-7" title="Zoom to stop" onClick={() => onScrollToStop(selectedEditIdx)}>
+              <BiCrosshair className="h-3 w-3" />
+            </Button>
+            <Button size="sm" variant="ghost" className="text-xs h-7" onClick={handleClose}>
+              <BiX className="mr-1 h-3 w-3" />Close
+            </Button>
+          </>) : (<>
+            <Button size="sm" variant="default" className="text-xs h-7" disabled={!selectedAddStop || !addArrival || !addDeparture} onClick={onHandleAddStopConfirm}>
+              <BiPlus className="mr-1 h-3 w-3" />Add
+            </Button>
+            {selectedAddStop && (
+              <Button size="sm" variant="ghost" className="text-xs h-7" title="Zoom to stop" onClick={() => onScrollToStop(null, true)}>
+                <BiCrosshair className="h-3 w-3" />
+              </Button>
+            )}
+            {!noStops && (
+              <Button size="sm" variant="ghost" className="text-xs h-7" onClick={handleClose}>
+                <BiX className="mr-1 h-3 w-3" />Cancel
+              </Button>
+            )}
+          </>)}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-amber-300 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-950/20 p-3 space-y-2">
+      <div className="text-xs font-medium text-amber-600 dark:text-amber-400">{label}</div>
+      <div className="flex flex-wrap gap-2 items-end">
+        <div className="w-14 shrink-0">
+          <div className="text-[10px] text-muted-foreground mb-1">Order</div>
+          <input type="number" min={1} max={maxSequence} value={sequence}
+            onChange={(e) => handleSequenceChange(parseInt(e.target.value))}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-2 py-2 text-sm text-center font-medium text-amber-600 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
+        </div>
+        <div className="flex-1 min-w-[120px]">
+          <div className="text-[10px] text-muted-foreground mb-1">Stop</div>
+          <Combobox options={addStopOptions} Message="Search stop..." value={addStopId} setValue={handleStopChange} />
+        </div>
+        <div className="w-24 shrink-0">
+          <div className="text-[10px] text-muted-foreground mb-1">Arrival</div>
+          <TimeInput value={addArrival} onChange={handleArrivalChange} placeholder="HH:MM" />
+        </div>
+        <div className="w-24 shrink-0">
+          <div className="text-[10px] text-muted-foreground mb-1">Departure</div>
+          <TimeInput value={addDeparture} onChange={handleDepartureChange} placeholder="HH:MM" />
+        </div>
+        <div className="shrink-0">
+          <div className="text-[10px] text-transparent mb-1">.</div>
+          <div className="flex gap-1">
+            {isEdit ? (<>
+              <Button size="sm" variant="ghost" className="text-xs h-10" title="Zoom to stop" onClick={() => onScrollToStop(selectedEditIdx)}>
+                <BiCrosshair className="h-4 w-4" />
+              </Button>
+              <Button size="sm" variant="ghost" className="text-xs h-10 text-destructive hover:text-destructive hover:bg-destructive/10" title="Delete stop" onClick={handleDelete}>
+                <BiTrash className="h-3.5 w-3.5" />
+              </Button>
+              <Button size="sm" variant="ghost" className="text-xs h-10" title="Close" onClick={handleClose}>
+                <BiX className="h-4 w-4" />
+              </Button>
+            </>) : (<>
+              <Button size="sm" variant="default" className="text-xs h-10" disabled={!selectedAddStop || !addArrival || !addDeparture} onClick={onHandleAddStopConfirm}>
+                <BiPlus className="mr-1 h-3 w-3" />Add
+              </Button>
+              {!noStops && (
+                <Button size="sm" variant="ghost" className="text-xs h-10" title="Scroll to position" onClick={() => onScrollToStop(null, true)}>
+                  <BiCrosshair className="h-4 w-4" />
+                </Button>
+              )}
+              {!noStops && (
+                <Button size="sm" variant="ghost" className="text-xs h-10" onClick={handleClose}>
+                  <BiX className="h-4 w-4" />
+                </Button>
+              )}
+            </>)}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/AllTrips/TripColumns.tsx
+++ b/packages/web/src/client/Trips/AllTrips/TripColumns.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { Link } from "@tanstack/react-router";
+import { getRouteTypeColor } from "@/client/Routes/routeTypeColors";
+import { formatTripTime } from "@/lib/tripUtils";
+import type { TripRow } from "./types";
+
+export function useTripColumns(hasStopTimes: boolean) {
+  return useMemo<ColumnDef<TripRow>[]>(
+    () => [
+      { accessorKey: "trip_id", header: "Trip ID" },
+      {
+        accessorKey: "route_name", header: "Route",
+        cell: ({ row }) => {
+          const t = row.original;
+          const color = t.route_color_hex || getRouteTypeColor(t.route_type_name);
+          return (
+            <Link to="/routes/info" search={{ selectedRouteId: t.route_id }}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex min-w-0 items-center gap-2 rounded px-1.5 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+              <span className="h-3 w-6 rounded-sm border shrink-0" style={{ backgroundColor: color }} />
+              <span className="truncate">{t.route_name || t.route_id || ""}</span>
+            </Link>
+          );
+        },
+      },
+      {
+        accessorKey: "service_id", header: "Service",
+        cell: ({ row }) => {
+          const t = row.original;
+          if (!t.service_id) return "";
+          return (
+            <Link to={hasStopTimes ? "/routes/service" : "/routes/info"}
+              search={{ selectedRouteId: t.route_id, ...(hasStopTimes ? { selectedServiceId: t.service_id } : {}) }}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center rounded px-1.5 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+              {t.service_id}
+            </Link>
+          );
+        },
+      },
+      { accessorKey: "route_type_name", header: "Type" },
+      ...(hasStopTimes ? [
+        { accessorKey: "first_departure_seconds", header: "Departure", cell: ({ row }: any) => formatTripTime(row.original.first_departure_seconds) || "" },
+        { accessorKey: "last_arrival_seconds", header: "Arrival", cell: ({ row }: any) => formatTripTime(row.original.last_arrival_seconds) || "" },
+      ] : []),
+      { accessorKey: "trip_headsign", header: "Headsign" },
+      { accessorKey: "direction_id", header: "Dir" },
+    ],
+    [hasStopTimes],
+  );
+}

--- a/packages/web/src/client/Trips/AllTrips/index.tsx
+++ b/packages/web/src/client/Trips/AllTrips/index.tsx
@@ -1,0 +1,1118 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { BiCrosshair, BiGitCompare, BiMapPin, BiPencil, BiPlus, BiReset, BiSave, BiUndo, BiX } from "react-icons/bi";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import TableComponent from "@/components/table";
+import { useDuckDB } from "@/context/duckdb.client";
+import { getRouteTypeColor } from "@/client/Routes/routeTypeColors";
+import { EditIndicator } from "@/components/ui/EditIndicator";
+import { fetchServiceTripStopTimesData, saveStopTimesEdits, fetchEditedTripStatuses, fetchStopsWithRouteFlag } from "@/lib/duckdb/DataFetching/fetchRouteData";
+import EntityForm from "@/components/forms/EntityForm";
+import {
+  type TripStopTime,
+  type EditableStop,
+  TRIP_COLORS,
+  TRIP_LINE_COLORS,
+  formatTripTime,
+  secondsValue,
+  defaultStopView,
+  validateStopTimes,
+  parseTime,
+  timeToSec,
+} from "@/lib/tripUtils";
+import { Timetable, TripStopPanel } from "@/client/Trips/components/Timetable";
+import { Timeline } from "@/client/Trips/components/Timeline";
+import { TripMap } from "@/client/Trips/components/Map";
+import type { TripRow, AllTripsProps } from "./types";
+import { TripsHeader } from "./Header";
+import { useTripColumns } from "./TripColumns";
+import { StopEditPanel } from "./StopEditPanel";
+
+function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch }: AllTripsProps) {
+  const { conn, initialized } = useDuckDB() ?? {};
+  const queryClient = useQueryClient();
+  const [tableSorting, setTableSorting] = useState([]);
+  const [clearSortingTrigger, setClearSortingTrigger] = useState(0);
+  const [tripView, setTripView] = useState<"timetable" | "timeline" | "map">(
+    search.view === "timeline" || search.view === "map" ? search.view : "timetable"
+  );
+  const [compareTripIds, setCompareTripIdsRaw] = useState<string[]>(() => {
+    if (search.compareTripIds) {
+      return search.compareTripIds.split(",").map((s) => s.trim()).filter(Boolean);
+    }
+    return [];
+  });
+  const setCompareTripIds = useCallback((updater: string[] | ((prev: string[]) => string[])) => {
+    setCompareTripIdsRaw((prev) => {
+      const next = typeof updater === "function" ? updater(prev) : updater;
+      updateSearch({ compareTripIds: next.length > 0 ? next.join(",") : undefined });
+      setHiddenTripIndices(new Set());
+      return next;
+    });
+  }, [updateSearch]);
+  const [isPicking, setIsPicking] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [hiddenTripIndices, setHiddenTripIndices] = useState<Set<number>>(new Set());
+  const toggleTripVisibility = useCallback((idx: number) => {
+    setHiddenTripIndices((prev) => { const next = new Set(prev); if (next.has(idx)) next.delete(idx); else next.add(idx); return next; });
+  }, []);
+  const [editStops, setEditStops] = useState<EditableStop[]>([]);
+  const [editErrors, setEditErrors] = useState<string[]>([]);
+  const [deletedStopIndices, setDeletedStopIndices] = useState<Set<number>>(new Set());
+  const [undoStack, setUndoStack] = useState<Array<{ stops: EditableStop[]; deleted: Set<number> }>>([]);
+
+  const [, setShowAddPanel] = useState(false);
+  const [selectedEditIdx, setSelectedEditIdx] = useState<number | null>(null);
+  // View-mode selection (for timeline/map popup in non-edit mode)
+  const [viewSelectedIdx, setViewSelectedIdx] = useState<number | null>(null);
+  const [viewSelectedTripIdx, setViewSelectedTripIdx] = useState<number>(0);
+  const [addStopId, setAddStopId] = useState<string | undefined>();
+  const [addArrival, setAddArrival] = useState("");
+  const [addDeparture, setAddDeparture] = useState("");
+
+  const tripId = search.tripId;
+  const routeId = search.routeId;
+  const routeType = search.routeType;
+  const selectedTripId = search.selectedTripId;
+
+  // Ref for TripMap zoom-to-stop function
+  const zoomToStopRef = useRef<((stopIdx: number) => void) | null>(null);
+
+  // Use refs for undo stack push so pushEdit never has stale closures
+  const editStopsRef = useRef(editStops);
+  editStopsRef.current = editStops;
+  const deletedStopIndicesRef = useRef(deletedStopIndices);
+  deletedStopIndicesRef.current = deletedStopIndices;
+
+  // Wrap setEditStops to push to undo stack
+  const pushEdit = useCallback((newStops: EditableStop[], newDeleted?: Set<number>) => {
+    setUndoStack((prev) => [...prev.slice(-19), { stops: editStopsRef.current, deleted: new Set(deletedStopIndicesRef.current) }]);
+    setEditStops(newStops);
+    if (newDeleted !== undefined) setDeletedStopIndices(newDeleted);
+    setEditErrors([]);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    setUndoStack((prev) => {
+      if (prev.length === 0) return prev;
+      const last = prev[prev.length - 1];
+      setEditStops(last.stops);
+      setDeletedStopIndices(last.deleted);
+      setEditErrors([]);
+      setAddStopSeqManual(null);
+      return prev.slice(0, -1);
+    });
+  }, []);
+
+  const { data: editedTripMap = new Map<string, string>() } = useQuery({
+    queryKey: ["editedTripMap"],
+    queryFn: () => fetchEditedTripStatuses(conn),
+    enabled: !!conn && !!initialized,
+    staleTime: 1000,
+  });
+
+  // Merge edit status into trips
+  const tripsWithStatus = useMemo(() =>
+    allTrips.map((t) => {
+      const status = editedTripMap.get(String(t.trip_id));
+      return status ? { ...t, status } : t;
+    }),
+    [allTrips, editedTripMap],
+  );
+
+  // --- Filters (cross-filtered) ---
+  const sliderBounds = useMemo<[number, number]>(() => {
+    if (tripTimeBounds[0] !== tripTimeBounds[1]) return tripTimeBounds;
+    return [Math.max(0, tripTimeBounds[0] - 300), tripTimeBounds[1] + 300];
+  }, [tripTimeBounds]);
+
+  const [timeRange, setTimeRange] = useState<[number, number]>(tripTimeBounds);
+  const prevBoundsRef = useRef(tripTimeBounds);
+  if (prevBoundsRef.current[0] !== tripTimeBounds[0] || prevBoundsRef.current[1] !== tripTimeBounds[1]) {
+    prevBoundsRef.current = tripTimeBounds;
+    setTimeRange(tripTimeBounds);
+  }
+
+  // For each filter dropdown, apply all OTHER filters to get available options
+  const tripsForTripIdFilter = useMemo(() => {
+    let filtered = tripsWithStatus;
+    if (routeId) filtered = filtered.filter((t) => String(t.route_id) === routeId);
+    if (routeType && routeType.length > 0) filtered = filtered.filter((t) => routeType.includes(t.route_type_name || ""));
+    return filtered;
+  }, [tripsWithStatus, routeId, routeType]);
+
+  const tripsForRouteFilter = useMemo(() => {
+    let filtered = tripsWithStatus;
+    if (tripId) filtered = filtered.filter((t) => String(t.trip_id) === tripId);
+    if (routeType && routeType.length > 0) filtered = filtered.filter((t) => routeType.includes(t.route_type_name || ""));
+    return filtered;
+  }, [tripsWithStatus, tripId, routeType]);
+
+  const tripsForTypeFilter = useMemo(() => {
+    let filtered = tripsWithStatus;
+    if (tripId) filtered = filtered.filter((t) => String(t.trip_id) === tripId);
+    if (routeId) filtered = filtered.filter((t) => String(t.route_id) === routeId);
+    return filtered;
+  }, [tripsWithStatus, tripId, routeId]);
+
+  const availableTripIds = useMemo(
+    () => tripsForTripIdFilter.map((t) => ({ value: String(t.trip_id), label: String(t.trip_id) }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [tripsForTripIdFilter],
+  );
+
+  const availableRouteIds = useMemo(() => {
+    const seen = new Set<string>();
+    return tripsForRouteFilter
+      .filter((t) => { if (!t.route_id || seen.has(t.route_id)) return false; seen.add(t.route_id); return true; })
+      .map((t) => ({
+        value: String(t.route_id),
+        label: t.route_name ? `${t.route_name} (${t.route_id})` : String(t.route_id),
+        searchLabel: `${t.route_id} ${t.route_name || ""}`,
+        color: t.route_color_hex || getRouteTypeColor(t.route_type_name),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [tripsForRouteFilter]);
+
+  const availableRouteTypes = useMemo(() => {
+    const types = new Set<string>();
+    for (const t of tripsForTypeFilter) { if (t.route_type_name) types.add(t.route_type_name); }
+    return Array.from(types).sort().map((type) => ({ label: type, value: type, color: getRouteTypeColor(type) }));
+  }, [tripsForTypeFilter]);
+
+  const filteredTrips = useMemo(() => {
+    let filtered = tripsWithStatus;
+    if (tripId) filtered = filtered.filter((t) => String(t.trip_id) === tripId);
+    if (routeId) filtered = filtered.filter((t) => String(t.route_id) === routeId);
+    if (routeType && routeType.length > 0)
+      filtered = filtered.filter((t) => routeType.includes(t.route_type_name || ""));
+    filtered = filtered.filter((t) => {
+      const start = secondsValue(t.first_departure_seconds);
+      const end = secondsValue(t.last_arrival_seconds) ?? start;
+      if (start === undefined && end === undefined) return true;
+      return (start ?? end ?? 0) <= timeRange[1] && (end ?? start ?? 0) >= timeRange[0];
+    });
+    return filtered;
+  }, [tripsWithStatus, tripId, routeId, routeType, timeRange]);
+
+  const tripById = useMemo(() => {
+    const m = new Map<string, TripRow>();
+    for (const t of tripsWithStatus) m.set(String(t.trip_id), t);
+    return m;
+  }, [tripsWithStatus]);
+
+  const selectedTrip = selectedTripId ? tripById.get(selectedTripId) : undefined;
+  const stopView = defaultStopView(selectedTrip?.route_type_name);
+
+  const { data: stopTimes = [], isLoading: stopTimesLoading, error: stopTimesError } = useQuery({
+    queryKey: ["fetchServiceTripStopTimesData", selectedTripId],
+    queryFn: async () => fetchServiceTripStopTimesData(conn, selectedTripId!),
+    enabled: !!conn && !!selectedTripId && !!initialized,
+    retry: false,
+  });
+
+  const compareTrips = useMemo(
+    () => compareTripIds.flatMap((id) => { const t = tripById.get(id); return t ? [t] : []; }),
+    [compareTripIds, tripById],
+  );
+
+  const { data: compareStopTimesMap = {}, isLoading: compareLoading } = useQuery({
+    queryKey: ["fetchCompareStopTimes", "allTrips", compareTripIds],
+    queryFn: async () => {
+      const entries = await Promise.all(
+        compareTripIds.map(async (id) => [id, await fetchServiceTripStopTimesData(conn, id)] as const),
+      );
+      return Object.fromEntries(entries) as Record<string, TripStopTime[]>;
+    },
+    enabled: !!conn && compareTripIds.length > 0 && !!initialized,
+    retry: false,
+  });
+
+  // Route stops for replacement dropdown
+  const selectedRouteId = selectedTrip?.route_id;
+  const { data: routeStops = [] } = useQuery({
+    queryKey: ["allStopsWithRouteFlag", selectedRouteId],
+    queryFn: () => fetchStopsWithRouteFlag(conn, selectedRouteId!),
+    enabled: !!conn && !!selectedRouteId && isEditing && !!initialized,
+    staleTime: Infinity,
+  });
+
+  // Stop form state
+  const [showStopForm, setShowStopForm] = useState(false);
+
+  const maxCompareSlots = Math.min(5, Math.max(0, filteredTrips.length - 1));
+  const allSelectedIds = new Set([selectedTripId, ...compareTripIds].filter(Boolean));
+
+  const hasActiveFilters = Boolean(
+    tripId || routeId || (routeType && routeType.length > 0) ||
+    timeRange[0] !== tripTimeBounds[0] || timeRange[1] !== tripTimeBounds[1],
+  );
+
+  const clearFilters = () => {
+    if (isPicking) {
+      updateSearch({ tripId: undefined, routeId: undefined, routeType: undefined });
+      setTimeRange(tripTimeBounds);
+      setClearSortingTrigger((p) => p + 1);
+    } else {
+      updateSearch({ tripId: undefined, routeId: undefined, routeType: undefined, selectedTripId: undefined });
+      setTimeRange(tripTimeBounds);
+      setClearSortingTrigger((p) => p + 1);
+      setCompareTripIds([]);
+      setIsPicking(false);
+      setIsEditing(false);
+    }
+  };
+
+  const handleTripSelect = (trip?: TripRow) => {
+    updateSearch({ selectedTripId: trip?.trip_id || undefined });
+    if (trip) setTripView("timetable");
+    setCompareTripIds([]);
+    setIsPicking(false);
+    setIsEditing(false);
+    setViewSelectedIdx(null);
+  };
+
+  const startEditing = () => {
+    setEditStops(stopTimes.map((s, i) => ({ ...s, _idx: i })));
+    setEditErrors([]);
+    setIsEditing(true);
+    setShowAddPanel(true);
+    setCompareTripIds([]);
+    setIsPicking(false);
+    setDeletedStopIndices(new Set());
+    setUndoStack([]);
+    setAddStopId(undefined); setAddArrival(""); setAddDeparture("");
+    // When no stops exist, pre-activate the add panel at position 1
+    setAddStopSeqManual(stopTimes.length === 0 ? 1 : null);
+  };
+
+  const cancelEditing = () => { setIsEditing(false); setEditErrors([]); setDeletedStopIndices(new Set()); setUndoStack([]); setShowAddPanel(false); setSelectedEditIdx(null); setAddStopId(undefined); setAddArrival(""); setAddDeparture(""); setAddStopSeqManual(null); };
+
+  const handleDeleteStop = useCallback((stopIdx: number) => {
+    setUndoStack((prev) => [...prev.slice(-19), { stops: editStops, deleted: new Set(deletedStopIndices) }]);
+    setDeletedStopIndices((prev) => new Set(prev).add(stopIdx));
+  }, [editStops, deletedStopIndices]);
+
+  const handleRestoreStop = useCallback((stopIdx: number) => {
+    setDeletedStopIndices((prev) => { const next = new Set(prev); next.delete(stopIdx); return next; });
+  }, []);
+
+  const handleReplaceStop = useCallback((stopIdx: number, newStop: { stop_id: string; stop_name: string; stop_lat?: number; stop_lon?: number }) => {
+    setEditStops((prev) => prev.map((s, i) => (i === stopIdx ? {
+      ...s,
+      stop_id: newStop.stop_id,
+      stop_name: newStop.stop_name,
+      stop_lat: newStop.stop_lat ?? s.stop_lat,
+      stop_lon: newStop.stop_lon ?? s.stop_lon,
+    } : s)));
+  }, []);
+
+  // Replace stop via selector in the unified edit form
+  const handleEditStopReplace = useCallback((newStopId: string) => {
+    if (selectedEditIdx == null) return;
+    const rs = routeStops.find((r: any) => r.stop_id === newStopId);
+    if (!rs) return;
+    pushEdit(editStopsRef.current.map((s, i) =>
+      i === selectedEditIdx ? {
+        ...s,
+        stop_id: rs.stop_id,
+        stop_name: rs.stop_name,
+        stop_lat: Number(rs.stop_lat) || s.stop_lat,
+        stop_lon: Number(rs.stop_lon) || s.stop_lon,
+      } : s
+    ));
+  }, [selectedEditIdx, routeStops, pushEdit]);
+
+  // Unified handler for selecting a stop in edit mode (populates form state)
+  const handleSelectEditStop = useCallback((idx: number | null) => {
+    setSelectedEditIdx(idx);
+    if (idx != null) {
+      const stop = editStopsRef.current[idx];
+      setAddStopId(stop?.stop_id);
+      setAddArrival(stop?.arrival_time || "");
+      setAddDeparture(stop?.departure_time || "");
+      setAddStopSeqManual(null);
+    } else {
+      setAddStopId(undefined);
+      setAddArrival("");
+      setAddDeparture("");
+    }
+  }, []);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      // Filter out deleted stops before saving
+      const activeStops = editStops.filter((_, i) => !deletedStopIndices.has(i));
+      const errors = validateStopTimes(activeStops);
+      if (errors.length > 0) { setEditErrors(errors); throw new Error("Validation failed"); }
+      await saveStopTimesEdits(conn, selectedTripId!, activeStops.map((s, i) => ({
+        stop_sequence: i + 1, stop_id: s.stop_id, arrival_time: s.arrival_time,
+        departure_time: s.departure_time, stop_headsign: s.stop_headsign,
+        pickup_type: s.pickup_type, drop_off_type: s.drop_off_type,
+      })));
+    },
+    onSuccess: () => {
+      setIsEditing(false);
+      setEditErrors([]);
+      queryClient.invalidateQueries({ queryKey: ["fetchServiceTripStopTimesData", selectedTripId] });
+      queryClient.invalidateQueries({ queryKey: ["fetchAllTripsData"] });
+      queryClient.invalidateQueries({ queryKey: ["fetchTripsTimeBounds"] });
+      queryClient.invalidateQueries({ queryKey: ["editedTripMap"] });
+      queryClient.invalidateQueries({ queryKey: ["EditStopTimesTable"] });
+    },
+  });
+
+  const handleEditStopUpdate = (stops: EditableStop[]) => { pushEdit(stops); };
+  const handleTimelineStopUpdate = (_ti: number, si: number, field: "arrival_time" | "departure_time", value: string) => {
+    setEditStops((prev) => prev.map((s, i) => (i === si ? { ...s, [field]: value } : s)));
+  };
+
+  const selectedAddStop = addStopId ? routeStops.find((rs: any) => rs.stop_id === addStopId) : undefined;
+
+  // Manual sequence override (set by clicking between rows in timetable)
+  const [addStopSeqManual, setAddStopSeqManual] = useState<number | null>(null);
+
+  // Time-based sequence (fallback when no manual override)
+  const addStopSeqFromTime = useMemo(() => {
+    const targetSec = timeToSec(addArrival) ?? timeToSec(addDeparture);
+    if (targetSec == null) return editStops.length + 1;
+    for (let i = 0; i < editStops.length; i++) {
+      const sSec = timeToSec(editStops[i].arrival_time) ?? timeToSec(editStops[i].departure_time);
+      if (sSec != null && sSec > targetSec) return i + 1;
+    }
+    return editStops.length + 1;
+  }, [editStops, addArrival, addDeparture]);
+
+  const addStopSequence = addStopSeqManual ?? addStopSeqFromTime;
+
+  const handleAddStopConfirm = () => {
+    if (!selectedAddStop) return;
+    const arr = addArrival ? (parseTime(addArrival) || addArrival) : "";
+    const dep = addDeparture ? (parseTime(addDeparture) || addDeparture) : arr;
+    // Give new stop a unique _idx that won't collide with originals
+    const maxIdx = editStops.reduce((max, s) => Math.max(max, s._idx ?? 0), 0);
+    const newStop = {
+      _idx: maxIdx + 1, trip_id: "", stop_sequence: 0,
+      stop_id: selectedAddStop.stop_id, stop_name: selectedAddStop.stop_name,
+      stop_lat: Number(selectedAddStop.stop_lat) || undefined,
+      stop_lon: Number(selectedAddStop.stop_lon) || undefined,
+      arrival_time: arr, departure_time: dep,
+    } as EditableStop;
+    const insertIdx = addStopSequence - 1;
+    const newStops = [...editStops];
+    newStops.splice(insertIdx, 0, newStop);
+    pushEdit(newStops.map((s, i) => ({ ...s, stop_sequence: i + 1 })));
+    setAddStopId(undefined); setAddArrival(""); setAddDeparture(""); setAddStopSeqManual(null);
+  };
+
+  const addStopOptions = useMemo(() => {
+    const onRoute: any[] = []; const offRoute: any[] = [];
+    for (const rs of routeStops) {
+      const opt = { value: rs.stop_id, label: `${rs.stop_name || rs.stop_id} (${rs.stop_id})`, searchLabel: `${rs.stop_id} ${rs.stop_name || ""}`, color: (rs as any).on_route ? "#3b82f6" : "#9ca3af" };
+      if ((rs as any).on_route) onRoute.push(opt); else offRoute.push(opt);
+    }
+    return [...onRoute, ...offRoute];
+  }, [routeStops]);
+
+  const startPicking = () => {
+    setIsPicking(true);
+    // Pre-filter to the selected trip's route
+    if (selectedTrip?.route_id) {
+      updateSearch({ routeId: selectedTrip.route_id });
+    }
+  };
+  const cancelPicking = () => {
+    setIsPicking(false);
+    updateSearch({ tripId: undefined, routeId: undefined, routeType: undefined });
+    setTimeRange(tripTimeBounds);
+  };
+
+  const columns = useTripColumns(hasStopTimes);
+
+  const scrollToStop = (idx: number | null, isPreview?: boolean) => {
+    if (tripView === "map") {
+      if (idx != null && zoomToStopRef.current) {
+        zoomToStopRef.current(idx);
+      } else if (isPreview && selectedAddStop) {
+        const lat = Number(selectedAddStop.stop_lat);
+        const lon = Number(selectedAddStop.stop_lon);
+        if (Number.isFinite(lat) && Number.isFinite(lon) && zoomToStopRef.current) {
+          zoomToStopRef.current(lon, lat);
+        }
+      }
+      return;
+    }
+    const selector = isPreview ? `[data-stop-preview="true"]` : idx != null ? `[data-stop-idx="${idx}"]` : null;
+    if (!selector) return;
+    const el = document.querySelector(selector);
+    if (!el) return;
+    const svgParent = el.closest("svg");
+    if (svgParent) {
+      const scrollContainer = svgParent.parentElement;
+      if (scrollContainer && scrollContainer.scrollWidth > scrollContainer.clientWidth) {
+        const elRect = (el as SVGElement).getBoundingClientRect();
+        const containerRect = scrollContainer.getBoundingClientRect();
+        const targetScroll = scrollContainer.scrollLeft + (elRect.left - containerRect.left) - (containerRect.width / 2) + (elRect.width / 2);
+        scrollContainer.scrollTo({ left: targetScroll, behavior: "smooth" });
+      }
+    } else {
+      el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
+    }
+  };
+
+  const handleReorderStop = (fromIdx: number, toPos: number) => {
+    // toPos is 1-based target position
+    const stops = editStopsRef.current;
+    const toIdx = Math.max(0, Math.min(stops.length - 1, toPos - 1));
+    if (fromIdx === toIdx) return;
+    const next = [...stops];
+    const [moved] = next.splice(fromIdx, 1);
+    next.splice(toIdx, 0, moved);
+    // Keep _idx stable (original identity) — only update stop_sequence
+    pushEdit(next.map((s, i) => ({ ...s, stop_sequence: i + 1 })));
+    // Sync selection + form state to the moved stop at its new position
+    const movedStop = next[toIdx];
+    setSelectedEditIdx(toIdx);
+    setAddStopId(movedStop?.stop_id);
+    setAddArrival(movedStop?.arrival_time || "");
+    setAddDeparture(movedStop?.departure_time || "");
+  };
+
+  const renderStopPanel = (compact?: boolean) => (
+    <StopEditPanel
+      compact={compact} isEditing={isEditing} editStops={editStops}
+      selectedEditIdx={selectedEditIdx} noStops={editStops.length === 0} addStopId={addStopId}
+      addArrival={addArrival} addDeparture={addDeparture}
+      addStopSequence={addStopSequence} addStopSeqManual={addStopSeqManual}
+      addStopOptions={addStopOptions} selectedAddStop={selectedAddStop}
+      onPushEdit={pushEdit} onSetSelectedEditIdx={setSelectedEditIdx}
+      onSetAddStopId={setAddStopId} onSetAddArrival={setAddArrival}
+      onSetAddDeparture={setAddDeparture} onSetAddStopSeqManual={setAddStopSeqManual}
+      onHandleReorderStop={handleReorderStop} onHandleAddStopConfirm={handleAddStopConfirm}
+      onScrollToStop={scrollToStop} editStopsRef={editStopsRef}
+      onEditStopReplace={handleEditStopReplace}
+    />
+  );
+
+  const renderTripLegend = (tripsList: TripRow[], colorOffset = 0) => {
+    if (tripsList.length < 2) return null;
+    return (
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+        {tripsList.map((t, idx) => {
+          const ci = idx + colorOffset;
+          const isHidden = hiddenTripIndices.has(ci);
+          return (
+            <span key={t.trip_id}
+              className="flex items-center gap-1.5 cursor-pointer select-none hover:bg-muted/50 rounded px-1.5 py-0.5 transition-colors"
+              onClick={() => toggleTripVisibility(ci)}>
+              <span className="rounded-full shrink-0 border" style={{
+                width: 8, height: 8,
+                backgroundColor: isHidden ? "transparent" : TRIP_LINE_COLORS[ci % TRIP_LINE_COLORS.length],
+                borderColor: TRIP_LINE_COLORS[ci % TRIP_LINE_COLORS.length],
+              }} />
+              <span className={`truncate max-w-[120px] font-medium ${isHidden ? "line-through opacity-50" : ""}`}>
+                {t.trip_headsign || t.trip_id}
+              </span>
+              {t.route_name && <span className={`text-muted-foreground truncate max-w-[80px] ${isHidden ? "opacity-50" : ""}`}>{t.route_name}</span>}
+              {t.service_id && <span className={`text-muted-foreground/60 truncate max-w-[60px] ${isHidden ? "opacity-50" : ""}`}>{t.service_id}</span>}
+            </span>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Filters (when no trip selected and not picking) */}
+      {!selectedTrip && !isEditing && !isPicking && (
+        <TripsHeader
+          hasStopTimes={hasStopTimes} tripId={tripId} routeId={routeId} routeType={routeType}
+          availableTripIds={availableTripIds} availableRouteIds={availableRouteIds} availableRouteTypes={availableRouteTypes}
+          timeRange={timeRange} sliderBounds={sliderBounds} tripsCount={tripsWithStatus.length}
+          hasActiveFilters={hasActiveFilters} tableSortingCount={tableSorting.length}
+          updateSearch={updateSearch} setTimeRange={setTimeRange} clearFilters={clearFilters}
+          extraButtons={hasStopTimes && compareTrips.length === 0 ? (
+            <Button variant="outline" onClick={startPicking} className="w-full md:w-auto flex items-center justify-center">
+              <BiGitCompare className="mr-2 h-5 w-5" />Compare Trips
+            </Button>
+          ) : undefined}
+        />
+      )}
+
+      {/* Validation errors */}
+      {editErrors.length > 0 && (
+        <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300 space-y-1">
+          {editErrors.map((err, i) => <div key={i}>{err}</div>)}
+        </div>
+      )}
+
+      {/* Selected trip bar */}
+      {selectedTrip && !isEditing && (
+        <div
+          className="flex min-w-0 items-center gap-3 rounded-md border bg-primary/5 px-4 py-3 cursor-pointer hover:bg-primary/10 transition-colors"
+          onClick={() => handleTripSelect(undefined)} role="button" tabIndex={0}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleTripSelect(undefined); }}>
+          <BiX className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <EditIndicator status={selectedTrip.status} className="h-5 w-5" />
+          <span className="h-3 w-6 rounded-sm border shrink-0"
+            style={{ backgroundColor: selectedTrip.route_color_hex || getRouteTypeColor(selectedTrip.route_type_name) }} />
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 min-w-0">
+            <span className="font-semibold truncate">{selectedTrip.trip_id}</span>
+            {selectedTrip.route_name && <span className="text-sm text-muted-foreground truncate">{selectedTrip.route_name}</span>}
+            {hasStopTimes && (
+              <span className="text-sm">{formatTripTime(selectedTrip.first_departure_seconds) || "?"} {"\u2192"} {formatTripTime(selectedTrip.last_arrival_seconds) || "?"}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Edit mode header + toolbar */}
+      {selectedTrip && isEditing && (
+        <div className="flex min-w-0 items-center gap-3 rounded-md border border-primary/50 bg-primary/5 px-4 py-2.5">
+          <BiPencil className="h-4 w-4 shrink-0 text-primary" />
+          <span className="h-3 w-6 rounded-sm border shrink-0"
+            style={{ backgroundColor: selectedTrip.route_color_hex || getRouteTypeColor(selectedTrip.route_type_name) }} />
+          <span className="font-semibold truncate">{selectedTrip.trip_id}</span>
+          <span className="text-xs text-primary font-medium">Editing</span>
+          {(() => {
+            let changed = 0;
+            for (let i = 0; i < editStops.length; i++) {
+              const orig = stopTimes[i];
+              if (!orig || editStops[i].stop_id !== orig.stop_id || editStops[i].arrival_time !== orig.arrival_time || editStops[i].departure_time !== orig.departure_time) changed++;
+            }
+            changed += deletedStopIndices.size;
+            if (editStops.length !== stopTimes.length) changed = Math.max(changed, Math.abs(editStops.length - stopTimes.length));
+            return changed > 0 ? (
+              <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium">
+                {changed} change{changed !== 1 ? "s" : ""}
+              </span>
+            ) : null;
+          })()}
+          {(() => {
+            const noChanges = JSON.stringify(editStops) === JSON.stringify(stopTimes.map((s, i) => ({ ...s, _idx: i }))) && deletedStopIndices.size === 0;
+            const noStops = editStops.length === 0 && stopTimes.length === 0;
+            return (
+              <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                <Button variant="ghost" onClick={handleUndo} disabled={undoStack.length === 0} size="sm" className="flex items-center h-7 text-xs px-2">
+                  <BiUndo className="mr-1 h-3 w-3" />Undo
+                </Button>
+                <Button variant="ghost" size="sm" disabled={noChanges}
+                  onClick={() => { setEditStops(stopTimes.map((s, i) => ({ ...s, _idx: i }))); setDeletedStopIndices(new Set()); setEditErrors([]); setUndoStack([]); setAddStopId(undefined); setAddArrival(""); setAddDeparture(""); setAddStopSeqManual(null); }}
+                  className="flex items-center h-7 text-xs px-2">
+                  <BiReset className="mr-1 h-3 w-3" />Reset
+                </Button>
+                <span className="mx-0.5 h-4 border-l" />
+                <Button variant="default" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || noChanges || noStops} size="sm" className="flex items-center h-7 text-xs px-3">
+                  <BiSave className="mr-1 h-3 w-3" />{saveMutation.isPending ? "Saving..." : "Save"}
+                </Button>
+                <Button variant="outline" onClick={cancelEditing} disabled={saveMutation.isPending} size="sm" className="h-7 text-xs px-3">Cancel</Button>
+              </div>
+            );
+          })()}
+        </div>
+      )}
+
+      {/* Non-edit action buttons */}
+      {selectedTrip && !isEditing && !isPicking && (
+        <div className="flex gap-2">
+          {hasStopTimes && compareTrips.length === 0 && stopTimes.length > 0 && (
+            <Button variant="outline" onClick={startEditing} size="sm" className="flex items-center">
+              <BiPencil className="mr-1 h-4 w-4" />Edit
+            </Button>
+          )}
+          {hasStopTimes && compareTrips.length === 0 && stopTimes.length > 0 && (
+            <Button variant="outline" onClick={startPicking} size="sm" className="flex items-center">
+              <BiGitCompare className="mr-1 h-4 w-4" />Compare
+            </Button>
+          )}
+        </div>
+      )}
+      {/* Compare trips chips */}
+      {compareTrips.length > 0 && !isPicking && !isEditing && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={startPicking} size="sm" disabled={compareTrips.length >= maxCompareSlots}
+              className="flex items-center h-7 text-xs shrink-0">
+              <BiPlus className="mr-1 h-3 w-3" />Add
+            </Button>
+            <Button variant="ghost" onClick={() => setCompareTripIds([])} size="sm"
+              className="flex items-center h-7 text-xs shrink-0">
+              <BiX className="mr-1 h-3 w-3" />Clear
+            </Button>
+            <Button variant="outline" onClick={() => { setCompareTripIds([]); if (selectedTrip) updateSearch({ selectedTripId: undefined }); }} size="sm"
+              className="flex items-center h-7 text-xs shrink-0 ml-auto">
+              <BiReset className="mr-1 h-3 w-3" />Reset
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {compareTrips.map((ct, idx) => {
+              const colorIdx = selectedTrip ? idx + 1 : idx;
+              return (
+                <div key={ct.trip_id}
+                  className="flex items-center gap-1.5 rounded-md border bg-primary/5 px-2.5 py-1.5 text-xs cursor-pointer hover:bg-primary/10 transition-colors"
+                  onClick={() => setCompareTripIds((prev) => prev.filter((id) => id !== ct.trip_id))}
+                  role="button" tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setCompareTripIds((prev) => prev.filter((id) => id !== ct.trip_id)); }}>
+                  <BiX className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: TRIP_LINE_COLORS[colorIdx % TRIP_LINE_COLORS.length] }} />
+                  <span className="font-medium truncate">{ct.trip_id}</span>
+                  {ct.route_name && <span className="text-muted-foreground truncate max-w-[100px]">{ct.route_name}</span>}
+                  {ct.service_id && <span className="text-muted-foreground/60 truncate max-w-[80px]">{ct.service_id}</span>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Filters (when picking compare trip) */}
+      {isPicking && (
+        <TripsHeader
+          hasStopTimes={hasStopTimes} tripId={tripId} routeId={routeId} routeType={routeType}
+          availableTripIds={availableTripIds} availableRouteIds={availableRouteIds} availableRouteTypes={availableRouteTypes}
+          timeRange={timeRange} sliderBounds={sliderBounds} tripsCount={tripsWithStatus.length}
+          hasActiveFilters={hasActiveFilters} tableSortingCount={tableSorting.length}
+          updateSearch={updateSearch} setTimeRange={setTimeRange} clearFilters={clearFilters}
+          extraButtons={
+            <Button variant="outline" onClick={cancelPicking} size="default" className="w-full md:w-auto flex items-center justify-center bg-primary/10 border-primary/50">
+              <BiX className="mr-2 h-5 w-5" />Cancel
+            </Button>
+          }
+        />
+      )}
+
+      {/* Table */}
+      {((!selectedTrip && compareTrips.length === 0) || isPicking) && (
+        <TableComponent
+          key={isPicking ? "pick" : "select"}
+          data={isPicking ? filteredTrips.filter((t) => !allSelectedIds.has(String(t.trip_id))) : filteredTrips}
+          columns={columns} ClickInfo={undefined}
+          setClickInfo={(trip: TripRow | undefined) => {
+            if (!trip) return;
+            if (isPicking) { setCompareTripIds((prev) => [...prev, String(trip.trip_id)]); setIsPicking(false); }
+            else handleTripSelect(trip);
+          }}
+          selectionKey="trip_id" hasActiveFilters={hasActiveFilters} onClearFilters={clearFilters}
+          onSortingChange={setTableSorting} clearSortingTrigger={clearSortingTrigger}>
+          <div className="text-sm text-muted-foreground p-3 border rounded-md bg-muted/30">
+            {isPicking ? "Select a trip to compare with" : hasStopTimes ? "Select a trip row to view its stops" : "Select a trip row to view details"}
+          </div>
+        </TableComponent>
+      )}
+
+      {/* Trip detail views */}
+      {selectedTrip && !isPicking && !hasStopTimes && (
+        <div className="text-sm text-yellow-800 dark:text-yellow-200 p-3 border border-yellow-300 rounded-md bg-yellow-50 dark:bg-yellow-900/20">
+          stop_times.txt not imported — stop times, editing, comparison, and timeline views are disabled
+        </div>
+      )}
+
+      {selectedTrip && !isPicking && hasStopTimes && (
+        <div className="space-y-3">
+          {!isEditing && (
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-md border p-3 text-sm">
+              <div><span className="text-xs text-muted-foreground">Time</span>
+                <div className={`font-medium ${!selectedTrip.first_departure_seconds && !selectedTrip.last_arrival_seconds ? "text-muted-foreground/50" : ""}`}>
+                  {formatTripTime(selectedTrip.first_departure_seconds) || "\u2014"} {"\u2192"} {formatTripTime(selectedTrip.last_arrival_seconds) || "\u2014"}
+                </div></div>
+              <div><span className="text-xs text-muted-foreground">Headsign</span>
+                <div className={`font-medium ${!selectedTrip.trip_headsign ? "text-muted-foreground/50" : ""}`}>{selectedTrip.trip_headsign || "\u2014"}</div></div>
+              {selectedTrip.route_name && (
+                <div><span className="text-xs text-muted-foreground">Route</span>
+                  <div className="font-medium">
+                    <Link to="/routes/info" search={{ selectedRouteId: selectedTrip.route_id }}
+                      className="inline-flex items-center rounded px-1.5 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">{selectedTrip.route_name}</Link>
+                  </div>
+                </div>
+              )}
+              {selectedTrip.service_id && (
+                <div><span className="text-xs text-muted-foreground">Service</span>
+                  <div className="font-medium">
+                    <Link to="/routes/service" search={{ selectedRouteId: selectedTrip.route_id, selectedServiceId: selectedTrip.service_id }}
+                      className="inline-flex items-center rounded px-1.5 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">{selectedTrip.service_id}</Link>
+                  </div>
+                </div>
+              )}
+              <div><span className="text-xs text-muted-foreground">{stopView === "stations" ? "Stations" : "Stops"}</span>
+                <div className={`font-medium ${stopTimes.length === 0 ? "text-muted-foreground/50" : ""}`}>{stopTimesLoading ? "..." : stopTimes.length}</div></div>
+            </div>
+          )}
+
+          {/* No stop times — show Add Stop prompt */}
+          {!isEditing && !stopTimesLoading && stopTimes.length === 0 && (
+            <div className="rounded-md border border-dashed p-6 text-center space-y-2">
+              <div className="text-sm text-muted-foreground">No stop times available</div>
+              <Button variant="outline" size="sm" onClick={startEditing}>
+                <BiPlus className="mr-1 h-4 w-4" />Add Stop
+              </Button>
+            </div>
+          )}
+
+          {(() => {
+            const stopsToCheck = isEditing ? editStops : stopTimes;
+            const hasPreview = isEditing && addStopSeqManual != null;
+            if (stopsToCheck.length === 0 && !hasPreview) return null;
+            const addingNoStops = isEditing && editStops.length === 0 && hasPreview;
+            const hasAddTime = Boolean(addArrival || addDeparture);
+            const hasAddStop = Boolean(addStopId);
+            const hasAnyTime = stopsToCheck.some((s) => s.arrival_time || s.departure_time);
+            const timelineDisabled = addingNoStops ? !hasAddTime : (isEditing && !hasAnyTime && !hasAddTime);
+            const mapDisabled = addingNoStops ? !hasAddStop : false;
+            return (
+              <Tabs value={tripView} onValueChange={(v) => { const view = v as typeof tripView; setTripView(view); updateSearch({ view: view === "timetable" ? undefined : view }); }}>
+                <TabsList className="h-8">
+                  <TabsTrigger value="timetable" className="text-xs px-3 py-1">Timetable</TabsTrigger>
+                  <TabsTrigger value="timeline" className="text-xs px-3 py-1" disabled={timelineDisabled}>Timeline</TabsTrigger>
+                  <TabsTrigger value="map" className="text-xs px-3 py-1" disabled={mapDisabled}>Map</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            );
+          })()}
+
+          {stopTimesLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : stopTimesError ? (
+            <div className="rounded-md border p-3 text-sm text-muted-foreground">Error loading trip stop times.</div>
+          ) : isEditing ? (
+            tripView === "timetable" ? (<>
+              {renderStopPanel()}
+              {editStops.length > 0 && (
+                <Timetable editable stops={editStops} onUpdate={handleEditStopUpdate}
+                  originalStops={stopTimes} showOnlyChanged
+                  selectedStopIdx={selectedEditIdx}
+                  onSelectStop={handleSelectEditStop}
+                  addStopPreview={selectedEditIdx == null && selectedAddStop
+                    ? { name: selectedAddStop.stop_name || selectedAddStop.stop_id, stopId: selectedAddStop.stop_id, arrival: addArrival, departure: addDeparture, stopSequence: addStopSequence }
+                    : (selectedEditIdx == null && addStopSeqManual != null)
+                      ? { name: "", arrival: addArrival, departure: addDeparture, stopSequence: addStopSequence }
+                      : undefined}
+                  onInsertAt={(seq, arr, dep) => {
+                    if (!arr && !dep) {
+                      setAddStopSeqManual(null); setAddStopId(undefined); setAddArrival(""); setAddDeparture("");
+                    } else if (addStopSeqManual === seq && !addStopId) {
+                      setAddStopSeqManual(null); setAddArrival(""); setAddDeparture("");
+                    } else {
+                      setSelectedEditIdx(null); setAddStopSeqManual(seq); setAddArrival(arr); setAddDeparture(dep);
+                    }
+                  }} />
+              )}
+            </>
+            ) : tripView === "timeline" ? (<>
+              <Timeline editable trips={[{ trip: selectedTrip, stops: editStops }]} onUpdateStop={handleTimelineStopUpdate}
+                onUpdateStopBoth={(_ti, si, arr, dep) => setEditStops((prev) => prev.map((s, i) => (i === si ? { ...s, arrival_time: arr, departure_time: dep } : s)))}
+                originalStops={stopTimes}
+                selectedStopIdx={selectedEditIdx}
+                onSelectStop={handleSelectEditStop}
+                addStopPreview={selectedEditIdx == null && selectedAddStop
+                  ? { name: selectedAddStop.stop_name || selectedAddStop.stop_id, arrival: addArrival, departure: addDeparture, stopSequence: addStopSequence }
+                  : (selectedEditIdx == null && addStopSeqManual != null)
+                    ? { name: "", arrival: addArrival, departure: addDeparture, stopSequence: addStopSequence }
+                    : undefined}
+                onAddArrivalChange={setAddArrival} onAddDepartureChange={setAddDeparture}
+                onInsertAt={(seq, arr, dep) => {
+                  if (!arr && !dep) {
+                    setAddStopSeqManual(null); setAddStopId(undefined); setAddArrival(""); setAddDeparture("");
+                  } else {
+                    setSelectedEditIdx(null); setAddStopSeqManual(seq); if (arr) setAddArrival(arr); if (dep) setAddDeparture(dep);
+                  }
+                }}
+                onDragStart={() => {
+                  setUndoStack((prev) => [...prev.slice(-19), { stops: editStopsRef.current, deleted: new Set(deletedStopIndicesRef.current) }]);
+                }} />
+              {renderStopPanel()}
+            </>
+            ) : (<>
+              {selectedEditIdx == null && addStopSeqManual == null && !addStopId && editStops.length > 0 && (
+                <Button variant="outline" size="sm" className="flex items-center"
+                  onClick={() => setAddStopSeqManual(editStops.length + 1)}>
+                  <BiPlus className="mr-1 h-4 w-4" />Add Stop
+                </Button>
+              )}
+              <TripMap
+                trips={[{ trip: selectedTrip, stopTimes: editStops }]}
+                editable
+                onDeleteStop={handleDeleteStop}
+                onRestoreStop={handleRestoreStop}
+                deletedStopIndices={deletedStopIndices}
+                onReplaceStop={handleReplaceStop}
+                routeStops={routeStops}
+                originalStops={stopTimes}
+                selectedStopIdx={selectedEditIdx}
+                onSelectStop={handleSelectEditStop}
+                addStopPreview={selectedEditIdx == null && selectedAddStop && Number.isFinite(Number(selectedAddStop.stop_lat)) && Number.isFinite(Number(selectedAddStop.stop_lon)) ? { lon: Number(selectedAddStop.stop_lon), lat: Number(selectedAddStop.stop_lat), name: selectedAddStop.stop_name || selectedAddStop.stop_id, stopSequence: addStopSequence } : undefined}
+                onUpdateStopTime={(stopIdx, field, value) => {
+                  pushEdit(editStops.map((s, i) => (i === stopIdx ? { ...s, [field]: value } : s)));
+                }}
+                editPanel={(selectedEditIdx != null || addStopSeqManual != null || addStopId || editStops.length === 0) ? renderStopPanel(true) : undefined}
+                zoomToStopRef={zoomToStopRef}
+              />
+            </>)
+          ) : (
+            tripView === "map" ? (
+              compareLoading && compareTrips.length > 0 ? <Skeleton className="h-[50vh] w-full" /> : (
+                <TripMap trips={[
+                  { trip: selectedTrip, stopTimes },
+                  ...compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] })),
+                ]}
+                  selectedStopIdx={viewSelectedIdx}
+                  onSelectStop={setViewSelectedIdx}
+                  zoomToStopRef={zoomToStopRef}
+                  onClickAnyStop={(info) => { setViewSelectedIdx(info.stopIdx); setViewSelectedTripIdx(info.tripIdx); }}
+                  hiddenTripIndices={hiddenTripIndices}
+                  onToggleTripVisibility={toggleTripVisibility} />
+              )
+            ) : tripView === "timeline" ? (
+              compareLoading && compareTrips.length > 0 ? <Skeleton className="h-64 w-full" /> : (<>
+              {compareTrips.length > 0 && renderTripLegend([selectedTrip, ...compareTrips])}
+              <div
+                onClick={(e) => {
+                  // Click outside a stop dot or the popup → deselect
+                  const target = e.target as HTMLElement;
+                  if (!target.closest("[data-stop-idx]") && !target.closest("[data-stop-popup]")) {
+                    setViewSelectedIdx(null);
+                  }
+                }}>
+                <Timeline trips={[
+                  { trip: selectedTrip, stopTimes },
+                  ...compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] })),
+                ]}
+                  selectedStopIdx={viewSelectedIdx}
+                  onSelectStop={setViewSelectedIdx}
+                  selectedTripIdx={viewSelectedTripIdx}
+                  onSelectStopWithTrip={(ti, idx) => { setViewSelectedTripIdx(ti); setViewSelectedIdx(idx); }}
+                  hiddenTripIndices={hiddenTripIndices} />
+                {viewSelectedIdx != null && (() => {
+                  const allTrips = [{ trip: selectedTrip, stopTimes }, ...compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] }))];
+                  const tripData = allTrips[viewSelectedTripIdx] || allTrips[0];
+                  const st = tripData?.stopTimes[viewSelectedIdx];
+                  if (!st) return null;
+                  // Match stops across trips by stop_id or parent_station (same as map)
+                  const stopsAcrossTrips = allTrips.map((t, ti) => {
+                    const match = t.stopTimes.find((s) => {
+                      if (st.stop_id && s.stop_id && st.stop_id === s.stop_id) return true;
+                      if ((st as any).parent_station && (s as any).parent_station && (st as any).parent_station === (s as any).parent_station) return true;
+                      return false;
+                    }) || (ti === viewSelectedTripIdx ? st : undefined);
+                    return match ? { trip: t.trip, st: match, ti } : null;
+                  }).filter(Boolean) as Array<{ trip: typeof selectedTrip; st: typeof st; ti: number }>;
+                  const hasCompare = compareTrips.length > 0 && stopsAcrossTrips.length > 1;
+                  // Compute time diffs relative to the selected trip
+                  const toSec = (t?: string) => { if (!t) return null; const p = t.split(":").map(Number); return p.length >= 2 ? p[0] * 3600 + p[1] * 60 + (p[2] || 0) : null; };
+                  const baseDep = toSec(st.departure_time) ?? toSec(st.arrival_time);
+                  const baseArr = toSec(st.arrival_time) ?? toSec(st.departure_time);
+                  return (
+                    <div data-stop-popup className="rounded-md border bg-background p-3 text-sm space-y-2 mt-3">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold">{st.stop_name || st.stop_id}</span>
+                        <button onClick={() => scrollToStop(viewSelectedIdx)} className="ml-auto text-muted-foreground hover:text-foreground shrink-0" title="Zoom to stop"><BiCrosshair className="h-4 w-4" /></button>
+                        <button onClick={() => setViewSelectedIdx(null)} className="text-muted-foreground hover:text-foreground shrink-0"><BiX className="h-4 w-4" /></button>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{st.stop_id}</span>
+                        <span>·</span>
+                        <span>#{viewSelectedIdx + 1}</span>
+                        {(st as any).parent_station || st.location_type_name === "Station" ? (
+                          <Link to="/stations/info" search={{ selectedStationId: (st as any).parent_station || st.stop_id }}
+                            className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+                            <BiMapPin className="h-3 w-3" />Station
+                          </Link>
+                        ) : (
+                          <Link to="/stops/map" search={{ selectedStopId: st.stop_id }}
+                            className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+                            <BiMapPin className="h-3 w-3" />Stop
+                          </Link>
+                        )}
+                      </div>
+                      {hasCompare ? (
+                        <div className="space-y-1 pt-1 border-t">
+                          {stopsAcrossTrips.map(({ trip: t, st: s, ti }) => {
+                            const isPrimary = ti === viewSelectedTripIdx;
+                            const sArr = toSec(s.arrival_time);
+                            const sDep = toSec(s.departure_time);
+                            const arrDiff = sArr != null && baseArr != null ? sArr - baseArr : null;
+                            const depDiff = sDep != null && baseDep != null ? sDep - baseDep : null;
+                            const fmtDiff = (d: number | null) => {
+                              if (d == null || d === 0) return null;
+                              const m = Math.round(d / 60);
+                              return m > 0 ? `+${m}m` : `${m}m`;
+                            };
+                            return (
+                              <div key={ti} className={`flex items-center gap-2 text-xs rounded px-1.5 py-1 ${isPrimary ? "bg-primary/10 font-medium" : ""}`}>
+                                <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length] }} />
+                                <span className="truncate max-w-[100px]">{t.trip_headsign || t.trip_id}</span>
+                                <span className="ml-auto text-muted-foreground whitespace-nowrap">
+                                  {s.arrival_time || "\u2014"}
+                                  {s.departure_time && s.departure_time !== s.arrival_time ? ` \u2192 ${s.departure_time}` : ""}
+                                </span>
+                                {!isPrimary && (arrDiff != null || depDiff != null) && (
+                                  <span className={`text-[10px] font-medium ${(arrDiff ?? 0) > 0 ? "text-red-500" : (arrDiff ?? 0) < 0 ? "text-green-500" : "text-muted-foreground"}`}>
+                                    {fmtDiff(arrDiff) || fmtDiff(depDiff)}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        (st.arrival_time || st.departure_time) ? (
+                          <div className="flex gap-4 text-xs pt-1 border-t">
+                            {st.arrival_time && <span>Arr: {st.arrival_time}</span>}
+                            {st.departure_time && <span>Dep: {st.departure_time}</span>}
+                          </div>
+                        ) : null
+                      )}
+                    </div>
+                  );
+                })()}
+              </div></>)
+            ) : compareTrips.length > 0 ? (
+              compareLoading ? <Skeleton className="h-64 w-full" /> : (<>
+                {renderTripLegend([selectedTrip, ...compareTrips])}
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                  {!hiddenTripIndices.has(0) && <TripStopPanel trip={selectedTrip} stopTimes={stopTimes} view={stopView} />}
+                  {compareTrips.map((ct, idx) => (
+                    !hiddenTripIndices.has(idx + 1) && <TripStopPanel key={ct.trip_id} trip={ct} stopTimes={compareStopTimesMap[ct.trip_id] || []} view={stopView} />
+                  ))}
+                </div>
+              </>)
+            ) : stopTimes.length > 0 ? (
+              <Timetable stopTimes={stopTimes} view={stopView} />
+            ) : null
+          )}
+
+        </div>
+      )}
+
+
+      {/* Compare-only views (no selected trip) */}
+      {!selectedTrip && !isPicking && compareTrips.length > 0 && hasStopTimes && (
+        <div className="space-y-3">
+          <Tabs value={tripView} onValueChange={(v) => { const view = v as typeof tripView; setTripView(view); updateSearch({ view: view === "timetable" ? undefined : view }); }}>
+            <TabsList className="h-8">
+              <TabsTrigger value="timetable" className="text-xs px-3 py-1">Timetable</TabsTrigger>
+              <TabsTrigger value="timeline" className="text-xs px-3 py-1">Timeline</TabsTrigger>
+              <TabsTrigger value="map" className="text-xs px-3 py-1">Map</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {renderTripLegend(compareTrips)}
+          {compareLoading ? <Skeleton className="h-64 w-full" /> : (
+            tripView === "map" ? (
+              <TripMap trips={compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] }))}
+                selectedStopIdx={viewSelectedIdx}
+                onSelectStop={setViewSelectedIdx}
+                zoomToStopRef={zoomToStopRef}
+                onClickAnyStop={(info) => { setViewSelectedIdx(info.stopIdx); setViewSelectedTripIdx(info.tripIdx); }}
+                hiddenTripIndices={hiddenTripIndices}
+                onToggleTripVisibility={toggleTripVisibility} />
+            ) : tripView === "timeline" ? (
+              <div onClick={(e) => {
+                const target = e.target as HTMLElement;
+                if (!target.closest("[data-stop-idx]") && !target.closest("[data-stop-popup]")) setViewSelectedIdx(null);
+              }}>
+                <Timeline trips={compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] }))}
+                  selectedStopIdx={viewSelectedIdx}
+                  onSelectStop={setViewSelectedIdx}
+                  selectedTripIdx={viewSelectedTripIdx}
+                  onSelectStopWithTrip={(ti, idx) => { setViewSelectedTripIdx(ti); setViewSelectedIdx(idx); }}
+                  hiddenTripIndices={hiddenTripIndices} />
+                {viewSelectedIdx != null && (() => {
+                  const allTripsData = compareTrips.map((ct) => ({ trip: ct, stopTimes: compareStopTimesMap[ct.trip_id] || [] }));
+                  const tripData = allTripsData[viewSelectedTripIdx] || allTripsData[0];
+                  const st = tripData?.stopTimes[viewSelectedIdx];
+                  if (!st) return null;
+                  // Match stops across trips by stop_id or parent_station (same as map)
+                  const stopsAcrossTrips = allTripsData.map((t, ti) => {
+                    const match = t.stopTimes.find((s) => {
+                      if (st.stop_id && s.stop_id && st.stop_id === s.stop_id) return true;
+                      if ((st as any).parent_station && (s as any).parent_station && (st as any).parent_station === (s as any).parent_station) return true;
+                      return false;
+                    }) || (ti === viewSelectedTripIdx ? st : undefined);
+                    return match ? { trip: t.trip, st: match, ti } : null;
+                  }).filter(Boolean) as Array<{ trip: TripRow; st: typeof st; ti: number }>;
+                  const hasCompare = stopsAcrossTrips.length > 1;
+                  const toSec = (t?: string) => { if (!t) return null; const p = t.split(":").map(Number); return p.length >= 2 ? p[0] * 3600 + p[1] * 60 + (p[2] || 0) : null; };
+                  const baseDep = toSec(st.departure_time) ?? toSec(st.arrival_time);
+                  const baseArr = toSec(st.arrival_time) ?? toSec(st.departure_time);
+                  return (
+                    <div data-stop-popup className="rounded-md border bg-background p-3 text-sm space-y-2 mt-3">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold">{st.stop_name || st.stop_id}</span>
+                        <button onClick={() => setViewSelectedIdx(null)} className="ml-auto text-muted-foreground hover:text-foreground shrink-0"><BiX className="h-4 w-4" /></button>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{st.stop_id}</span>
+                        <span>·</span>
+                        <span>#{viewSelectedIdx + 1}</span>
+                      </div>
+                      {hasCompare ? (
+                        <div className="space-y-1 pt-1 border-t">
+                          {stopsAcrossTrips.map(({ trip: t, st: s, ti }) => {
+                            const isPrimary = ti === viewSelectedTripIdx;
+                            const sArr = toSec(s.arrival_time);
+                            const sDep = toSec(s.departure_time);
+                            const arrDiff = sArr != null && baseArr != null ? sArr - baseArr : null;
+                            const depDiff = sDep != null && baseDep != null ? sDep - baseDep : null;
+                            const fmtDiff = (d: number | null) => { if (d == null || d === 0) return null; const m = Math.round(d / 60); return m > 0 ? `+${m}m` : `${m}m`; };
+                            return (
+                              <div key={ti} className={`flex items-center gap-2 text-xs rounded px-1.5 py-1 ${isPrimary ? "bg-primary/10 font-medium" : ""}`}>
+                                <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length] }} />
+                                <span className="truncate max-w-[100px]">{t.trip_headsign || t.trip_id}</span>
+                                <span className="ml-auto text-muted-foreground whitespace-nowrap">
+                                  {s.arrival_time || "\u2014"}{s.departure_time && s.departure_time !== s.arrival_time ? ` \u2192 ${s.departure_time}` : ""}
+                                </span>
+                                {!isPrimary && (arrDiff != null || depDiff != null) && (
+                                  <span className={`text-[10px] font-medium ${(arrDiff ?? 0) > 0 ? "text-red-500" : (arrDiff ?? 0) < 0 ? "text-green-500" : "text-muted-foreground"}`}>
+                                    {fmtDiff(arrDiff) || fmtDiff(depDiff)}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        (st.arrival_time || st.departure_time) ? (
+                          <div className="flex gap-4 text-xs pt-1 border-t">
+                            {st.arrival_time && <span>Arr: {st.arrival_time}</span>}
+                            {st.departure_time && <span>Dep: {st.departure_time}</span>}
+                          </div>
+                        ) : null
+                      )}
+                    </div>
+                  );
+                })()}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {compareTrips.map((ct, idx) => (
+                  !hiddenTripIndices.has(idx) && <TripStopPanel key={ct.trip_id} trip={ct} stopTimes={compareStopTimesMap[ct.trip_id] || []} view={stopView} />
+                ))}
+              </div>
+            )
+          )}
+        </div>
+      )}
+
+      {/* Stop creation form */}
+      {showStopForm && (
+        <EntityForm
+          Data={editStops.filter((s) => s.stop_lat != null && s.stop_lon != null).map((s) => ({
+            stop_id: s.stop_id, stop_name: s.stop_name,
+            stop_lat: s.stop_lat, stop_lon: s.stop_lon,
+            location_type_name: "Stop",
+          }))}
+          OpenValue={{ formType: "add", state: true }}
+          setOpenValue={({ state }) => { if (!state) setShowStopForm(false); }}
+          ClickInfo={undefined}
+          setClickInfo={() => {}}
+          type="stop"
+        />
+      )}
+    </div>
+  );
+}
+
+export default AllTrips;

--- a/packages/web/src/client/Trips/AllTrips/index.tsx
+++ b/packages/web/src/client/Trips/AllTrips/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { BiCrosshair, BiGitCompare, BiMapPin, BiPencil, BiPlus, BiReset, BiSave, BiUndo, BiX } from "react-icons/bi";
+import { BiChevronDown, BiChevronUp, BiCrosshair, BiGitCompare, BiMapPin, BiPencil, BiPlus, BiReset, BiSave, BiUndo, BiX } from "react-icons/bi";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -48,7 +48,8 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
   const setCompareTripIds = useCallback((updater: string[] | ((prev: string[]) => string[])) => {
     setCompareTripIdsRaw((prev) => {
       const next = typeof updater === "function" ? updater(prev) : updater;
-      updateSearch({ compareTripIds: next.length > 0 ? next.join(",") : undefined });
+      // Defer router update to avoid setState-in-render warning (Transitioner)
+      queueMicrotask(() => updateSearch({ compareTripIds: next.length > 0 ? next.join(",") : undefined }));
       setHiddenTripIndices(new Set());
       return next;
     });
@@ -544,11 +545,52 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
       )}
 
       {/* Validation errors */}
-      {editErrors.length > 0 && (
-        <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300 space-y-1">
-          {editErrors.map((err, i) => <div key={i}>{err}</div>)}
-        </div>
-      )}
+      {editErrors.length > 0 && (() => {
+        // Parse stop index from error strings like "Stop 3 (name): ..."
+        const parseStopIdx = (err: string) => {
+          const m = err.match(/^Stop (\d+)/);
+          return m ? parseInt(m[1]) - 1 : null;
+        };
+        const [errorsExpanded, setErrorsExpanded] = [editErrors.length <= 3, null]; // auto-expand if few
+        return (
+          <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300">
+            <button className="flex items-center gap-2 w-full text-left font-medium"
+              onClick={() => setEditErrors((prev) => prev.length > 0 ? prev : prev)}>
+              {editErrors.length <= 3
+                ? <BiChevronUp className="h-4 w-4 shrink-0" />
+                : <BiChevronDown className="h-4 w-4 shrink-0" />}
+              <span>{editErrors.length} validation error{editErrors.length !== 1 ? "s" : ""}</span>
+            </button>
+            <details open={editErrors.length <= 3} className="mt-1">
+              <summary className="sr-only">Show errors</summary>
+              <div className="space-y-1 pt-1">
+                {editErrors.map((err, i) => {
+                  const stopIdx = parseStopIdx(err);
+                  return (
+                    <div key={i} className="flex items-center gap-2">
+                      <span className="flex-1">{err}</span>
+                      {stopIdx != null && (
+                        <button
+                          className="shrink-0 text-xs px-2 py-0.5 rounded border border-red-300 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+                          onClick={() => {
+                            handleSelectEditStop(stopIdx);
+                            setTripView("timetable");
+                            setTimeout(() => {
+                              const el = document.querySelector(`[data-stop-idx="${stopIdx}"]`);
+                              el?.scrollIntoView({ behavior: "smooth", block: "center" });
+                            }, 100);
+                          }}>
+                          Go to stop #{stopIdx + 1}
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
+          </div>
+        );
+      })()}
 
       {/* Selected trip bar */}
       {selectedTrip && !isEditing && (
@@ -597,10 +639,10 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
             const noStops = editStops.length === 0 && stopTimes.length === 0;
             return (
               <div className="ml-auto flex items-center gap-1.5 shrink-0">
-                <Button variant="ghost" onClick={handleUndo} disabled={undoStack.length === 0} size="sm" className="flex items-center h-7 text-xs px-2">
+                <Button variant="ghost" onClick={handleUndo} disabled={undoStack.length === 0 || saveMutation.isPending} size="sm" className="flex items-center h-7 text-xs px-2">
                   <BiUndo className="mr-1 h-3 w-3" />Undo
                 </Button>
-                <Button variant="ghost" size="sm" disabled={noChanges}
+                <Button variant="ghost" size="sm" disabled={noChanges || saveMutation.isPending}
                   onClick={() => { setEditStops(stopTimes.map((s, i) => ({ ...s, _idx: i }))); setDeletedStopIndices(new Set()); setEditErrors([]); setUndoStack([]); setAddStopId(undefined); setAddArrival(""); setAddDeparture(""); setAddStopSeqManual(null); }}
                   className="flex items-center h-7 text-xs px-2">
                   <BiReset className="mr-1 h-3 w-3" />Reset
@@ -704,14 +746,24 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
         </TableComponent>
       )}
 
+      {/* Saving overlay — blocks all interaction while save is processing */}
+      {saveMutation.isPending && (
+        <div className="relative rounded-md border bg-background/80 backdrop-blur-[2px] p-8">
+          <div className="flex items-center justify-center gap-3 text-sm font-medium">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            Saving changes...
+          </div>
+        </div>
+      )}
+
       {/* Trip detail views */}
-      {selectedTrip && !isPicking && !hasStopTimes && (
+      {selectedTrip && !isPicking && !hasStopTimes && !saveMutation.isPending && (
         <div className="text-sm text-yellow-800 dark:text-yellow-200 p-3 border border-yellow-300 rounded-md bg-yellow-50 dark:bg-yellow-900/20">
           stop_times.txt not imported — stop times, editing, comparison, and timeline views are disabled
         </div>
       )}
 
-      {selectedTrip && !isPicking && hasStopTimes && (
+      {selectedTrip && !isPicking && hasStopTimes && !saveMutation.isPending && (
         <div className="space-y-3">
           {!isEditing && (
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-md border p-3 text-sm">
@@ -782,7 +834,7 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
               {renderStopPanel()}
               {editStops.length > 0 && (
                 <Timetable editable stops={editStops} onUpdate={handleEditStopUpdate}
-                  originalStops={stopTimes} showOnlyChanged
+                  originalStops={stopTimes}
                   selectedStopIdx={selectedEditIdx}
                   onSelectStop={handleSelectEditStop}
                   addStopPreview={selectedEditIdx == null && selectedAddStop

--- a/packages/web/src/client/Trips/AllTrips/types.ts
+++ b/packages/web/src/client/Trips/AllTrips/types.ts
@@ -1,0 +1,25 @@
+import type { TripInfo } from "@/lib/tripUtils";
+
+export type TripRow = TripInfo & {
+  route_id?: string;
+  service_id?: string;
+  route_name?: string;
+  route_type_name?: string;
+  route_color_hex?: string;
+  status?: string;
+};
+
+export interface AllTripsProps {
+  allTrips: TripRow[];
+  tripTimeBounds: [number, number];
+  hasStopTimes: boolean;
+  search: {
+    tripId?: string;
+    routeId?: string;
+    routeType?: string[];
+    selectedTripId?: string;
+    view?: string;
+    compareTripIds?: string;
+  };
+  updateSearch: (next: Record<string, any>) => void;
+}

--- a/packages/web/src/client/Trips/components/Map/Components/MapSection.tsx
+++ b/packages/web/src/client/Trips/components/Map/Components/MapSection.tsx
@@ -1,0 +1,771 @@
+import { useCallback, useMemo, useRef } from "react";
+import { PathLayer, ScatterplotLayer, TextLayer, LineLayer, IconLayer } from "@deck.gl/layers";
+import { PathStyleExtension } from "@deck.gl/extensions";
+
+/** Strip accented characters to ASCII so deck.gl's default font atlas can render them */
+const stripAccents = (s: string) => s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
+const pathStyleExt = [new PathStyleExtension({ offset: true })];
+
+/** Create a circle icon as a data URL for use with IconLayer */
+const makeCircleIcon = (() => {
+  const cache = new Map<string, string>();
+  return (color: [number, number, number], size = 32, stroke?: [number, number, number]) => {
+    const key = `${color}-${size}-${stroke}`;
+    if (cache.has(key)) return cache.get(key)!;
+    const canvas = document.createElement("canvas");
+    canvas.width = size; canvas.height = size;
+    const ctx = canvas.getContext("2d")!;
+    const r = size / 2 - 2;
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, r, 0, Math.PI * 2);
+    ctx.fillStyle = `rgb(${color[0]},${color[1]},${color[2]})`;
+    ctx.fill();
+    if (stroke) {
+      ctx.strokeStyle = `rgb(${stroke[0]},${stroke[1]},${stroke[2]})`;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+    const url = canvas.toDataURL();
+    cache.set(key, url);
+    return url;
+  };
+})();
+
+/** Create a capsule/pill icon — width varies, height fixed */
+const makeCapsuleIcon = (() => {
+  const cache = new Map<string, { url: string; w: number; h: number }>();
+  return (w: number, h: number, fillColor: string, strokeColor: string, strokeWidth: number) => {
+    const key = `${w}-${h}-${fillColor}-${strokeColor}-${strokeWidth}`;
+    if (cache.has(key)) return cache.get(key)!;
+    const scale = 2; // retina
+    const cw = w * scale, ch = h * scale;
+    const canvas = document.createElement("canvas");
+    canvas.width = cw; canvas.height = ch;
+    const ctx = canvas.getContext("2d")!;
+    const r = ch / 2 - strokeWidth * scale;
+    const pad = strokeWidth * scale + 1;
+    ctx.beginPath();
+    ctx.moveTo(pad + r, pad);
+    ctx.lineTo(cw - pad - r, pad);
+    ctx.arc(cw - pad - r, ch / 2, r, -Math.PI / 2, Math.PI / 2);
+    ctx.lineTo(pad + r, ch - pad);
+    ctx.arc(pad + r, ch / 2, r, Math.PI / 2, -Math.PI / 2);
+    ctx.closePath();
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    if (strokeWidth > 0) {
+      ctx.strokeStyle = strokeColor;
+      ctx.lineWidth = strokeWidth * scale;
+      ctx.stroke();
+    }
+    const url = canvas.toDataURL();
+    const result = { url, w: cw, h: ch };
+    cache.set(key, result);
+    return result;
+  };
+})();
+import DeckglMap from "@/components/maps/DeckglMap.lazy";
+import { useThemeContext } from "@/context/theme.client";
+import { TRIP_LINE_COLORS } from "@/lib/tripUtils";
+import { safeHexToRgb } from "@/components/colorUtil";
+import type { StopPoint, Segment } from "../types";
+
+interface MapSectionProps {
+  stopPoints: StopPoint[];
+  segments: Segment[];
+  paths: Array<{ path: [number, number][]; tripIdx: number }>;
+  clickedStop: StopPoint | null;
+  clickedSegment: Segment | null;
+  viewState: any;
+  setViewState: (v: any) => void;
+  boundBox?: [number[], number[]];
+  fitZoom: number;
+  editable: boolean;
+  deletedStopIndices: Set<number>;
+  selectedStopIdx?: number | null;
+  stopStatusMap: Map<number, string>;
+  previewStop: { lon: number; lat: number; name: string } | null;
+  externalPreview?: { lon: number; lat: number; name: string; stopSequence?: number } | null;
+  onDragStop?: (stopIdx: number, lat: number, lon: number) => void;
+  onSelectStop?: (idx: number | null) => void;
+  onClickStop: (stop: StopPoint | null) => void;
+  onClickSegment: (segment: Segment | null) => void;
+  hiddenTripIndices?: Set<number>;
+}
+
+export function MapSection({
+  stopPoints, segments, paths,
+  clickedStop, clickedSegment,
+  viewState, setViewState, boundBox, fitZoom,
+  editable, deletedStopIndices, selectedStopIdx, stopStatusMap,
+  previewStop, externalPreview,
+  onDragStop, onSelectStop, onClickStop, onClickSegment,
+  hiddenTripIndices,
+}: MapSectionProps) {
+  const { theme } = useThemeContext();
+  const isDraggingRef = useRef(false);
+  const dragIdxRef = useRef<number | null>(null);
+  const stopPointsRef = useRef(stopPoints);
+  stopPointsRef.current = stopPoints;
+
+  // Single click handler — same pattern as ShapeDrawMap in TripForm
+  const handleClick = useCallback((event: any) => {
+    if (isDraggingRef.current) return;
+    // Clicked on a stop, overlap dot, or capsule wrapper
+    if (event?.object && (event.layer?.id === "trip-stops" || event.layer?.id === "trip-stops-overlap" || event.layer?.id === "trip-stops-overlap-ring")) {
+      let stop: StopPoint;
+      if (event.layer?.id === "trip-stops" || event.layer?.id === "trip-stops-overlap") {
+        // Direct stop point (solo or overlap dot)
+        stop = event.object as StopPoint;
+      } else {
+        // Capsule hit — resolve to the first stop at this location
+        const obj = event.object;
+        stop = obj.pt ? (obj.pt as StopPoint) : (stopPointsRef.current.find((p) => `${p.lon.toFixed(3)},${p.lat.toFixed(3)}` === `${Number(obj.lon).toFixed(3)},${Number(obj.lat).toFixed(3)}`) || obj);
+      }
+      // Toggle: deselect if same stop clicked again
+      if (clickedStop && clickedStop.stopIdx === stop.stopIdx && clickedStop.tripIdx === stop.tripIdx) {
+        onClickStop(null);
+        onSelectStop?.(null);
+      } else {
+        onClickStop(stop);
+        onSelectStop?.(stop.stopIdx);
+      }
+      onClickSegment(null);
+      return;
+    }
+    // Clicked on a segment (LineLayer or PathLayer) — toggle on re-click
+    if (event?.object && (event.layer?.id === "trip-segments" || event.layer?.id?.startsWith("trip-path"))) {
+      if (event.layer?.id === "trip-segments") {
+        const seg = event.object as Segment;
+        const isSame = clickedSegment && clickedSegment.fromIdx === seg.fromIdx && clickedSegment.toIdx === seg.toIdx && clickedSegment.tripIdx === seg.tripIdx;
+        onClickSegment(isSame ? null : seg);
+        onClickStop(null);
+        onSelectStop?.(null);
+        return;
+      } else {
+        // PathLayer click: resolve from the path data which contains from/to coords
+        const [cLon, cLat] = event.coordinate || [0, 0];
+        const pathData = event.object;
+        const tripIdx = pathData?.tripIdx ?? 0;
+        // Use the path endpoints directly if available (from segRender data)
+        const pathCoords = pathData?.path;
+        let bestSeg: Segment | null = null;
+        if (pathCoords && pathCoords.length === 2) {
+          // Find the stop points closest to the path endpoints for this trip
+          const pts = stopPointsRef.current.filter((p) => p.tripIdx === tripIdx);
+          const findStop = (coord: [number, number]) => {
+            let best: StopPoint | null = null; let bd = Infinity;
+            for (const p of pts) { const d = (p.lon - coord[0]) ** 2 + (p.lat - coord[1]) ** 2; if (d < bd) { bd = d; best = p; } }
+            return best;
+          };
+          const fromPt = findStop(pathCoords[0]);
+          const toPt = findStop(pathCoords[1]);
+          if (fromPt && toPt) {
+            bestSeg = { from: pathCoords[0], to: pathCoords[1], fromIdx: fromPt.stopIdx, toIdx: toPt.stopIdx,
+              fromName: fromPt.name, toName: toPt.name, fromTime: fromPt.departureTime || fromPt.arrivalTime, toTime: toPt.arrivalTime || toPt.departureTime, tripIdx, disabled: false,
+              fromStopId: fromPt.stopId, toStopId: toPt.stopId, fromStation: fromPt.parentStation, toStation: toPt.parentStation };
+          }
+        }
+        if (!bestSeg) {
+          // Fallback: find closest segment by midpoint
+          const pts = stopPointsRef.current.filter((p) => p.tripIdx === tripIdx);
+          let bestDist = Infinity;
+          for (let i = 1; i < pts.length; i++) {
+            const a = pts[i - 1], b = pts[i];
+            const mx = (a.lon + b.lon) / 2, my = (a.lat + b.lat) / 2;
+            const d = (mx - cLon) ** 2 + (my - cLat) ** 2;
+            if (d < bestDist) {
+              bestDist = d;
+              bestSeg = { from: [a.lon, a.lat], to: [b.lon, b.lat], fromIdx: a.stopIdx, toIdx: b.stopIdx,
+                fromName: a.name, toName: b.name, fromTime: a.departureTime || a.arrivalTime, toTime: b.arrivalTime || b.departureTime, tripIdx, disabled: false,
+                fromStopId: a.stopId, toStopId: b.stopId, fromStation: a.parentStation, toStation: b.parentStation };
+            }
+          }
+        }
+        if (bestSeg) {
+          const isSame = clickedSegment && clickedSegment.fromIdx === bestSeg.fromIdx && clickedSegment.toIdx === bestSeg.toIdx && clickedSegment.tripIdx === bestSeg.tripIdx;
+          onClickSegment(isSame ? null : bestSeg);
+        }
+      }
+      onClickStop(null);
+      onSelectStop?.(null);
+      return;
+    }
+    // Empty space click — deselect
+    onClickStop(null);
+    onClickSegment(null);
+    onSelectStop?.(null);
+  }, [onSelectStop, onClickStop, onClickSegment, selectedStopIdx, editable, clickedStop, clickedSegment]);
+
+  const zoomBucket = viewState?.zoom != null ? Math.floor(viewState.zoom) : 14;
+  const layers = useMemo(() => {
+    if (stopPoints.length === 0 && !previewStop && !externalPreview) return [];
+    const isDark = theme === "dark";
+    const layerList: any[] = [];
+    const hidden = hiddenTripIndices ?? new Set<number>();
+
+    // Filter visible data
+    const visibleStops = stopPoints.filter((d) => !hidden.has(d.tripIdx));
+    const visiblePaths = paths.filter((p) => !hidden.has(p.tripIdx));
+    const visibleTripIds = Array.from(new Set(visibleStops.map((p) => p.tripIdx))).sort();
+    const isCompare = visibleTripIds.length > 1;
+
+    // Overlap detection: group stops sharing the same location across trips
+    const curZoom = viewState?.zoom ?? 14;
+    const segR = curZoom < 11 ? 6 : curZoom < 13 ? 8 : curZoom < 15 ? 10 : 13;
+    const segGap = 0;
+    const segLen = segR * 2;
+    const stopLocKey = (pt: StopPoint) => `${pt.lon.toFixed(3)},${pt.lat.toFixed(3)}`;
+    type OverlapEntry = { ox: number; oy: number; isOverlap: boolean; locKey: string; angle: number; count: number };
+    const overlapInfo = new Map<string, OverlapEntry>();
+    const stopCoordMap = new Map<string, [number, number]>();
+
+    if (isCompare) {
+      // Group stops by same stop_id or same parent_station across different trips.
+      // For same stop_id: must share exact coordinates.
+      // For same parent_station: merge at centroid even if coords differ (different platforms).
+      const byKey = new Map<string, StopPoint[]>();
+      for (const pt of visibleStops) {
+        const key = (pt.parentStation && pt.parentStation.length > 0) ? pt.parentStation : pt.stopId;
+        if (!key) continue;
+        (byKey.get(key) ?? (byKey.set(key, []), byKey.get(key)!)).push(pt);
+      }
+
+      for (const [locKey, pts] of byKey) {
+        const tripSet = new Set(pts.map((p) => p.tripIdx));
+        if (tripSet.size <= 1) continue;
+        // Check if this is a station group (different stop_ids, same parent_station)
+        const isStationGroup = pts.some((p) => p.parentStation && p.parentStation.length > 0) &&
+          new Set(pts.map((p) => p.stopId)).size > 1;
+
+        let filteredPts: StopPoint[];
+        if (isStationGroup) {
+          // Station group: take one stop per trip, center at centroid
+          const perTrip = new Map<number, StopPoint>();
+          for (const pt of pts) { if (!perTrip.has(pt.tripIdx)) perTrip.set(pt.tripIdx, pt); }
+          if (perTrip.size <= 1) continue;
+          const allPts = Array.from(perTrip.values());
+          const cLat = allPts.reduce((s, p) => s + p.lat, 0) / allPts.length;
+          const cLon = allPts.reduce((s, p) => s + p.lon, 0) / allPts.length;
+          // Override coordinates to centroid for capsule positioning + segments
+          filteredPts = allPts.map((p) => ({ ...p, lat: cLat, lon: cLon }));
+          for (const p of allPts) stopCoordMap.set(`${p.tripIdx}-${p.stopIdx}`, [cLon, cLat]);
+        } else {
+          // Same stop_id group: only capsule if coords overlap
+          const coordGroups = new Map<string, StopPoint[]>();
+          for (const pt of pts) {
+            const ck = stopLocKey(pt);
+            (coordGroups.get(ck) ?? (coordGroups.set(ck, []), coordGroups.get(ck)!)).push(pt);
+          }
+          const overlappingPts: StopPoint[] = [];
+          for (const [, cPts] of coordGroups) {
+            const cTrips = new Set(cPts.map((p) => p.tripIdx));
+            if (cTrips.size > 1) overlappingPts.push(...cPts);
+          }
+          if (overlappingPts.length === 0) continue;
+          filteredPts = overlappingPts;
+        }
+        const filteredTripSet = new Set(filteredPts.map((p) => p.tripIdx));
+        if (filteredTripSet.size <= 1) continue;
+        const trips = Array.from(filteredTripSet).sort();
+
+        // Find route direction from next/prev stop to orient the bar perpendicular
+        let rdx = 0, rdy = 0;
+        for (const pt of filteredPts) {
+          const next = visibleStops.find((p) => p.tripIdx === pt.tripIdx && p.stopIdx === pt.stopIdx + 1);
+          if (next) {
+            const ddx = next.lon - pt.lon;
+            const ddy = next.lat - pt.lat;
+            if (Math.abs(ddx) > 1e-6 || Math.abs(ddy) > 1e-6) {
+              rdx = ddx; rdy = -ddy;
+              break;
+            }
+          }
+        }
+        if (rdx === 0 && rdy === 0) {
+          for (const pt of filteredPts) {
+            const prev = visibleStops.find((p) => p.tripIdx === pt.tripIdx && p.stopIdx === pt.stopIdx - 1);
+            if (prev) {
+              const ddx = pt.lon - prev.lon;
+              const ddy = pt.lat - prev.lat;
+              if (Math.abs(ddx) > 1e-6 || Math.abs(ddy) > 1e-6) {
+                rdx = ddx; rdy = -ddy;
+                break;
+              }
+            }
+          }
+        }
+        let bx: number, by: number;
+        if (Math.abs(rdx) > 1e-8 || Math.abs(rdy) > 1e-8) {
+          const len = Math.sqrt(rdx * rdx + rdy * rdy);
+          bx = -rdy / len;
+          by = rdx / len;
+        } else {
+          bx = 1; by = 0;
+        }
+
+        const angle = Math.atan2(by, bx) * (180 / Math.PI);
+        // Larger dots, shrink after 3 to cap capsule
+        const n = trips.length;
+        const dr = n <= 3 ? Math.round(segR * 0.7) : Math.max(3, Math.round(segR * 0.7 * 3 / n));
+        const spacing = dr * 2;
+        for (const pt of filteredPts) {
+          const idx = trips.indexOf(pt.tripIdx);
+          const t = (idx - (n - 1) / 2) * spacing;
+          overlapInfo.set(`${pt.tripIdx}-${pt.stopIdx}`, {
+            ox: bx * t, oy: by * t,
+            isOverlap: true, locKey, angle, count: n,
+          });
+        }
+      }
+    }
+
+    // Build quick lookup: is this stop in an overlap group?
+    const isStopOverlap = (pt: StopPoint) => overlapInfo.has(`${pt.tripIdx}-${pt.stopIdx}`);
+
+    // Coordinate overrides for station-merged stops
+    const getStopCoord = (pt: StopPoint): [number, number] => stopCoordMap.get(`${pt.tripIdx}-${pt.stopIdx}`) || [pt.lon, pt.lat];
+
+    // Build per-segment data: segments are "shared" when both endpoints match
+    // another trip's segment by stop_id or parent_station
+    type SegRender = { from: [number, number]; to: [number, number]; tripIdx: number; bothOverlap: boolean;
+      fromStopId?: string; toStopId?: string; fromStation?: string; toStation?: string };
+    const segRenders: SegRender[] = [];
+    if (isCompare) {
+      // First pass: collect all segments with identity info
+      const rawSegs: Array<{ pt: StopPoint; next: StopPoint }> = [];
+      for (const pt of visibleStops) {
+        const next = visibleStops.find((p) => p.tripIdx === pt.tripIdx && p.stopIdx === pt.stopIdx + 1);
+        if (next) rawSegs.push({ pt, next });
+      }
+      // Build identity key for a stop: parent_station or stop_id
+      const stopKey = (p: StopPoint) => (p.parentStation && p.parentStation.length > 0) ? p.parentStation : p.stopId;
+      // Build segment identity key — bidirectional (same key regardless of direction)
+      const segIdentity = (from: StopPoint, to: StopPoint) => {
+        const a = stopKey(from), b = stopKey(to);
+        return a < b ? `${a}↔${b}` : `${b}↔${a}`;
+      };
+      // Count how many trips share each segment identity
+      const segIdentityCounts = new Map<string, Set<number>>();
+      for (const { pt, next } of rawSegs) {
+        const key = segIdentity(pt, next);
+        if (!segIdentityCounts.has(key)) segIdentityCounts.set(key, new Set());
+        segIdentityCounts.get(key)!.add(pt.tripIdx);
+      }
+      // For shared segments, pick a canonical direction so all trips render from→to consistently
+      const segCanonicalDir = new Map<string, [string, string]>();
+      for (const { pt, next } of rawSegs) {
+        const key = segIdentity(pt, next);
+        if (!segCanonicalDir.has(key)) {
+          segCanonicalDir.set(key, [stopKey(pt), stopKey(next)]);
+        }
+      }
+      // Second pass: build segRenders with bothOverlap = shared by 2+ trips
+      for (const { pt, next } of rawSegs) {
+        const fromCoord = getStopCoord(pt);
+        const toCoord = getStopCoord(next);
+        const key = segIdentity(pt, next);
+        const shared = (segIdentityCounts.get(key)?.size ?? 0) > 1;
+        // Normalize direction: if this segment's from→to doesn't match canonical, swap coords
+        let renderFrom = fromCoord, renderTo = toCoord;
+        if (shared) {
+          const canon = segCanonicalDir.get(key);
+          if (canon && canon[0] !== stopKey(pt)) {
+            renderFrom = toCoord; renderTo = fromCoord;
+          }
+        }
+        segRenders.push({ from: renderFrom, to: renderTo, tripIdx: pt.tripIdx, bothOverlap: shared,
+          fromStopId: pt.stopId, toStopId: next.stopId, fromStation: pt.parentStation, toStation: next.parentStation });
+      }
+    }
+
+    // 1. Segment selection highlight — highlight all matching lines with their offsets
+    if (clickedSegment) {
+      // Match using identity key: parent_station (if exists) or stop_id
+      const segStopKeyFn = (stopId?: string, station?: string) =>
+        (station && station.length > 0) ? station : (stopId || '');
+      const clickedFromK = segStopKeyFn(clickedSegment.fromStopId, clickedSegment.fromStation);
+      const clickedToK = segStopKeyFn(clickedSegment.toStopId, clickedSegment.toStation);
+      const matchingRendered = segRenders.filter((s) => {
+        const sFromK = segStopKeyFn(s.fromStopId, s.fromStation);
+        const sToK = segStopKeyFn(s.toStopId, s.toStation);
+        return (sFromK === clickedFromK && sToK === clickedToK) ||
+               (sFromK === clickedToK && sToK === clickedFromK);
+      });
+      if (matchingRendered.length > 0 && matchingRendered[0].bothOverlap) {
+        // Shared segment: highlight each trip's line at its per-group offset
+        const sorted = [...new Set(matchingRendered.map((s) => s.tripIdx))].sort();
+        for (const seg of matchingRendered) {
+          const ti = seg.tripIdx;
+          const idx = sorted.indexOf(ti);
+          const offset = (idx - (sorted.length - 1) / 2) * 1.8;
+          const color = safeHexToRgb(TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length]);
+          layerList.push(new PathLayer({
+            id: `trip-seg-hl-${ti}`,
+            data: [{ path: [seg.from, seg.to] }],
+            getPath: (d: any) => d.path,
+            getColor: isDark ? [245, 158, 11, 80] : [200, 130, 0, 100],
+            getWidth: 8, widthUnits: "pixels",
+            capRounded: true, jointRounded: true, pickable: false,
+            getOffset: offset, extensions: pathStyleExt,
+          }));
+        }
+      } else {
+        // Solo segment: simple glow + colored highlight
+        layerList.push(new PathLayer({
+          id: "trip-segment-highlight-glow",
+          data: [{ path: [clickedSegment.from, clickedSegment.to] }],
+          getPath: (d: any) => d.path,
+          getColor: isDark ? [245, 158, 11, 50] : [200, 130, 0, 60],
+          getWidth: 16, widthUnits: "pixels",
+          capRounded: true, jointRounded: true, pickable: false,
+        }));
+        const segColor = safeHexToRgb(TRIP_LINE_COLORS[clickedSegment.tripIdx % TRIP_LINE_COLORS.length]);
+        layerList.push(new PathLayer({
+          id: "trip-segment-highlight",
+          data: [{ path: [clickedSegment.from, clickedSegment.to] }],
+          getPath: (d: any) => d.path,
+          getColor: [...segColor, 255] as [number, number, number, number],
+          getWidth: 6, widthUnits: "pixels",
+          capRounded: true, jointRounded: true, pickable: false,
+        }));
+      }
+    }
+
+    // 2. Trip path lines — visual only, rendered early so dots render on top
+    if (isCompare) {
+      const overlapSegs = segRenders.filter((s) => s.bothOverlap);
+      if (overlapSegs.length > 0) {
+        // Group shared segments by identity to compute per-group offsets
+        const segStopKey = (s: SegRender) => {
+          const fk = (s.fromStation && s.fromStation.length > 0) ? s.fromStation : (s.fromStopId || '');
+          const tk = (s.toStation && s.toStation.length > 0) ? s.toStation : (s.toStopId || '');
+          return fk < tk ? `${fk}↔${tk}` : `${tk}↔${fk}`;
+        };
+        for (const ti of visibleTripIds) {
+          const tripSegs = overlapSegs.filter((s) => s.tripIdx === ti);
+          if (tripSegs.length === 0) continue;
+          const color = safeHexToRgb(TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length]);
+          // Compute per-segment offset based on how many trips share that specific segment
+          const pathData = tripSegs.map((s) => {
+            const key = segStopKey(s);
+            const sharingTrips = overlapSegs.filter((o) => segStopKey(o) === key).map((o) => o.tripIdx);
+            const sorted = [...new Set(sharingTrips)].sort();
+            const idx = sorted.indexOf(ti);
+            const offset = (idx - (sorted.length - 1) / 2) * 1.8;
+            return { path: [s.from, s.to], tripIdx: ti, offset };
+          });
+          layerList.push(new PathLayer({
+            id: `trip-path-ov-${ti}`, data: pathData,
+            getPath: (d: any) => d.path,
+            getColor: [...color, 230] as [number, number, number, number],
+            getWidth: 4, widthUnits: "pixels", capRounded: true, jointRounded: true,
+            pickable: true, getOffset: (d: any) => d.offset, extensions: pathStyleExt,
+          }));
+        }
+      }
+      const soloSegs = segRenders.filter((s) => !s.bothOverlap);
+      if (soloSegs.length > 0) {
+        for (const ti of visibleTripIds) {
+          const tripSegs = soloSegs.filter((s) => s.tripIdx === ti);
+          if (tripSegs.length === 0) continue;
+          const color = safeHexToRgb(TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length]);
+          const pathData = tripSegs.map((s) => ({ path: [s.from, s.to], tripIdx: ti }));
+          layerList.push(new PathLayer({
+            id: `trip-path-solo-${ti}`, data: pathData,
+            getPath: (d: any) => d.path,
+            getColor: [...color, 230] as [number, number, number, number],
+            getWidth: 4, widthUnits: "pixels", capRounded: true, jointRounded: true,
+            pickable: true,
+          }));
+        }
+      }
+    } else {
+      visiblePaths.forEach((p) => {
+        const color = safeHexToRgb(TRIP_LINE_COLORS[p.tripIdx % TRIP_LINE_COLORS.length]);
+        layerList.push(new PathLayer({
+          id: `trip-path-${p.tripIdx}`, data: [p],
+          getPath: (d: any) => d.path,
+          getColor: [...color, 230] as [number, number, number, number],
+          getWidth: 4, widthUnits: "pixels", capRounded: true, jointRounded: true,
+          pickable: true,
+        }));
+      });
+    }
+
+    // Line click target — rendered BEFORE dots so dots get pick priority
+    {
+      const primarySegs = segments.filter((s) => s.tripIdx === 0 && !hidden.has(0));
+      if (primarySegs.length > 0) {
+        layerList.push(new LineLayer({
+          id: "trip-segments",
+          data: primarySegs,
+          getSourcePosition: (d: Segment) => d.from,
+          getTargetPosition: (d: Segment) => d.to,
+          getColor: (d: Segment) => {
+            if (isCompare) return [0, 0, 0, 0] as [number, number, number, number];
+            if (d.disabled) return [150, 150, 150, 80] as [number, number, number, number];
+            const isClicked = clickedSegment?.fromIdx === d.fromIdx && clickedSegment?.toIdx === d.toIdx;
+            const rgb = safeHexToRgb(TRIP_LINE_COLORS[0]);
+            return isClicked ? [...rgb, 255] as [number, number, number, number] : [...rgb, 200] as [number, number, number, number];
+          },
+          getWidth: isCompare ? 12 : 10, widthUnits: "pixels", pickable: true,
+          updateTriggers: { getColor: [deletedStopIndices.size, clickedSegment?.fromIdx, clickedSegment?.toIdx, isCompare] },
+        }));
+      }
+    }
+
+    // Determine which locations are "bar-selected"
+    const clickedLocKey = clickedStop ? stopLocKey(clickedStop) : null;
+
+    // Split stops: overlap (capsule handles clicks) vs solo (directly pickable)
+    // For station-merged stops, override coordinates to centroid
+    const overlapStops = isCompare ? visibleStops
+      .filter((d) => overlapInfo.has(`${d.tripIdx}-${d.stopIdx}`))
+      .map((d) => { const c = stopCoordMap.get(`${d.tripIdx}-${d.stopIdx}`); return c ? { ...d, lon: c[0], lat: c[1] } : d; })
+      : [];
+    const soloStops = isCompare ? visibleStops.filter((d) => !overlapInfo.has(`${d.tripIdx}-${d.stopIdx}`)) : visibleStops;
+
+    // Overlap: capsule + colored dots — only in compare mode
+    if (overlapStops.length > 0 && isCompare) {
+      const getOvOff = (d: StopPoint): [number, number] => {
+        const info = overlapInfo.get(`${d.tripIdx}-${d.stopIdx}`);
+        return info ? [info.ox, info.oy] : [0, 0];
+      };
+
+      // Capsule wrapper — pill shape using IconLayer, rotated to bar direction
+      const hitLocs = new Map<string, { pt: StopPoint; count: number }>();
+      for (const pt of overlapStops) {
+        const k = stopLocKey(pt);
+        const existing = hitLocs.get(k);
+        if (existing) existing.count++;
+        else hitLocs.set(k, { pt, count: 1 });
+      }
+      const hitData = Array.from(hitLocs.values());
+
+      // Larger dots, shrink after 3 to cap capsule
+      const baseR = Math.round(segR * 0.7);
+      const dotR = (count: number) => count <= 3 ? baseR : Math.max(3, Math.round(baseR * 3 / count));
+      const dotSp = (count: number) => dotR(count) * 2;
+      const capsuleW = (count: number) => { const r = dotR(count); return (count - 1) * r * 2 + r * 2; };
+      layerList.push(new IconLayer({
+        id: "trip-stops-overlap-ring", data: hitData,
+        getPosition: (d: { pt: StopPoint }) => [d.pt.lon, d.pt.lat],
+        getIcon: (d: { pt: StopPoint; count: number }) => {
+          const isSel = stopLocKey(d.pt) === clickedLocKey;
+          const w = Math.round(capsuleW(d.count) * (d.count <= 2 ? 0.7 : 0.5));
+          const h = Math.round(dotR(d.count) * 1.2);
+          const fill = isSel
+            ? (isDark ? "rgba(245,158,11,0.35)" : "rgba(200,130,0,0.3)")
+            : (isDark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.08)");
+          const stroke = isSel
+            ? (isDark ? "rgba(245,158,11,0.9)" : "rgba(200,130,0,0.85)")
+            : (isDark ? "rgba(255,255,255,0.35)" : "rgba(0,0,0,0.25)");
+          const sw = isSel ? 2.5 : 1;
+          const icon = makeCapsuleIcon(w, h, fill, stroke, sw);
+          return { url: icon.url, width: icon.w, height: icon.h, anchorY: icon.h / 2 };
+        },
+        getSize: (d: { count: number }) => Math.round(capsuleW(d.count) * (d.count <= 2 ? 0.7 : 0.5)),
+        getAngle: (d: { pt: StopPoint }) => {
+          const info = overlapInfo.get(`${d.pt.tripIdx}-${d.pt.stopIdx}`);
+          return info ? -info.angle : 0;
+        },
+        sizeUnits: "pixels",
+        pickable: true,
+        updateTriggers: { getIcon: [clickedLocKey, isDark, segR], getSize: [segR], getAngle: [] },
+      }));
+
+      // Colored dots — IconLayer per trip color
+      const tripIconCache = new Map<number, string>();
+      const getTripIcon = (tripIdx: number) => {
+        if (!tripIconCache.has(tripIdx)) {
+          const rgb = safeHexToRgb(TRIP_LINE_COLORS[tripIdx % TRIP_LINE_COLORS.length]);
+          const stroke: [number, number, number] = isDark ? [30, 30, 30] : [255, 255, 255];
+          tripIconCache.set(tripIdx, makeCircleIcon(rgb as [number, number, number], 32, stroke));
+        }
+        return tripIconCache.get(tripIdx)!;
+      };
+      layerList.push(new IconLayer({
+        id: "trip-stops-overlap", data: overlapStops,
+        getPosition: (d: StopPoint) => [d.lon, d.lat],
+        getIcon: (d: StopPoint) => ({
+          url: getTripIcon(d.tripIdx),
+          width: 32, height: 32, mask: false,
+        }),
+        getSize: (d: StopPoint) => {
+          const info = overlapInfo.get(`${d.tripIdx}-${d.stopIdx}`);
+          const r = info ? dotR(info.count) : segR;
+          return stopLocKey(d) === clickedLocKey ? r * 2 + 2 : r * 2;
+        },
+        getPixelOffset: getOvOff,
+        sizeUnits: "pixels", pickable: true,
+        updateTriggers: { getIcon: [isDark], getSize: [clickedLocKey, segR] },
+      }));
+    }
+
+    // Selection buffer for clicked solo stop — renders behind the dot
+    if (clickedStop && !overlapInfo.has(`${clickedStop.tripIdx}-${clickedStop.stopIdx}`)) {
+      layerList.push(new ScatterplotLayer({
+        id: "trip-stop-selection-buffer", data: [clickedStop],
+        getPosition: (d: StopPoint) => [d.lon, d.lat],
+        getFillColor: isDark ? [245, 158, 11, 60] : [200, 130, 0, 70],
+        radiusUnits: "pixels", getRadius: 11,
+        stroked: true,
+        getLineColor: isDark ? [245, 158, 11, 180] : [200, 130, 0, 200],
+        getLineWidth: 2, lineWidthUnits: "pixels", pickable: false,
+      }));
+    }
+
+    // Non-overlap dots — pickable
+    layerList.push(new ScatterplotLayer({
+      id: "trip-stops", data: soloStops,
+      getPosition: (d: StopPoint) => [d.lon, d.lat],
+      getFillColor: (d: StopPoint) => {
+        if (d.disabled) return [150, 150, 150, 100] as [number, number, number, number];
+        const isClicked = clickedStop?.stopIdx === d.stopIdx && clickedStop?.tripIdx === d.tripIdx;
+        const isSelected = d.tripIdx === 0 && selectedStopIdx === d.stopIdx;
+        const status = d.tripIdx === 0 ? stopStatusMap.get(d.stopIdx) : undefined;
+        if (isSelected) return [245, 158, 11, 255] as [number, number, number, number];
+        if (isClicked) return [255, 80, 80, 255] as [number, number, number, number];
+        if (status === "new") return [34, 197, 94, 230] as [number, number, number, number];
+        if (status === "edit") return [245, 158, 11, 200] as [number, number, number, number];
+        const rgb = safeHexToRgb(TRIP_LINE_COLORS[d.tripIdx % TRIP_LINE_COLORS.length]);
+        return [...rgb, 240] as [number, number, number, number];
+      },
+      radiusUnits: "pixels",
+      getRadius: (d: StopPoint) => {
+        if (d.disabled) return 4;
+        const isClicked = clickedStop?.stopIdx === d.stopIdx && clickedStop?.tripIdx === d.tripIdx;
+        const isSelected = d.tripIdx === 0 && selectedStopIdx === d.stopIdx;
+        return isClicked || isSelected ? 10 : 8;
+      },
+      radiusMinPixels: 3, stroked: true,
+      getLineColor: isDark ? [40, 40, 40, 230] : [255, 255, 255, 230],
+      getLineWidth: 1.5, lineWidthUnits: "pixels",
+      pickable: true,
+      // Drag handlers required so deck.gl fires onClick for empty space
+      onDragStart: editable ? (info: any) => {
+        if (info.object && info.object.tripIdx === 0) {
+          isDraggingRef.current = true;
+          dragIdxRef.current = info.object.stopIdx;
+          return true;
+        }
+        return false;
+      } : undefined,
+      onDrag: editable ? (info: any) => {
+        if (!isDraggingRef.current || dragIdxRef.current === null || !info.coordinate) return false;
+        const [lon, lat] = info.coordinate;
+        onDragStop?.(dragIdxRef.current, lat, lon);
+        return true;
+      } : undefined,
+      onDragEnd: editable ? () => {
+        if (isDraggingRef.current) { isDraggingRef.current = false; dragIdxRef.current = null; return true; }
+        return false;
+      } : undefined,
+      updateTriggers: {
+        getFillColor: [clickedStop?.stopIdx, clickedStop?.tripIdx, deletedStopIndices.size, selectedStopIdx, clickedLocKey],
+        getRadius: [clickedStop?.stopIdx, clickedStop?.tripIdx, deletedStopIndices.size, selectedStopIdx, clickedLocKey],
+      },
+    }));
+
+    // (capsule layer above handles click targets for overlap bars)
+
+    // Labels — stop order number INSIDE every dot
+    const previewSeqNum = externalPreview?.stopSequence;
+    layerList.push(new TextLayer({
+      id: "trip-stop-labels", data: visibleStops.filter((d) => !d.disabled),
+      getPosition: (d: StopPoint) => { const c = stopCoordMap.get(`${d.tripIdx}-${d.stopIdx}`); return c || [d.lon, d.lat]; },
+      getText: (d: StopPoint) => {
+        if (previewSeqNum && d.tripIdx === 0 && d.sequence >= previewSeqNum) return String(d.sequence + 1);
+        return String(d.sequence);
+      },
+      getSize: (d: StopPoint) => {
+        const info = overlapInfo.get(`${d.tripIdx}-${d.stopIdx}`);
+        if (info?.isOverlap) {
+          const r = Math.round(segR * 0.7);
+          return Math.max(8, Math.round(r * 1.2));
+        }
+        return 10;
+      },
+      getColor: () => isDark ? [255, 255, 255, 240] : [0, 0, 0, 220],
+      getPixelOffset: (d: StopPoint) => {
+        const info = overlapInfo.get(`${d.tripIdx}-${d.stopIdx}`);
+        return info ? [info.ox, info.oy] : [0, 0];
+      },
+      fontFamily: "system-ui, sans-serif", fontWeight: 700,
+      getTextAnchor: "middle", getAlignmentBaseline: "center",
+      pickable: false, sizeUnits: "pixels",
+      updateTriggers: { getText: [previewSeqNum], getColor: [isDark], getPixelOffset: [overlapInfo.size, segR], getSize: [overlapInfo.size, segR] },
+    }));
+
+
+
+    // Preview stop
+    const activePreview = previewStop || externalPreview;
+    if (activePreview) {
+      layerList.push(new ScatterplotLayer({
+        id: "preview-stop", data: [activePreview],
+        getPosition: (d: any) => [d.lon, d.lat],
+        getFillColor: [245, 158, 11, 220], radiusUnits: "pixels", getRadius: 10,
+        radiusMinPixels: 8, stroked: true, getLineColor: [255, 255, 255, 255],
+        getLineWidth: 2, lineWidthUnits: "pixels", pickable: false,
+      }));
+      const seqNum = (activePreview as any).stopSequence;
+      const rawName = activePreview.name ? stripAccents(activePreview.name) : "";
+      const nameStr = rawName.length > 12 ? rawName.slice(0, 10) + "..." : rawName;
+      const previewLabel = seqNum
+        ? (nameStr ? `#${seqNum} ${nameStr}` : `#${seqNum}`)
+        : (nameStr || "New");
+      layerList.push(new TextLayer({
+        id: "preview-stop-label", data: [{ ...activePreview, _label: previewLabel }],
+        getPosition: (d: any) => [d.lon, d.lat], getText: (d: any) => d._label,
+        getSize: 11, getColor: [245, 158, 11, 255], getPixelOffset: [0, -18],
+        fontFamily: "system-ui, sans-serif", fontWeight: 700, pickable: false, sizeUnits: "pixels",
+      }));
+      // Connection lines to adjacent stops
+      const seq = (activePreview as any).stopSequence;
+      if (seq && stopPoints.length > 0) {
+        const primaryStops = stopPoints.filter((p) => p.tripIdx === 0 && !p.disabled);
+        const prevStop = seq > 1 ? primaryStops[seq - 2] : undefined;
+        const nextStop = seq <= primaryStops.length ? primaryStops[seq - 1] : undefined;
+        const connectionData: Array<{ from: [number, number]; to: [number, number] }> = [];
+        if (prevStop) connectionData.push({ from: [prevStop.lon, prevStop.lat], to: [activePreview.lon, activePreview.lat] });
+        if (nextStop) connectionData.push({ from: [activePreview.lon, activePreview.lat], to: [nextStop.lon, nextStop.lat] });
+        if (connectionData.length > 0) {
+          layerList.push(new LineLayer({
+            id: "preview-connection", data: connectionData,
+            getSourcePosition: (d: any) => d.from, getTargetPosition: (d: any) => d.to,
+            getColor: [245, 158, 11, 150], getWidth: 3, widthUnits: "pixels", pickable: false,
+            getDashArray: [6, 4], dashJustified: true, extensions: [],
+          }));
+        }
+      } else if (clickedStop) {
+        layerList.push(new LineLayer({
+          id: "preview-connection",
+          data: [{ from: [clickedStop.lon, clickedStop.lat], to: [activePreview.lon, activePreview.lat] }],
+          getSourcePosition: (d: any) => d.from, getTargetPosition: (d: any) => d.to,
+          getColor: [34, 197, 94, 150], getWidth: 3, widthUnits: "pixels", pickable: false,
+        }));
+      }
+    }
+
+    return layerList;
+  }, [stopPoints, segments, paths, clickedStop, clickedSegment, theme, editable, deletedStopIndices, previewStop, externalPreview, stopStatusMap, selectedStopIdx, hiddenTripIndices, zoomBucket]);
+
+  return (
+    <div className="h-full w-full">
+      <DeckglMap
+        viewState={viewState}
+        setViewState={setViewState}
+        MapLayers={layers}
+        BoundBox={boundBox}
+        MinZoom={Math.max(1, fitZoom - 2)}
+        dragRotate={false}
+        maxPitch={0}
+        setClickInfo={handleClick}
+        setHoverInfo={() => {}}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Map/Components/SegmentPopup.tsx
+++ b/packages/web/src/client/Trips/components/Map/Components/SegmentPopup.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { BiTrash, BiUndo } from "react-icons/bi";
+import { Button } from "@/components/ui/button";
+import { parseTime, timeToSec } from "@/lib/tripUtils";
+import type { Segment } from "../types";
+
+export function SegmentPopup({ segment, editable, onUpdateTime, onDeleteStop, onRestoreStop, deletedStopIndices, onClose }: {
+  segment: Segment;
+  editable: boolean;
+  onUpdateTime?: (stopIdx: number, field: "arrival_time" | "departure_time", value: string) => void;
+  onDeleteStop?: (stopIdx: number) => void;
+  onRestoreStop?: (stopIdx: number) => void;
+  deletedStopIndices?: Set<number>;
+  onClose: () => void;
+}) {
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [invalid, setInvalid] = useState(false);
+
+  const fromSec = timeToSec(segment.fromTime);
+  const toSec = timeToSec(segment.toTime);
+  const durationMin = fromSec != null && toSec != null ? Math.round((toSec - fromSec) / 60) : undefined;
+
+  const startEdit = (field: string, value: string) => {
+    setEditingField(field);
+    setDraft(value);
+    setInvalid(false);
+  };
+
+  const commitEdit = () => {
+    if (!editingField || !onUpdateTime) return;
+    const parsed = parseTime(draft);
+    if (!parsed && draft.trim() !== "") { setInvalid(true); return; }
+    const value = parsed || "";
+    if (editingField === "fromDep") onUpdateTime(segment.fromIdx, "departure_time", value);
+    else if (editingField === "toArr") onUpdateTime(segment.toIdx, "arrival_time", value);
+    setEditingField(null);
+    setInvalid(false);
+  };
+
+  const renderTimeField = (label: string, value: string | undefined, fieldKey: string) => {
+    if (editingField === fieldKey) {
+      return (
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-muted-foreground w-12">{label}</span>
+          <input
+            autoFocus
+            className={`w-20 rounded border px-1 py-0.5 text-xs outline-none ${invalid ? "border-red-500 bg-red-50 dark:bg-red-950" : "border-primary/50 bg-background"}`}
+            value={draft}
+            placeholder="HH:MM:SS"
+            onChange={(e) => { setDraft(e.target.value); setInvalid(false); }}
+            onBlur={commitEdit}
+            onKeyDown={(e) => { if (e.key === "Enter") commitEdit(); if (e.key === "Escape") { setEditingField(null); setInvalid(false); } }}
+          />
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center gap-1">
+        <span className="text-xs text-muted-foreground w-12">{label}</span>
+        <span
+          className={`text-xs ${editable ? "cursor-pointer rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors" : ""}`}
+          onClick={editable ? () => startEdit(fieldKey, value || "") : undefined}
+        >
+          {value || "\u2014"}
+        </span>
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-3 text-sm space-y-2">
+      <div className="font-semibold text-xs text-muted-foreground">Connection</div>
+
+      <div className="rounded-md border p-2 space-y-1">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-medium">{segment.fromName}</div>
+          {editable && (
+            deletedStopIndices?.has(segment.fromIdx) ? (
+              <Button size="sm" variant="outline" className="text-[10px] h-5 px-1.5"
+                onClick={() => { onRestoreStop?.(segment.fromIdx); onClose(); }}>
+                <BiUndo className="mr-0.5 h-2.5 w-2.5" />Restore
+              </Button>
+            ) : (
+              <Button size="sm" variant="ghost" className="text-[10px] h-5 px-1.5 text-destructive hover:text-destructive"
+                onClick={() => { onDeleteStop?.(segment.fromIdx); onClose(); }}>
+                <BiTrash className="mr-0.5 h-2.5 w-2.5" />Remove
+              </Button>
+            )
+          )}
+        </div>
+        {renderTimeField("Dep:", segment.fromTime, "fromDep")}
+      </div>
+
+      <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+        <span>{"\u2193"}</span>
+        {durationMin != null && <span className="bg-muted rounded px-1.5 py-0.5">{durationMin} min</span>}
+      </div>
+
+      <div className="rounded-md border p-2 space-y-1">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-medium">{segment.toName}</div>
+          {editable && (
+            deletedStopIndices?.has(segment.toIdx) ? (
+              <Button size="sm" variant="outline" className="text-[10px] h-5 px-1.5"
+                onClick={() => { onRestoreStop?.(segment.toIdx); onClose(); }}>
+                <BiUndo className="mr-0.5 h-2.5 w-2.5" />Restore
+              </Button>
+            ) : (
+              <Button size="sm" variant="ghost" className="text-[10px] h-5 px-1.5 text-destructive hover:text-destructive"
+                onClick={() => { onDeleteStop?.(segment.toIdx); onClose(); }}>
+                <BiTrash className="mr-0.5 h-2.5 w-2.5" />Remove
+              </Button>
+            )
+          )}
+        </div>
+        {renderTimeField("Arr:", segment.toTime, "toArr")}
+      </div>
+
+      {segment.disabled && (
+        <div className="text-xs text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 rounded p-1.5">
+          Segment disabled (stop removed)
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Map/Components/StopPopup.tsx
+++ b/packages/web/src/client/Trips/components/Map/Components/StopPopup.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { BiCrosshair, BiMapPin, BiPlus, BiTrash, BiUndo } from "react-icons/bi";
+import { Button } from "@/components/ui/button";
+import Combobox from "@/components/ui/combobox";
+import { TimeInput } from "@/components/ui/TimeInput";
+import type { StopPoint, RouteStop } from "../types";
+
+export function StopPopup({ stop, editable, routeStops, onDeleteStop, onRestoreStop, onReplaceStop, onCreateStop, deletedStopIndices, onPreviewStop, onClose, onUpdateStopTime, stopStatus, onZoomToStop }: {
+  stop: StopPoint;
+  editable: boolean;
+  routeStops: RouteStop[];
+  onDeleteStop?: (stopIdx: number) => void;
+  onRestoreStop?: (stopIdx: number) => void;
+  onReplaceStop?: (stopIdx: number, newStop: RouteStop) => void;
+  onCreateStop?: () => void;
+  deletedStopIndices?: Set<number>;
+  onPreviewStop?: (preview: { lon: number; lat: number; name: string } | null) => void;
+  onClose: () => void;
+  onUpdateStopTime?: (stopIdx: number, field: "arrival_time" | "departure_time", value: string) => void;
+  stopStatus?: string;
+  onZoomToStop?: () => void;
+}) {
+  const [showReplace, setShowReplace] = useState(false);
+  const [replaceValue, setReplaceValue] = useState<string | undefined>();
+
+  const stopOptions = useMemo(() => {
+    const onRoute: Array<{ value: string; label: string; searchLabel: string; color: string }> = [];
+    const offRoute: Array<{ value: string; label: string; searchLabel: string; color: string }> = [];
+    for (const rs of routeStops) {
+      if (rs.stop_id === stop.stopId) continue;
+      const opt = {
+        value: rs.stop_id,
+        label: `${rs.stop_name || rs.stop_id} (${rs.stop_id})`,
+        searchLabel: `${rs.stop_id} ${rs.stop_name || ""}`,
+        color: (rs as any).on_route ? "#3b82f6" : "#9ca3af",
+      };
+      if ((rs as any).on_route) onRoute.push(opt);
+      else offRoute.push(opt);
+    }
+    return [...onRoute, ...offRoute];
+  }, [routeStops, stop.stopId]);
+
+  const selectedReplace = replaceValue ? routeStops.find((rs) => rs.stop_id === replaceValue) : undefined;
+  const isOnRoute = selectedReplace ? (selectedReplace as any).on_route : false;
+
+  const handleSelectReplace = useCallback((val: string | undefined) => {
+    setReplaceValue(val);
+    if (val) {
+      const rs = routeStops.find((s) => s.stop_id === val);
+      if (rs && rs.stop_lat != null && rs.stop_lon != null) {
+        onPreviewStop?.({ lon: Number(rs.stop_lon), lat: Number(rs.stop_lat), name: rs.stop_name || rs.stop_id });
+      } else {
+        onPreviewStop?.(null);
+      }
+    } else {
+      onPreviewStop?.(null);
+    }
+  }, [routeStops, onPreviewStop]);
+
+  const handleReplace = () => {
+    if (selectedReplace && onReplaceStop) {
+      onReplaceStop(stop.stopIdx, selectedReplace);
+      onPreviewStop?.(null);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="p-3 text-sm space-y-2">
+      {!showReplace ? (
+        <>
+          <div className="flex items-center gap-2">
+            {stopStatus && (
+              <span className={`inline-flex items-center justify-center h-4 w-4 rounded-full text-[8px] ${stopStatus === "new" ? "bg-green-100 dark:bg-green-900/40" : "bg-amber-100 dark:bg-amber-900/40"}`}>
+                {stopStatus === "new" ? "🆕" : "✏️"}
+              </span>
+            )}
+            <span className="font-semibold">{stop.name}</span>
+            {onZoomToStop && (
+              <button onClick={(e) => { e.stopPropagation(); onZoomToStop(); }} className="ml-auto text-muted-foreground hover:text-foreground shrink-0" title="Zoom to stop">
+                <BiCrosshair className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{stop.stopId}</span>
+            <span>·</span>
+            <span>#{stop.sequence}</span>
+            {stop.parentStation ? (
+              <Link to="/stations/info" search={{ selectedStationId: stop.parentStation }}
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+                <BiMapPin className="h-3 w-3" />Station
+              </Link>
+            ) : (
+              <Link to="/stops/map" search={{ selectedStopId: stop.stopId }}
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+                <BiMapPin className="h-3 w-3" />Stop
+              </Link>
+            )}
+          </div>
+          {editable && stop.tripIdx === 0 && onUpdateStopTime ? (
+            <div className="grid grid-cols-2 gap-2 pt-1">
+              <div>
+                <div className="text-[10px] text-muted-foreground mb-0.5">Arrival</div>
+                <TimeInput value={stop.arrivalTime || ""} onChange={(v) => onUpdateStopTime(stop.stopIdx, "arrival_time", v)} placeholder="HH:MM" />
+              </div>
+              <div>
+                <div className="text-[10px] text-muted-foreground mb-0.5">Departure</div>
+                <TimeInput value={stop.departureTime || ""} onChange={(v) => onUpdateStopTime(stop.stopIdx, "departure_time", v)} placeholder="HH:MM" />
+              </div>
+            </div>
+          ) : (
+            <>
+              {stop.arrivalTime && <div className="text-xs">Arr: {stop.arrivalTime}</div>}
+              {stop.departureTime && <div className="text-xs">Dep: {stop.departureTime}</div>}
+            </>
+          )}
+
+          {editable && stop.tripIdx === 0 && (
+            <div className="flex gap-1 pt-1 border-t">
+              {deletedStopIndices?.has(stop.stopIdx) ? (
+                <Button size="sm" variant="outline" className="text-xs h-7"
+                  onClick={() => { onRestoreStop?.(stop.stopIdx); onClose(); }}>
+                  <BiUndo className="mr-1 h-3 w-3" />Restore
+                </Button>
+              ) : (
+                <>
+                  <Button size="sm" variant="destructive" className="text-xs h-7"
+                    onClick={() => { onDeleteStop?.(stop.stopIdx); onClose(); }}>
+                    <BiTrash className="mr-1 h-3 w-3" />Remove
+                  </Button>
+                  <Button size="sm" variant="outline" className="text-xs h-7"
+                    onClick={() => { setShowReplace(true); setReplaceValue(undefined); }}>
+                    Replace
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="font-semibold text-xs text-muted-foreground">Replace Stop</div>
+
+          <div className="rounded-md border p-2 space-y-0.5">
+            <div className="text-xs font-medium">{stop.name}</div>
+            <div className="text-[10px] text-muted-foreground">{stop.stopId}</div>
+          </div>
+
+          <div className="flex items-center justify-center text-xs text-muted-foreground">
+            <span>{"\u2193"} {"\u2191"}</span>
+          </div>
+
+          {selectedReplace ? (
+            <div className={`rounded-md border p-2 space-y-1 ${isOnRoute ? "border-blue-300 bg-blue-50 dark:bg-blue-950/20" : "border-gray-300 bg-gray-50 dark:bg-gray-800/30"}`}>
+              <div className="flex items-center gap-1.5">
+                <span className="rounded-full shrink-0" style={{ width: 6, height: 6, backgroundColor: isOnRoute ? "#3b82f6" : "#9ca3af" }} />
+                <div className="text-xs font-medium">{selectedReplace.stop_name || selectedReplace.stop_id}</div>
+              </div>
+              <div className="text-[10px] text-muted-foreground">{selectedReplace.stop_id}</div>
+              <div className="text-[10px] text-muted-foreground">
+                {isOnRoute ? "On this route" : "Not on this route"}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-md border border-dashed p-2 text-xs text-muted-foreground text-center">
+              Select a replacement stop below
+            </div>
+          )}
+
+          <Combobox
+            options={stopOptions}
+            Message="Search by name or ID..."
+            value={replaceValue}
+            setValue={handleSelectReplace}
+          />
+
+          <div className="flex gap-1">
+            <Button size="sm" variant="outline" className="text-xs h-7 flex-1"
+              onClick={() => { setShowReplace(false); onPreviewStop?.(null); }}>
+              Back
+            </Button>
+            {selectedReplace && (
+              <Button size="sm" variant="default" className="text-xs h-7 flex-1" onClick={handleReplace}>
+                Confirm
+              </Button>
+            )}
+          </div>
+
+          {onCreateStop && (
+            <Button size="sm" variant="outline" className="text-xs h-7 w-full" onClick={onCreateStop}>
+              <BiPlus className="mr-1 h-3 w-3" />Create Stop
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Map/index.tsx
+++ b/packages/web/src/client/Trips/components/Map/index.tsx
@@ -1,0 +1,489 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { BiCrosshair, BiMapPin, BiX } from "react-icons/bi";
+import MapContainer from "@/components/maps/MapContainer";
+import { fitBoundsToPoints } from "@/functions/mapComponent/fitBounds";
+import { useDuckDB } from "@/context/duckdb.client";
+import { fetchTripMapBounds } from "@/lib/duckdb/DataFetching/fetchRouteData";
+import { TRIP_LINE_COLORS } from "@/lib/tripUtils";
+import { MapSection } from "./Components/MapSection";
+import type { TripMapProps, StopPoint, Segment } from "./types";
+
+export function TripMap({
+  trips,
+  editable = false,
+  onDeleteStop: _onDeleteStop,
+  onRestoreStop: _onRestoreStop,
+  onReplaceStop: _onReplaceStop,
+  onAddStop: _onAddStop,
+  routeStops: _routeStops = [],
+  onCreateStop: _onCreateStop,
+  addStopPreview: externalPreview,
+  deletedStopIndices = new Set(),
+  onDragStop,
+  onUpdateStopTime: _onUpdateStopTime,
+  originalStops,
+  selectedStopIdx,
+  onSelectStop,
+  editPanel,
+  zoomToStopRef,
+  onClickAnyStop,
+  hiddenTripIndices: externalHidden,
+  onToggleTripVisibility,
+}: TripMapProps) {
+  const { conn } = useDuckDB() ?? {};
+  const [viewState, setViewState] = useState<any>(null);
+  const [boundBox, setBoundBox] = useState<[number[], number[]] | undefined>();
+  const [fitZoom, setFitZoom] = useState<number>(2);
+  const [clickedStop, setClickedStop] = useState<StopPoint | null>(null);
+  const [clickedSegment, setClickedSegment] = useState<Segment | null>(null);
+  const [previewStop, setPreviewStop] = useState<{ lon: number; lat: number; name: string } | null>(null);
+  const [internalHidden, setInternalHidden] = useState<Set<number>>(new Set());
+  const hiddenTripIndices = externalHidden ?? internalHidden;
+  const boundsFittedRef = useRef(false);
+
+  // Prepare data
+  const { stopPoints, segments, paths } = useMemo(() => {
+    const pts: StopPoint[] = [];
+    const segs: Segment[] = [];
+    const pths: Array<{ path: [number, number][]; tripIdx: number }> = [];
+
+    for (let ti = 0; ti < trips.length; ti++) {
+      const { stopTimes } = trips[ti];
+      const tripPath: [number, number][] = [];
+      let prevPt: StopPoint | null = null;
+
+      for (let si = 0; si < stopTimes.length; si++) {
+        const st = stopTimes[si];
+        const lat = Number(st.stop_lat);
+        const lon = Number(st.stop_lon);
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+
+        const isDeleted = editable && ti === 0 && deletedStopIndices.has(si);
+        const pt: StopPoint = {
+          lon, lat,
+          name: st.stop_name || st.stop_id || `Stop ${si + 1}`,
+          stopId: st.stop_id || "",
+          sequence: si + 1,
+          stopIdx: si,
+          arrivalTime: st.arrival_time,
+          departureTime: st.departure_time,
+          parentStation: (st as any).parent_station,
+          tripIdx: ti,
+          disabled: isDeleted,
+        };
+        pts.push(pt);
+        if (!isDeleted) tripPath.push([lon, lat]);
+
+        if (prevPt) {
+          segs.push({
+            from: [prevPt.lon, prevPt.lat], to: [lon, lat],
+            fromIdx: prevPt.stopIdx, toIdx: si,
+            fromName: prevPt.name, toName: pt.name,
+            fromTime: prevPt.departureTime || prevPt.arrivalTime,
+            toTime: st.arrival_time || st.departure_time,
+            tripIdx: ti,
+            disabled: isDeleted || prevPt.disabled,
+            fromStopId: prevPt.stopId, toStopId: pt.stopId,
+            fromStation: prevPt.parentStation, toStation: pt.parentStation,
+          });
+        }
+        prevPt = pt;
+      }
+
+      if (tripPath.length > 1) pths.push({ path: tripPath, tripIdx: ti });
+    }
+
+    return { stopPoints: pts, segments: segs, paths: pths };
+  }, [trips, editable, deletedStopIndices]);
+
+  // Zoom to a specific stop by index
+  const stopPointsRef = useRef(stopPoints);
+  stopPointsRef.current = stopPoints;
+  useEffect(() => {
+    if (zoomToStopRef) {
+      zoomToStopRef.current = (stopIdxOrLon: number, lat?: number) => {
+        // If lat is provided, zoom to coordinates directly (for preview stops)
+        if (lat != null) {
+          setViewState((prev: any) => ({
+            ...(prev || {}),
+            longitude: stopIdxOrLon, latitude: lat,
+            zoom: Math.max(prev?.zoom ?? 12, 15),
+            pitch: 0, bearing: 0, transitionDuration: 500,
+          }));
+          return;
+        }
+        const pt = stopPointsRef.current.find((p) => p.tripIdx === 0 && p.stopIdx === stopIdxOrLon);
+        if (pt) {
+          setViewState((prev: any) => ({
+            ...(prev || {}),
+            longitude: pt.lon, latitude: pt.lat,
+            zoom: Math.max(prev?.zoom ?? 12, 15),
+            pitch: 0, bearing: 0, transitionDuration: 500,
+          }));
+        }
+      };
+    }
+  }, [zoomToStopRef]);
+
+  // Sync selectedStopIdx from parent
+  // In compare mode: only sync on mount (to carry selection from other views), not on click-triggered updates
+  const prevSelectedRef = useRef(selectedStopIdx);
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    const idxChanged = prevSelectedRef.current !== selectedStopIdx;
+    prevSelectedRef.current = selectedStopIdx;
+
+    // In compare mode, skip after mount — click handler manages clickedStop directly
+    if (onClickAnyStop && hasMountedRef.current) return;
+    hasMountedRef.current = true;
+
+    if (selectedStopIdx != null) {
+      // In compare mode, search ALL trips for the stop; in single-trip mode, only trip 0
+      const pt = onClickAnyStop
+        ? stopPointsRef.current.find((p) => p.stopIdx === selectedStopIdx)
+        : stopPointsRef.current.find((p) => p.tripIdx === 0 && p.stopIdx === selectedStopIdx);
+      if (pt) {
+        setClickedStop((prev) => {
+          if (idxChanged || !prev || prev.stopId !== pt.stopId || prev.lat !== pt.lat || prev.lon !== pt.lon || prev.name !== pt.name) {
+            return pt;
+          }
+          return prev;
+        });
+        if (idxChanged) setClickedSegment(null);
+      }
+    } else {
+      setClickedStop((prev) => prev ? null : prev);
+    }
+  }, [selectedStopIdx, stopPoints, onClickAnyStop]);
+
+  // Track stop count to refit when stops are added/removed
+  const prevStopCountRef = useRef(stopPoints.length);
+  const prevPreviewRef = useRef(externalPreview);
+
+  // Center on preview when no stops exist (no conn needed)
+  useEffect(() => {
+    if (stopPoints.length > 0 || !externalPreview) return;
+    if (!Number.isFinite(externalPreview.lat) || !Number.isFinite(externalPreview.lon)) return;
+    setViewState((prev: any) => ({
+      ...(prev || {}),
+      longitude: externalPreview.lon, latitude: externalPreview.lat,
+      zoom: 14, pitch: 0, bearing: 0, transitionDuration: prev ? 300 : 0,
+    }));
+    setBoundBox([[externalPreview.lon - 0.02, externalPreview.lat - 0.02], [externalPreview.lon + 0.02, externalPreview.lat + 0.02]]);
+    setFitZoom(14);
+  }, [externalPreview?.lon, externalPreview?.lat, stopPoints.length]);
+
+  // Fit bounds on first load or refit when stops change
+  useEffect(() => {
+    if (!conn || stopPoints.length === 0) return;
+
+    const stopsChanged = prevStopCountRef.current !== stopPoints.length;
+    prevStopCountRef.current = stopPoints.length;
+    prevPreviewRef.current = externalPreview;
+
+    const allPoints = [...stopPoints.map((p) => ({ lat: p.lat, lon: p.lon }))];
+    if (externalPreview && Number.isFinite(externalPreview.lat) && Number.isFinite(externalPreview.lon)) {
+      allPoints.push({ lat: externalPreview.lat, lon: externalPreview.lon });
+    }
+
+    if (!boundsFittedRef.current) {
+      boundsFittedRef.current = true;
+      let cancelled = false;
+      const tripId = trips[0]?.trip?.trip_id;
+      const fetchBounds = async () => {
+        try {
+          if (tripId) {
+            const fit = await fetchTripMapBounds(conn, tripId);
+            if (!cancelled && fit) {
+              setViewState(fit.viewState);
+              setBoundBox(fit.boundBox as [number[], number[]]);
+              setFitZoom(fit.viewState.zoom);
+              return;
+            }
+          }
+        } catch { /* fallback */ }
+        const fit = await fitBoundsToPoints(conn, allPoints);
+        if (cancelled || !fit) return;
+        setViewState({ ...fit.viewState, transitionDuration: 0 });
+        setBoundBox(fit.boundBox as [number[], number[]]);
+        setFitZoom(fit.viewState.zoom);
+      };
+      fetchBounds();
+      return () => { cancelled = true; };
+    }
+
+    if (stopsChanged) {
+      let cancelled = false;
+      fitBoundsToPoints(conn, allPoints).then((fit) => {
+        if (cancelled || !fit) return;
+        setViewState((prev: any) => ({ ...prev, ...fit.viewState, transitionDuration: 300 }));
+        setBoundBox(fit.boundBox as [number[], number[]]);
+        setFitZoom(fit.viewState.zoom);
+      });
+      return () => { cancelled = true; };
+    }
+  }, [conn, stopPoints, trips, externalPreview]);
+
+  // Stop status detection for coloring — identity-based via _idx
+  const stopStatusMap = useMemo(() => {
+    const map = new Map<number, string>();
+    if (originalStops && editable) {
+      const primaryStops = trips[0]?.stopTimes || [];
+      for (let i = 0; i < primaryStops.length; i++) {
+        const st = primaryStops[i];
+        const origIdx = (st as any)._idx;
+        const orig = origIdx != null && origIdx < originalStops.length ? originalStops[origIdx] : undefined;
+        if (!orig) {
+          map.set(i, "new");
+        } else if (
+          (st.stop_id || "") !== (orig.stop_id || "") ||
+          st.arrival_time !== orig.arrival_time ||
+          st.departure_time !== orig.departure_time
+        ) {
+          map.set(i, "edit");
+        }
+      }
+    }
+    return map;
+  }, [originalStops, editable, trips]);
+
+  if (stopPoints.length === 0 && !externalPreview) {
+    return <div className="rounded-md border p-4 text-sm text-muted-foreground text-center">No stop times available</div>;
+  }
+
+  if (!viewState) {
+    // Fallback: if conn isn't available but we have stop points, compute bounds locally
+    if (stopPoints.length > 0) {
+      let minLat = Infinity, maxLat = -Infinity, minLon = Infinity, maxLon = -Infinity;
+      for (const p of stopPoints) {
+        if (p.lat < minLat) minLat = p.lat; if (p.lat > maxLat) maxLat = p.lat;
+        if (p.lon < minLon) minLon = p.lon; if (p.lon > maxLon) maxLon = p.lon;
+      }
+      const fallbackView = { longitude: (minLon + maxLon) / 2, latitude: (minLat + maxLat) / 2, zoom: 12, pitch: 0, bearing: 0 };
+      const fallbackBox: [number[], number[]] = [[minLon, minLat], [maxLon, maxLat]];
+      setViewState(fallbackView);
+      setBoundBox(fallbackBox);
+      setFitZoom(12);
+    }
+    return <div className="h-[50vh] rounded-md border animate-pulse bg-muted" />;
+  }
+
+  // Popups — in edit mode, only show the editPanel (no StopPopup/SegmentPopup)
+  let popup: React.ReactNode | undefined;
+  if (editable) {
+    if (editPanel) {
+      popup = <div className="p-2 text-sm">{editPanel}</div>;
+    }
+  } else if (clickedStop) {
+    // Find stops with same stop_id or parent_station across trips (not by coordinates)
+    const colocatedStops = trips.length > 1
+      ? stopPoints.filter((p) => {
+          if (hiddenTripIndices.has(p.tripIdx)) return false;
+          if (clickedStop.stopId && p.stopId && clickedStop.stopId === p.stopId) return true;
+          if (clickedStop.parentStation && p.parentStation && clickedStop.parentStation === p.parentStation) return true;
+          return false;
+        })
+      : [];
+    const hasOverlap = colocatedStops.length > 1 && new Set(colocatedStops.map((p) => p.tripIdx)).size > 1;
+
+    popup = (
+      <div className="p-3 text-sm space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold">{clickedStop.name}</span>
+          <button onClick={(e) => { e.stopPropagation(); setViewState((prev: any) => ({ ...(prev || {}), longitude: clickedStop.lon, latitude: clickedStop.lat, zoom: Math.max(prev?.zoom ?? 12, 15), pitch: 0, bearing: 0, transitionDuration: 500 })); }}
+            className="ml-auto text-muted-foreground hover:text-foreground shrink-0" title="Zoom to stop">
+            <BiCrosshair className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => { setClickedStop(null); setPreviewStop(null); }}
+            className="text-muted-foreground hover:text-foreground shrink-0">
+            <BiX className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{clickedStop.stopId}</span>
+          {clickedStop.parentStation ? (
+            <Link to="/stations/info" search={{ selectedStationId: clickedStop.parentStation }}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+              <BiMapPin className="h-3 w-3" />Station
+            </Link>
+          ) : (
+            <Link to="/stops/map" search={{ selectedStopId: clickedStop.stopId }}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors">
+              <BiMapPin className="h-3 w-3" />Stop
+            </Link>
+          )}
+        </div>
+        {hasOverlap ? (
+          <div className="space-y-1 pt-1 border-t">
+            {colocatedStops.sort((a, b) => a.tripIdx - b.tripIdx).map((st) => (
+              <div key={`${st.tripIdx}-${st.stopIdx}`}
+                className="flex items-center gap-2 text-xs rounded px-1.5 py-1">
+                <span className="rounded-sm shrink-0" style={{ width: 10, height: 10, backgroundColor: TRIP_LINE_COLORS[st.tripIdx % TRIP_LINE_COLORS.length] }} />
+                <span className="truncate max-w-[80px]">{trips[st.tripIdx]?.trip?.trip_headsign || trips[st.tripIdx]?.trip?.trip_id || `Trip ${st.tripIdx + 1}`}</span>
+                <span className="text-muted-foreground">#{st.sequence}</span>
+                <span className="ml-auto text-muted-foreground whitespace-nowrap">
+                  {st.arrivalTime || "\u2014"}{st.departureTime && st.departureTime !== st.arrivalTime ? ` \u2192 ${st.departureTime}` : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="pt-1 border-t text-xs space-y-1">
+            {trips.length > 1 && (
+              <div className="flex items-center gap-1.5">
+                <span className="rounded-sm shrink-0" style={{ width: 10, height: 10, backgroundColor: TRIP_LINE_COLORS[clickedStop.tripIdx % TRIP_LINE_COLORS.length] }} />
+                <span className="text-muted-foreground">{trips[clickedStop.tripIdx]?.trip?.trip_headsign || trips[clickedStop.tripIdx]?.trip?.trip_id}</span>
+                <span className="text-muted-foreground">#{clickedStop.sequence}</span>
+              </div>
+            )}
+            {clickedStop.arrivalTime && <div>Arr: {clickedStop.arrivalTime}</div>}
+            {clickedStop.departureTime && <div>Dep: {clickedStop.departureTime}</div>}
+          </div>
+        )}
+      </div>
+    );
+  } else if (clickedSegment) {
+    // Find matching segments using identity key: parent_station (if exists) or stop_id
+    const stopKey = (stopId?: string, station?: string) =>
+      (station && station.length > 0) ? station : (stopId || '');
+    const clickedFromKey = stopKey(clickedSegment.fromStopId, clickedSegment.fromStation);
+    const clickedToKey = stopKey(clickedSegment.toStopId, clickedSegment.toStation);
+    const matchingSegs = trips.length > 1
+      ? segments.filter((s) => {
+          if (hiddenTripIndices.has(s.tripIdx)) return false;
+          const sFromKey = stopKey(s.fromStopId, s.fromStation);
+          const sToKey = stopKey(s.toStopId, s.toStation);
+          // Match both directions (trips may run opposite ways on the same track)
+          return (sFromKey === clickedFromKey && sToKey === clickedToKey) ||
+                 (sFromKey === clickedToKey && sToKey === clickedFromKey);
+        })
+      : [clickedSegment];
+
+    const fromSec = (t?: string) => { if (!t) return null; const p = t.split(":").map(Number); return p.length >= 2 ? p[0] * 3600 + p[1] * 60 + (p[2] || 0) : null; };
+    const durMin = (from?: string, to?: string) => { const a = fromSec(from), b = fromSec(to); return a != null && b != null ? Math.round((b - a) / 60) : null; };
+
+    popup = (
+      <div className="p-3 text-sm space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-xs text-muted-foreground">Segment</span>
+          <button onClick={(e) => {
+            e.stopPropagation();
+            const midLon = (clickedSegment.from[0] + clickedSegment.to[0]) / 2;
+            const midLat = (clickedSegment.from[1] + clickedSegment.to[1]) / 2;
+            setViewState((prev: any) => ({ ...(prev || {}), longitude: midLon, latitude: midLat, zoom: Math.max(prev?.zoom ?? 12, 15), pitch: 0, bearing: 0, transitionDuration: 500 }));
+          }} className="ml-auto text-muted-foreground hover:text-foreground shrink-0" title="Zoom to segment">
+            <BiCrosshair className="h-3.5 w-3.5" />
+          </button>
+          <button onClick={() => setClickedSegment(null)} className="text-muted-foreground hover:text-foreground shrink-0">
+            <BiX className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="text-xs space-y-0.5">
+          <div className="font-medium">{clickedSegment.fromName}</div>
+          <div className="text-muted-foreground">{"\u2193"}</div>
+          <div className="font-medium">{clickedSegment.toName}</div>
+        </div>
+        {matchingSegs.length > 1 ? (
+          <div className="space-y-1 pt-1 border-t">
+            {matchingSegs.sort((a, b) => a.tripIdx - b.tripIdx).map((seg) => {
+              const dur = durMin(seg.fromTime, seg.toTime);
+              return (
+                <div key={seg.tripIdx}
+                  className={`flex items-center gap-2 text-xs rounded px-1.5 py-1 ${clickedSegment.tripIdx === seg.tripIdx ? "bg-primary/10 font-medium" : ""}`}>
+                  <span className="rounded-full shrink-0" style={{ width: 6, height: 6, backgroundColor: TRIP_LINE_COLORS[seg.tripIdx % TRIP_LINE_COLORS.length] }} />
+                  <span className="truncate max-w-[80px]">{trips[seg.tripIdx]?.trip?.trip_headsign || trips[seg.tripIdx]?.trip?.trip_id || `Trip ${seg.tripIdx + 1}`}</span>
+                  <span className="ml-auto text-muted-foreground whitespace-nowrap">
+                    {seg.fromTime || "\u2014"} {"\u2192"} {seg.toTime || "\u2014"}
+                    {dur != null && <span className="ml-1 text-[10px] opacity-70">({dur}m)</span>}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-xs space-y-0.5 pt-1 border-t">
+            {trips.length > 1 && (
+              <div className="flex items-center gap-1.5 mb-1">
+                <span className="rounded-full shrink-0" style={{ width: 6, height: 6, backgroundColor: TRIP_LINE_COLORS[clickedSegment.tripIdx % TRIP_LINE_COLORS.length] }} />
+                <span className="text-muted-foreground">{trips[clickedSegment.tripIdx]?.trip?.trip_headsign || trips[clickedSegment.tripIdx]?.trip?.trip_id}</span>
+              </div>
+            )}
+            <div>Dep: {clickedSegment.fromTime || "\u2014"}</div>
+            <div>Arr: {clickedSegment.toTime || "\u2014"}</div>
+            {(() => { const d = durMin(clickedSegment.fromTime, clickedSegment.toTime); return d != null ? <div className="text-muted-foreground">{d} min</div> : null; })()}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const legend = trips.length > 1 && !externalHidden ? (
+    <div className="rounded-md border bg-background/90 backdrop-blur-sm p-2 text-xs space-y-1">
+      {trips.map(({ trip }, idx) => {
+        const isHidden = hiddenTripIndices.has(idx);
+        return (
+          <div key={trip.trip_id}
+            className="flex items-center gap-1.5 cursor-pointer select-none hover:bg-muted/50 rounded px-1 py-0.5 transition-colors"
+            onClick={() => {
+              if (onToggleTripVisibility) onToggleTripVisibility(idx);
+              else setInternalHidden((prev) => { const next = new Set(prev); if (next.has(idx)) next.delete(idx); else next.add(idx); return next; });
+            }}>
+            <span className="rounded-full shrink-0 border" style={{
+              width: 8, height: 8,
+              backgroundColor: isHidden ? "transparent" : TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length],
+              borderColor: TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length],
+            }} />
+            <span className={`truncate max-w-[150px] ${isHidden ? "line-through opacity-50" : ""}`}>{trip.trip_headsign || trip.trip_id}</span>
+          </div>
+        );
+      })}
+    </div>
+  ) : undefined;
+
+  return (
+    <div className="rounded-md border shadow-sm">
+      <div className="h-[50vh] overflow-hidden">
+        <MapContainer
+          instructionText={editable
+            ? (clickedStop ? `Stop #${clickedStop.sequence} selected` : "Click a stop to select and edit")
+            : "Click stops or segments for details"}
+          clickPopup={popup}
+          popupPosition="bottom-right"
+          showLegend={Boolean(legend)}
+          legendContent={legend}
+        >
+          <MapSection
+            stopPoints={stopPoints}
+            segments={segments}
+            paths={paths}
+            clickedStop={clickedStop}
+            clickedSegment={clickedSegment}
+            viewState={viewState}
+            setViewState={setViewState}
+            boundBox={boundBox}
+            fitZoom={fitZoom}
+            editable={editable}
+            deletedStopIndices={deletedStopIndices}
+            selectedStopIdx={selectedStopIdx}
+            stopStatusMap={stopStatusMap}
+            previewStop={previewStop}
+            externalPreview={externalPreview}
+            onDragStop={onDragStop}
+            onSelectStop={onSelectStop}
+            onClickStop={(stop) => {
+              setClickedStop(stop);
+              if (stop && onClickAnyStop) {
+                onClickAnyStop({ tripIdx: stop.tripIdx, stopIdx: stop.stopIdx, name: stop.name, stopId: stop.stopId, arrivalTime: stop.arrivalTime, departureTime: stop.departureTime, parentStation: stop.parentStation });
+              }
+            }}
+            onClickSegment={setClickedSegment}
+            hiddenTripIndices={hiddenTripIndices}
+          />
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Map/types.ts
+++ b/packages/web/src/client/Trips/components/Map/types.ts
@@ -1,0 +1,64 @@
+import type { TripInfo, TripStopTime, EditableStop } from "@/lib/tripUtils";
+
+export type StopPoint = {
+  lon: number;
+  lat: number;
+  name: string;
+  stopId: string;
+  sequence: number;
+  stopIdx: number;
+  arrivalTime?: string;
+  departureTime?: string;
+  parentStation?: string;
+  tripIdx: number;
+  disabled?: boolean;
+};
+
+export type Segment = {
+  from: [number, number];
+  to: [number, number];
+  fromIdx: number;
+  toIdx: number;
+  fromName: string;
+  toName: string;
+  fromTime?: string;
+  toTime?: string;
+  tripIdx: number;
+  disabled?: boolean;
+  fromStopId?: string;
+  toStopId?: string;
+  fromStation?: string;
+  toStation?: string;
+};
+
+export type RouteStop = {
+  stop_id: string;
+  stop_name: string;
+  stop_lat?: number;
+  stop_lon?: number;
+  location_type_name?: string;
+  parent_station?: string;
+};
+
+export interface TripMapProps {
+  trips: Array<{ trip: TripInfo; stopTimes: (TripStopTime | EditableStop)[] }>;
+  editable?: boolean;
+  onDeleteStop?: (stopIdx: number) => void;
+  onRestoreStop?: (stopIdx: number) => void;
+  deletedStopIndices?: Set<number>;
+  onDragStop?: (stopIdx: number, lat: number, lon: number) => void;
+  onUpdateStopTime?: (stopIdx: number, field: "arrival_time" | "departure_time", value: string) => void;
+  onReplaceStop?: (stopIdx: number, newStop: RouteStop) => void;
+  onAddStop?: (stop: RouteStop, arrival: string, departure: string) => void;
+  routeStops?: RouteStop[];
+  onCreateStop?: () => void;
+  addStopPreview?: { lon: number; lat: number; name: string; stopSequence?: number } | null;
+  originalStops?: Array<{ stop_id?: string; arrival_time?: string; departure_time?: string }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  editPanel?: React.ReactNode;
+  zoomToStopRef?: React.MutableRefObject<((stopIdx: number) => void) | null>;
+  onClickAnyStop?: (stop: { tripIdx: number; stopIdx: number; name: string; stopId: string; arrivalTime?: string; departureTime?: string; parentStation?: string }) => void;
+  hiddenTripIndices?: Set<number>;
+  onToggleTripVisibility?: (idx: number) => void;
+}

--- a/packages/web/src/client/Trips/components/Timeline/EditableTimeline.tsx
+++ b/packages/web/src/client/Trips/components/Timeline/EditableTimeline.tsx
@@ -1,0 +1,680 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type EditableStop,
+  type TripInfo,
+  type RouteStopOption,
+  TRIP_LINE_COLORS,
+  timeToSec,
+  secToTime,
+  fmtTime,
+} from "@/lib/tripUtils";
+
+export function EditableTimeline({ trips, onUpdateStop, onUpdateStopBoth, routeStops: _routeStops = [], onAddStop: _onAddStop, onCreateStop: _onCreateStop,
+  addStopPreview, onAddArrivalChange, onAddDepartureChange, readOnly: _readOnly, originalStops, selectedStopIdx, onSelectStop, onInsertAt, onDragStart: onDragStartCb }: {
+  trips: Array<{ trip: TripInfo; stops: EditableStop[] }>;
+  onUpdateStop: (tripIdx: number, stopIdx: number, field: "arrival_time" | "departure_time", value: string) => void;
+  onUpdateStopBoth?: (tripIdx: number, stopIdx: number, arrival: string, departure: string) => void;
+  routeStops?: RouteStopOption[];
+  onAddStop?: (stop: RouteStopOption, arrival: string, departure: string) => void;
+  onCreateStop?: () => void;
+  addStopPreview?: { name: string; arrival: string; departure: string; stopSequence?: number };
+  onAddArrivalChange?: (v: string) => void;
+  onAddDepartureChange?: (v: string) => void;
+  readOnly?: boolean;
+  originalStops?: Array<{ stop_id?: string; arrival_time?: string; departure_time?: string }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  onInsertAt?: (seq: number, arrival: string, departure: string) => void;
+  onDragStart?: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const showAddPanel = false;
+  const [, setAddArrival] = useState("");
+  const [, setAddDeparture] = useState("");
+  const selectedAddStop = undefined as RouteStopOption | undefined;
+  const [placingPreview, setPlacingPreview] = useState<{ sec: number; depSec?: number } | null>(null);
+  const isPlacingRef = useRef<false | "arr" | "dep">(false);
+  const [hoverX, setHoverX] = useState<number | null>(null);
+
+  // Clear stale preview when parent's add completes (addStopPreview becomes undefined)
+  const prevAddStopPreviewRef = useRef(addStopPreview);
+  if (prevAddStopPreviewRef.current && !addStopPreview) {
+    setPlacingPreview(null);
+    isPlacingRef.current = false;
+  }
+  prevAddStopPreviewRef.current = addStopPreview;
+
+  const dragRef = useRef<{ tripIdx: number; stopIdx: number; field: "arrival_time" | "departure_time" | "both"; offsetSec?: number; duration?: number } | null>(null);
+  const didDragRef = useRef(false);
+  const interactiveClickRef = useRef(false);
+
+  // global time bounds
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  let maxStops = 0;
+  for (const { stops } of trips) {
+    if (stops.length > maxStops) maxStops = stops.length;
+    for (const s of stops) {
+      const arr = timeToSec(s.arrival_time);
+      const dep = timeToSec(s.departure_time);
+      if (arr != null) { if (arr < minTime) minTime = arr; if (arr > maxTime) maxTime = arr; }
+      if (dep != null) { if (dep < minTime) minTime = dep; if (dep > maxTime) maxTime = dep; }
+    }
+  }
+
+  // Include preview times so timeline renders when only a preview exists
+  if (addStopPreview) {
+    const pArr = timeToSec(addStopPreview.arrival);
+    const pDep = timeToSec(addStopPreview.departure);
+    if (pArr != null) { if (pArr < minTime) minTime = pArr; if (pArr > maxTime) maxTime = pArr; }
+    if (pDep != null) { if (pDep < minTime) minTime = pDep; if (pDep > maxTime) maxTime = pDep; }
+  }
+
+  const paddingLeft = 40;
+  const paddingRight = 60;
+
+  // Zoom hooks — must be called before early returns to satisfy Rules of Hooks
+  const zoomRef = useRef(zoomLevel);
+  zoomRef.current = zoomLevel;
+  const baseWidthRef = useRef(Math.max(800, maxStops * 80));
+  baseWidthRef.current = Math.max(800, maxStops * 80);
+
+  const handleWheel = useCallback((e: WheelEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Horizontal scroll (deltaX or shift+wheel) → pan along time axis natively
+    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return; // let browser handle horizontal scroll
+
+    // Vertical scroll → zoom time intervals
+    e.preventDefault();
+    const rect = container.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left + container.scrollLeft;
+    const curZoom = zoomRef.current;
+    const bw = baseWidthRef.current;
+    const oldTotal = paddingLeft + Math.round(bw * curZoom) + paddingRight;
+    const mouseRatio = mouseX / oldTotal;
+
+    const delta = e.deltaY > 0 ? 0.85 : 1.18;
+    const newZoom = Math.max(0.3, Math.min(8, curZoom * delta));
+    zoomRef.current = newZoom;
+    setZoomLevel(newZoom);
+
+    requestAnimationFrame(() => {
+      const newTotal = paddingLeft + Math.round(bw * newZoom) + paddingRight;
+      container.scrollLeft = Math.max(0, mouseRatio * newTotal - (e.clientX - rect.left));
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  if (minTime === Infinity) {
+    return null;
+  }
+
+  // Add padding so stops can be dragged past current min/max
+  const timePad = Math.max(1800, Math.round((maxTime - minTime) * 0.2)); // 30 min or 20% of range
+  const chartMinTime = Math.max(0, minTime - timePad);
+  const chartMaxTime = maxTime + timePad;
+  const timeSpan = chartMaxTime - chartMinTime || 1;
+  const labelHeight = 70;
+  const laneHeight = 70;
+  const laneGap = 20;
+  const baseChartWidth = Math.max(800, maxStops * 80);
+  const chartWidth = Math.round(baseChartWidth * zoomLevel);
+  const totalWidth = paddingLeft + chartWidth + paddingRight;
+  const totalHeight = labelHeight + trips.length * (laneHeight + laneGap) + 30;
+  const timeToX = (sec: number) => Math.round(paddingLeft + ((sec - chartMinTime) / timeSpan) * chartWidth);
+  const xToTime = (x: number) => Math.round(chartMinTime + ((x - paddingLeft) / chartWidth) * timeSpan);
+
+  const stepSeconds = Math.max(300, Math.ceil(timeSpan / Math.max(8, Math.floor(chartWidth / 80)) / 300) * 300);
+  const axisTicks: number[] = [];
+  for (let t = Math.floor(chartMinTime / stepSeconds) * stepSeconds; t <= chartMaxTime + stepSeconds; t += stepSeconds) {
+    if (t >= chartMinTime && t <= chartMaxTime) axisTicks.push(t);
+  }
+  const axisY = totalHeight - 20;
+
+  const showTip = (e: React.MouseEvent, text: string) => {
+    const container = containerRef.current;
+    const tip = tooltipRef.current;
+    if (!container || !tip) return;
+    const rect = container.getBoundingClientRect();
+    tip.style.left = `${e.clientX - rect.left + 12}px`;
+    tip.style.top = `${e.clientY - rect.top - 10}px`;
+    tip.style.display = "block";
+    tip.innerHTML = text.split("\n").map((line, i) =>
+      `<div class="${i === 0 ? "font-medium" : "text-muted-foreground"}">${line}</div>`
+    ).join("");
+  };
+  const hideTip = () => { if (tooltipRef.current) tooltipRef.current.style.display = "none"; };
+
+  const handleMouseDown = (e: React.MouseEvent, tripIdx: number, stopIdx: number, field: "arrival_time" | "departure_time" | "both", offsetSec?: number) => {
+    e.preventDefault(); // prevent text selection during drag
+    e.stopPropagation();
+    didDragRef.current = false;
+    interactiveClickRef.current = true;
+    let dur = 0;
+    if (field === "both") {
+      const stop = trips[tripIdx]?.stops[stopIdx];
+      const a = timeToSec(stop?.arrival_time);
+      const d = timeToSec(stop?.departure_time);
+      dur = (a != null && d != null) ? d - a : 0;
+    }
+    dragRef.current = { tripIdx, stopIdx, field, offsetSec: offsetSec ?? 0, duration: dur };
+    onDragStartCb?.();
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (!dragRef.current) return;
+    didDragRef.current = true;
+    const svg = e.currentTarget;
+    const rect = svg.getBoundingClientRect();
+    const svgX = e.clientX - rect.left;
+    const rawSec = Math.max(0, xToTime(svgX));
+    const sec = Math.round(rawSec / 60) * 60;
+    const { tripIdx, stopIdx, field, duration } = dragRef.current;
+    if (field === "both") {
+      const dur = duration ?? 0;
+      const newArr = Math.max(0, sec);
+      if (stopIdx === -1) {
+        // Preview stop drag — update parent's add times
+        onAddArrivalChange?.(secToTime(newArr));
+        onAddDepartureChange?.(secToTime(newArr + dur));
+      } else if (onUpdateStopBoth) {
+        onUpdateStopBoth(tripIdx, stopIdx, secToTime(newArr), secToTime(newArr + dur));
+      } else {
+        onUpdateStop(tripIdx, stopIdx, "arrival_time", secToTime(newArr));
+        onUpdateStop(tripIdx, stopIdx, "departure_time", secToTime(newArr + dur));
+      }
+    } else {
+      // Clamp so arrival never exceeds departure and vice versa
+      const stop = trips[tripIdx]?.stops[stopIdx];
+      let clampedSec = sec;
+      if (field === "arrival_time") {
+        const depSec = timeToSec(stop?.departure_time);
+        if (depSec != null && sec > depSec) clampedSec = depSec;
+      } else if (field === "departure_time") {
+        const arrSec = timeToSec(stop?.arrival_time);
+        if (arrSec != null && sec < arrSec) clampedSec = arrSec;
+      }
+      onUpdateStop(tripIdx, stopIdx, field, secToTime(clampedSec));
+    }
+
+    const tip = tooltipRef.current;
+    if (tip && containerRef.current) {
+      const cRect = containerRef.current.getBoundingClientRect();
+      tip.style.left = `${e.clientX - cRect.left + 12}px`;
+      tip.style.top = `${e.clientY - cRect.top - 10}px`;
+      tip.style.display = "block";
+      const fieldLabel = field === "both" ? "" : field === "arrival_time" ? "arr " : "dep ";
+      tip.innerHTML = `<div class="font-medium">${fieldLabel}${fmtTime(field === "both" ? sec : (field === "arrival_time" ? Math.min(sec, timeToSec(trips[tripIdx]?.stops[stopIdx]?.departure_time) ?? sec) : Math.max(sec, timeToSec(trips[tripIdx]?.stops[stopIdx]?.arrival_time) ?? sec)))}</div>`;
+    }
+  };
+
+  const handleMouseUp = () => {
+    dragRef.current = null;
+    hideTip();
+  };
+
+  return (
+    <div className="rounded-md border shadow-sm overflow-hidden">
+      <div className="border-b px-4 py-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {trips.map(({ trip }, idx) => (
+            <span key={trip.trip_id} className="flex items-center gap-1.5">
+              <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length] }} />
+              <span className="truncate max-w-[200px] font-medium">{trip.trip_headsign || trip.trip_id}</span>
+            </span>
+          ))}
+          <span className="ml-2 pl-2 border-l italic">
+            {addStopPreview || (showAddPanel && selectedAddStop) ? "Click timeline to place stop, drag to set range" : onInsertAt ? "Click to add stop, click bar to edit" : "Drag dots to change times"} · Scroll to zoom
+          </span>
+        </div>
+      </div>
+      <div ref={containerRef} className="overflow-x-auto relative">
+        <div ref={tooltipRef} className="absolute z-50 pointer-events-none rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md font-medium" style={{ display: "none" }} />
+        <svg
+          width={totalWidth} height={totalHeight} className="block"
+          onMouseMove={(e) => {
+            handleMouseMove(e);
+            // Track hover position for cursor indicator (only when not dragging)
+            if (!dragRef.current && !isPlacingRef.current && onInsertAt) {
+              const svgRect = e.currentTarget.getBoundingClientRect();
+              const x = e.clientX - svgRect.left;
+              setHoverX(x);
+            } else {
+              setHoverX(null);
+            }
+            // Dragging preview handle (arr or dep)
+            if (isPlacingRef.current) {
+              const svgRect = e.currentTarget.getBoundingClientRect();
+              const svgX = e.clientX - svgRect.left;
+              const sec = Math.max(0, Math.round(xToTime(svgX) / 60) * 60);
+              if (isPlacingRef.current === "arr") {
+                const depSec = placingPreview?.depSec ?? (addStopPreview ? timeToSec(addStopPreview.departure) : undefined) ?? sec;
+                const arrSec = Math.min(sec, depSec);
+                if (placingPreview) setPlacingPreview((prev) => prev ? { ...prev, sec: arrSec } : null);
+                setAddArrival(secToTime(arrSec));
+                onAddArrivalChange?.(secToTime(arrSec));
+              } else {
+                const arrSec = placingPreview?.sec ?? (addStopPreview ? timeToSec(addStopPreview.arrival) : undefined) ?? sec;
+                const depSec = Math.max(sec, arrSec);
+                if (placingPreview) setPlacingPreview((prev) => prev ? { ...prev, depSec } : null);
+                setAddDeparture(secToTime(depSec));
+                onAddDepartureChange?.(secToTime(depSec));
+              }
+              const tip = tooltipRef.current;
+              if (tip && containerRef.current) {
+                const cRect = containerRef.current.getBoundingClientRect();
+                tip.style.left = `${e.clientX - cRect.left + 12}px`;
+                tip.style.top = `${e.clientY - cRect.top - 10}px`;
+                tip.style.display = "block";
+                tip.textContent = `${isPlacingRef.current === "arr" ? "arr" : "dep"} ${fmtTime(sec)}`;
+              }
+            }
+          }}
+          onMouseUp={() => {
+            handleMouseUp();
+            if (isPlacingRef.current) { isPlacingRef.current = false; hideTip(); }
+            // Clear after a tick so click event (which fires after mouseup) can still check them,
+            // but they won't be stale for the NEXT click if no click event fired (drag ended on different element)
+            requestAnimationFrame(() => { interactiveClickRef.current = false; didDragRef.current = false; });
+          }}
+          onMouseLeave={() => { handleMouseUp(); hideTip(); isPlacingRef.current = false; didDragRef.current = false; interactiveClickRef.current = false; setHoverX(null); }}
+          onClick={(e) => {
+            if (interactiveClickRef.current) { interactiveClickRef.current = false; return; }
+            if (didDragRef.current) { didDragRef.current = false; return; }
+            if (dragRef.current || isPlacingRef.current) return;
+            const svgRect = e.currentTarget.getBoundingClientRect();
+            const svgX = e.clientX - svgRect.left;
+            const sec = Math.max(0, Math.round(xToTime(svgX) / 60) * 60);
+            const time = secToTime(sec);
+            if (addStopPreview) {
+              // Add preview active — update times at clicked position
+              const primaryStops = trips[0]?.stops || [];
+              let insertPos = primaryStops.length + 1;
+              for (let i = 0; i < primaryStops.length; i++) {
+                const sSec = timeToSec(primaryStops[i].arrival_time) ?? timeToSec(primaryStops[i].departure_time);
+                if (sSec != null && sSec > sec) { insertPos = i + 1; break; }
+              }
+              onInsertAt?.(insertPos, time, time);
+            } else if (showAddPanel && selectedAddStop) {
+              setAddArrival(time);
+              setAddDeparture(time);
+              setPlacingPreview({ sec, depSec: sec });
+            } else if (selectedStopIdx != null && onSelectStop) {
+              onSelectStop(null);
+            } else if (onInsertAt) {
+              // Compute insert position based on clicked time
+              const primaryStops = trips[0]?.stops || [];
+              let insertPos = primaryStops.length + 1;
+              for (let i = 0; i < primaryStops.length; i++) {
+                const sSec = timeToSec(primaryStops[i].arrival_time) ?? timeToSec(primaryStops[i].departure_time);
+                if (sSec != null && sSec > sec) { insertPos = i + 1; break; }
+              }
+              onInsertAt(insertPos, time, time);
+            } else {
+              const margin = Math.max(60, Math.round(timeSpan / chartWidth * 10));
+              const stopsAtTime: string[] = [];
+              for (const { stops } of trips) {
+                for (const s of stops) {
+                  const a = timeToSec(s.arrival_time);
+                  const d = timeToSec(s.departure_time);
+                  const sMin = a ?? d;
+                  const sMax = d ?? a;
+                  if (sMin != null && sMax != null && sec >= sMin - margin && sec <= sMax + margin) {
+                    const name = s.stop_name || s.stop_id || "Stop";
+                    const timeStr = sMin !== sMax ? `${fmtTime(sMin)}-${fmtTime(sMax)}` : fmtTime(sMin);
+                    stopsAtTime.push(`${name} (${timeStr})`);
+                  }
+                }
+              }
+              const tip = tooltipRef.current;
+              if (tip && containerRef.current) {
+                const cRect = containerRef.current.getBoundingClientRect();
+                tip.style.left = `${e.clientX - cRect.left + 12}px`;
+                tip.style.top = `${e.clientY - cRect.top - 10}px`;
+                tip.style.display = "block";
+                const lines = [`<div class="font-medium">${fmtTime(sec)}</div>`];
+                for (const s of stopsAtTime) {
+                  lines.push(`<div class="text-muted-foreground">${s}</div>`);
+                }
+                tip.innerHTML = lines.join("");
+                setTimeout(() => { tip.style.display = "none"; }, 3000);
+              }
+            }
+          }}
+          style={{ cursor: isPlacingRef.current ? "ew-resize" : dragRef.current ? "grabbing" : (addStopPreview || (showAddPanel && selectedAddStop) ? "crosshair" : "default") }}
+        >
+          {/* Background */}
+          <rect x={0} y={0} width={totalWidth} height={totalHeight} fill="transparent" />
+
+          {/* Hover cursor indicator */}
+          {hoverX != null && hoverX >= paddingLeft && hoverX <= paddingLeft + chartWidth && (
+            <g style={{ pointerEvents: "none" }}>
+              <line x1={hoverX} y1={labelHeight - 10} x2={hoverX} y2={axisY}
+                stroke="#f59e0b" strokeWidth={1} strokeDasharray="4,3" opacity={0.4} />
+              <text x={hoverX} y={axisY + 16} textAnchor="middle" fill="#f59e0b" fontSize={10} opacity={0.6}>
+                {fmtTime(Math.max(0, Math.round(xToTime(hoverX) / 60) * 60))}
+              </text>
+            </g>
+          )}
+
+          {/* Time axis */}
+          <line x1={paddingLeft} y1={axisY} x2={paddingLeft + chartWidth} y2={axisY} stroke="currentColor" strokeWidth={1} opacity={0.2} />
+          {axisTicks.map((t) => {
+            const x = timeToX(t);
+            return (
+              <g key={t}>
+                <line x1={x} y1={axisY - 4} x2={x} y2={axisY + 4} stroke="currentColor" strokeWidth={1} opacity={0.3} />
+                <line x1={x} y1={labelHeight - 10} x2={x} y2={axisY} stroke="currentColor" strokeWidth={0.5} strokeDasharray="3,4" opacity={0.08} />
+                <text x={x} y={axisY + 16} textAnchor="middle" fill="currentColor" fontSize={11} opacity={0.5}>{fmtTime(t)}</text>
+              </g>
+            );
+          })}
+
+          {/* Trip lanes */}
+          {trips.map(({ trip, stops }, ti) => {
+            const color = TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length];
+            const baseLaneY = labelHeight + ti * (laneHeight + laneGap) + laneHeight / 2;
+
+            const pts = stops.flatMap((s, si) => {
+              const arrSec = timeToSec(s.arrival_time);
+              const depSec = timeToSec(s.departure_time);
+              const sec = depSec ?? arrSec;
+              return sec != null ? [{ ...s, si, sec, arrSec, depSec }] : [];
+            });
+
+            // Detect changed/new stops for green highlighting
+            const changedIndices = new Set<number>();
+            if (originalStops && ti === 0) {
+              const remaining = [...originalStops];
+              for (let i = 0; i < stops.length; i++) {
+                const idx = remaining.findIndex((o) => o.stop_id === (stops[i].stop_id || "") && o.arrival_time === stops[i].arrival_time && o.departure_time === stops[i].departure_time);
+                if (idx !== -1) remaining.splice(idx, 1);
+                else changedIndices.add(i);
+              }
+            }
+
+            // Compute vertical offsets — only shift when bars visually overlap in pixels
+            const barH = 16;
+            const barGap = 2;
+            const minBarPx = 14;
+
+            // If there's a preview, compute its pixel range so existing overlapping stops shift up
+            let previewLeft = -Infinity;
+            let previewRight = -Infinity;
+            const extArrSec = addStopPreview ? timeToSec(addStopPreview.arrival) : undefined;
+            const extDepSec = addStopPreview ? timeToSec(addStopPreview.departure) : undefined;
+            if (placingPreview && ti === 0) {
+              const pA = placingPreview.sec;
+              const pD = placingPreview.depSec ?? pA;
+              previewLeft = timeToX(pA) - (pA === pD ? minBarPx / 2 : 0);
+              previewRight = timeToX(pD) + (pA === pD ? minBarPx / 2 : 0);
+            } else if (extArrSec != null && ti === 0) {
+              const pA = extArrSec;
+              const pD = extDepSec ?? pA;
+              previewLeft = timeToX(pA) - (pA === pD ? minBarPx / 2 : 0);
+              previewRight = timeToX(pD) + (pA === pD ? minBarPx / 2 : 0);
+            }
+            // Preview sequence for label shifting
+            const previewSeq = addStopPreview?.stopSequence;
+            const hasTimePreview = previewLeft > -Infinity;
+
+            const offsets: number[] = [];
+            for (let i = 0; i < pts.length; i++) {
+              const aI = pts[i].arrSec ?? pts[i].sec;
+              const dI = pts[i].depSec ?? pts[i].sec;
+              const leftI = timeToX(aI) - (aI === dI ? minBarPx / 2 : 0);
+              const rightI = timeToX(dI) + (aI === dI ? minBarPx / 2 : 0);
+              let row = 0;
+
+              // Check overlap with preview (preview sits on row 0, so existing must shift up)
+              if (previewLeft > -Infinity && leftI < previewRight && rightI > previewLeft) {
+                row = 1;
+              }
+
+              // Check overlap with other existing bars
+              for (let j = 0; j < i; j++) {
+                if (offsets[j] !== row) continue;
+                const aJ = pts[j].arrSec ?? pts[j].sec;
+                const dJ = pts[j].depSec ?? pts[j].sec;
+                const leftJ = timeToX(aJ) - (aJ === dJ ? minBarPx / 2 : 0);
+                const rightJ = timeToX(dJ) + (aJ === dJ ? minBarPx / 2 : 0);
+                if (leftI < rightJ && rightI > leftJ) {
+                  row++;
+                }
+              }
+              offsets.push(row);
+            }
+
+            return (
+              <g key={trip.trip_id}>
+                {/* Line — spans min to max time across all stops (including preview) */}
+                {(pts.length > 0) && (() => {
+                  let lineMin = Infinity, lineMax = -Infinity;
+                  for (const p of pts) {
+                    const a = p.arrSec ?? p.sec;
+                    const d = p.depSec ?? p.sec;
+                    if (a < lineMin) lineMin = a;
+                    if (d > lineMax) lineMax = d;
+                  }
+                  // Extend line to include preview stop
+                  if (ti === 0) {
+                    if (placingPreview) {
+                      if (placingPreview.sec < lineMin) lineMin = placingPreview.sec;
+                      const pd = placingPreview.depSec ?? placingPreview.sec;
+                      if (pd > lineMax) lineMax = pd;
+                    } else if (addStopPreview) {
+                      const pa = timeToSec(addStopPreview.arrival);
+                      const pd = timeToSec(addStopPreview.departure);
+                      if (pa != null && pa < lineMin) lineMin = pa;
+                      if (pd != null && pd > lineMax) lineMax = pd;
+                      if (pa != null && pa > lineMax) lineMax = pa;
+                      if (pd != null && pd < lineMin) lineMin = pd;
+                    }
+                  }
+                  if (lineMin === Infinity) return null;
+                  return <line x1={timeToX(lineMin)} y1={baseLaneY} x2={timeToX(lineMax)} y2={baseLaneY}
+                    stroke={color} strokeWidth={2} opacity={0.3} />;
+                })()}
+
+                {/* Stop range bars */}
+                {pts.map((p, pi) => {
+                  const aSec = p.arrSec ?? p.sec;
+                  const dSec = p.depSec ?? p.sec;
+                  const arrX = timeToX(aSec);
+                  const depX = timeToX(dSec);
+                  const barW = Math.max(depX - arrX, 22);
+                  const barX = depX > arrX ? arrX : arrX - 11;
+                  const row = offsets[pi] || 0;
+                  const laneY = baseLaneY - row * (barH + barGap);
+                  const displaySeq = hasTimePreview && previewSeq && (p.si + 1) >= previewSeq ? p.si + 2 : p.si + 1;
+                  const shortId = (p.stop_id || "").length > 10 ? (p.stop_id || "").slice(0, 8) + "..." : (p.stop_id || "");
+                  const isChanged = changedIndices.has(p.si);
+                  const isSelected = ti === 0 && selectedStopIdx === p.si;
+                  const barColor = isSelected ? "#f59e0b" : isChanged ? "#22c55e" : color;
+                  const labelColor = isSelected ? "#f59e0b" : isChanged ? "#22c55e" : "currentColor";
+                  const idLabel = `#${displaySeq} ${shortId}`;
+                  const stopLabel = (p.stop_name || p.stop_id || "");
+                  const tipText = aSec !== dSec ? `${stopLabel}\narr ${fmtTime(aSec)}  dep ${fmtTime(dSec)}` : `${stopLabel}\n${fmtTime(p.sec)}`;
+                  const handleW = 6;
+
+                  return (
+                    <g key={p.si} data-stop-idx={ti === 0 ? p.si : undefined}>
+                      {/* Label above */}
+                      <text x={barX} y={laneY - barH / 2 - 4} textAnchor="start"
+                        transform={`rotate(-45, ${barX}, ${laneY - barH / 2 - 4})`}
+                        fill={labelColor} fontSize={10} fontWeight={isChanged ? 700 : 500} opacity={0.7}
+                        style={{ pointerEvents: "none" }}>{idLabel}</text>
+
+                      {/* Invisible hover zone for tooltip */}
+                      <rect x={barX - 4} y={laneY - barH / 2 - 4} width={barW + 8} height={barH + 8}
+                        fill="transparent" style={{ pointerEvents: "visible" }}
+                        onMouseMove={(e) => showTip(e, tipText)}
+                        onMouseLeave={hideTip} />
+
+                      {/* Left handle — arrival */}
+                      <rect x={barX} y={laneY - barH / 2} width={handleW} height={barH}
+                        rx={2} fill={barColor} opacity={isSelected ? 0.8 : 0.6}
+                        style={{ cursor: "w-resize" }}
+                        onClick={(e) => { e.stopPropagation(); if (ti === 0 && onSelectStop && !didDragRef.current) onSelectStop(isSelected ? null : p.si); }}
+                        onMouseDown={(e) => handleMouseDown(e, ti, p.si, "arrival_time")} />
+
+                      {/* Main bar body — drag to move whole range, click to select */}
+                      <rect x={barX + handleW} y={laneY - barH / 2} width={Math.max(barW - handleW * 2, 4)} height={barH}
+                        rx={2} fill={barColor} opacity={isSelected ? 0.5 : 0.3}
+                        style={{ cursor: "grab" }}
+                        onClick={(e) => { e.stopPropagation(); if (ti === 0 && onSelectStop && !didDragRef.current) onSelectStop(isSelected ? null : p.si); }}
+                        onMouseDown={(e) => handleMouseDown(e, ti, p.si, "both", 0)} />
+
+                      {/* Right handle — departure */}
+                      <rect x={barX + barW - handleW} y={laneY - barH / 2}
+                        width={handleW} height={barH}
+                        rx={2} fill={barColor} opacity={isSelected ? 0.8 : 0.6}
+                        style={{ cursor: "e-resize" }}
+                        onClick={(e) => { e.stopPropagation(); if (ti === 0 && onSelectStop && !didDragRef.current) onSelectStop(isSelected ? null : p.si); }}
+                        onMouseDown={(e) => handleMouseDown(e, ti, p.si, "departure_time")} />
+
+                      {/* Time label below — only on base row */}
+                      {row === 0 && (
+                        <text x={barX + barW / 2} y={laneY + barH / 2 + 10} textAnchor="middle"
+                          fill={labelColor} fontSize={8} opacity={isChanged ? 0.6 : 0.4}
+                          style={{ pointerEvents: "none" }}>
+                          {aSec !== dSec ? `${fmtTime(aSec)}-${fmtTime(dSec)}` : fmtTime(p.sec)}
+                        </text>
+                      )}
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+
+          {/* Preview range bar for placing new stop */}
+          {placingPreview && trips.length > 0 && (() => {
+            const baseLaneY = labelHeight + 0 * (laneHeight + laneGap) + laneHeight / 2;
+            const aSec = placingPreview.sec;
+            const dSec = placingPreview.depSec ?? aSec;
+            const arrX = timeToX(aSec);
+            const depX = timeToX(dSec);
+            const barW = Math.max(depX - arrX, 22);
+            const barX = depX > arrX ? arrX : arrX - 11;
+            const barH = 16;
+            const handleW = 6;
+            const pvColor = "#f59e0b";
+
+            const laneY = baseLaneY;
+            const label = addStopPreview?.name || selectedAddStop?.stop_name || selectedAddStop?.stop_id || "New";
+            const shortLabel = label.length > 15 ? label.slice(0, 13) + "..." : label;
+            const seqNum = addStopPreview?.stopSequence;
+            const seqLabel = seqNum ? `#${seqNum}` : "";
+            return (
+              <g>
+                <text x={barX} y={laneY - barH / 2 - (seqLabel ? 14 : 4)} textAnchor="start"
+                  transform={`rotate(-45, ${barX}, ${laneY - barH / 2 - (seqLabel ? 14 : 4)})`}
+                  fill={pvColor} fontSize={10} fontWeight={700}
+                  style={{ pointerEvents: "none" }}>{shortLabel}</text>
+                {seqLabel && <text x={barX} y={laneY - barH / 2 - 4} textAnchor="start"
+                  transform={`rotate(-45, ${barX}, ${laneY - barH / 2 - 4})`}
+                  fill={pvColor} fontSize={8} opacity={0.7} style={{ pointerEvents: "none" }}>{seqLabel}</text>}
+
+                {/* Left handle */}
+                <rect x={barX} y={laneY - barH / 2} width={handleW} height={barH}
+                  rx={2} fill={pvColor} opacity={0.6}
+                  style={{ cursor: "w-resize" }}
+                  onMouseDown={(e) => { e.stopPropagation(); isPlacingRef.current = "arr"; interactiveClickRef.current = true; }} />
+
+                {/* Middle body — drag to move */}
+                <rect x={barX + handleW} y={laneY - barH / 2} width={Math.max(barW - handleW * 2, 4)} height={barH}
+                  rx={2} fill={pvColor} opacity={0.3} style={{ cursor: "grab" }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation(); e.preventDefault();
+                    interactiveClickRef.current = true;
+                    const dur = Math.max(0, dSec - aSec);
+                    dragRef.current = { tripIdx: 0, stopIdx: -1, field: "both", duration: dur };
+                    didDragRef.current = false;
+                  }} />
+
+                {/* Right handle */}
+                <rect x={barX + barW - handleW} y={laneY - barH / 2} width={handleW} height={barH}
+                  rx={2} fill={pvColor} opacity={0.6}
+                  style={{ cursor: "e-resize" }}
+                  onMouseDown={(e) => { e.stopPropagation(); isPlacingRef.current = "dep"; interactiveClickRef.current = true; }} />
+
+                {/* Time label */}
+                <text x={barX + barW / 2} y={laneY + barH / 2 + 12} textAnchor="middle"
+                  fill={pvColor} fontSize={9} opacity={0.7}
+                  style={{ pointerEvents: "none" }}>
+                  {aSec !== dSec ? `${fmtTime(aSec)}-${fmtTime(dSec)}` : fmtTime(aSec)}
+                </text>
+              </g>
+            );
+          })()}
+
+          {/* External preview from parent add-stop panel */}
+          {!placingPreview && addStopPreview && trips.length > 0 && (() => {
+            const aSec = timeToSec(addStopPreview.arrival);
+            const dSec = timeToSec(addStopPreview.departure);
+            if (aSec == null && dSec == null) return null;
+            const a = aSec ?? dSec!;
+            const d = dSec ?? a;
+            const baseLaneY = labelHeight + 0 * (laneHeight + laneGap) + laneHeight / 2;
+            const arrX = timeToX(a);
+            const depX = timeToX(d);
+            const barW = Math.max(depX - arrX, 22);
+            const barX = depX > arrX ? arrX : arrX - 11;
+            const barH = 16;
+            const handleW = 6;
+            const previewColor = "#f59e0b"; // amber/yellow for selected preview
+            const label = addStopPreview.name.length > 15 ? addStopPreview.name.slice(0, 13) + "..." : addStopPreview.name;
+            const seqLabel = addStopPreview.stopSequence ? `#${addStopPreview.stopSequence}` : "";
+            return (
+              <g data-stop-preview="true">
+                <text x={barX} y={baseLaneY - barH / 2 - 14} textAnchor="start"
+                  transform={`rotate(-45, ${barX}, ${baseLaneY - barH / 2 - 14})`}
+                  fill={previewColor} fontSize={10} fontWeight={700} style={{ pointerEvents: "none" }}>{label}</text>
+                {seqLabel && <text x={barX} y={baseLaneY - barH / 2 - 4} textAnchor="start"
+                  transform={`rotate(-45, ${barX}, ${baseLaneY - barH / 2 - 4})`}
+                  fill={previewColor} fontSize={8} opacity={0.7} style={{ pointerEvents: "none" }}>{seqLabel}</text>}
+                {/* Left handle — drag to change arrival */}
+                <rect x={barX} y={baseLaneY - barH / 2} width={handleW} height={barH}
+                  rx={2} fill={previewColor} opacity={0.6}
+                  style={{ cursor: "w-resize" }}
+                  onMouseDown={(e) => { e.stopPropagation(); isPlacingRef.current = "arr"; interactiveClickRef.current = true; }} />
+                {/* Middle body — drag to move whole range */}
+                <rect x={barX + handleW} y={baseLaneY - barH / 2} width={Math.max(barW - handleW * 2, 4)} height={barH}
+                  rx={2} fill={previewColor} opacity={0.3} style={{ cursor: "grab" }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation(); e.preventDefault();
+                    interactiveClickRef.current = true;
+                    // Store initial state for "both" drag
+                    const dur = Math.max(0, d - a);
+                    dragRef.current = { tripIdx: 0, stopIdx: -1, field: "both", duration: dur };
+                    didDragRef.current = false;
+                  }} />
+                {/* Right handle — drag to change departure */}
+                <rect x={barX + barW - handleW} y={baseLaneY - barH / 2}
+                  width={handleW} height={barH}
+                  rx={2} fill={previewColor} opacity={0.6}
+                  style={{ cursor: "e-resize" }}
+                  onMouseDown={(e) => { e.stopPropagation(); isPlacingRef.current = "dep"; interactiveClickRef.current = true; }} />
+                <text x={barX + barW / 2} y={baseLaneY + barH / 2 + 12} textAnchor="middle"
+                  fill={previewColor} fontSize={9} opacity={0.7} style={{ pointerEvents: "none" }}>
+                  {a !== d ? `${fmtTime(a)}-${fmtTime(d)}` : fmtTime(a)}
+                </text>
+              </g>
+            );
+          })()}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Timeline/ReadOnlyTimeline.tsx
+++ b/packages/web/src/client/Trips/components/Timeline/ReadOnlyTimeline.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TRIP_LINE_COLORS, type TripStopTime, type TripInfo, fmtTime, timeToSec } from "@/lib/tripUtils";
+
+export function TripTimeline({ trips, selectedStopIdx, onSelectStop, selectedTripIdx, onSelectStopWithTrip, hiddenTripIndices }: {
+  trips: Array<{ trip: TripInfo; stopTimes: TripStopTime[] }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  selectedTripIdx?: number;
+  onSelectStopWithTrip?: (tripIdx: number, stopIdx: number | null) => void;
+  hiddenTripIndices?: Set<number>;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [zoomLevel, setZoomLevel] = useState(1);
+
+  const showTooltip = useCallback((e: React.MouseEvent, lines: string[]) => {
+    const container = containerRef.current;
+    const tip = tooltipRef.current;
+    if (!container || !tip) return;
+    const rect = container.getBoundingClientRect();
+    tip.style.left = `${e.clientX - rect.left + 12}px`;
+    tip.style.top = `${e.clientY - rect.top - 10}px`;
+    tip.style.display = "block";
+    tip.innerHTML = lines.map((line, i) =>
+      `<div class="${i === 0 ? "font-medium" : "text-muted-foreground"}">${line}</div>`
+    ).join("");
+  }, []);
+  const hideTooltip = useCallback(() => {
+    const tip = tooltipRef.current;
+    if (tip) tip.style.display = "none";
+  }, []);
+
+  const parsed = useMemo(() => trips.map(({ trip, stopTimes }) => ({
+    trip,
+    stops: stopTimes.map((st, i) => ({
+      stopId: st.stop_id || `${i + 1}`,
+      name: st.stop_name || st.stop_id || `Stop ${i + 1}`,
+      arrivalSec: timeToSec(st.arrival_time),
+      departureSec: timeToSec(st.departure_time),
+    })),
+  })), [trips]);
+
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  let maxStops = 0;
+  for (const { stops } of parsed) {
+    if (stops.length > maxStops) maxStops = stops.length;
+    for (const s of stops) {
+      if (s.arrivalSec != null) { if (s.arrivalSec < minTime) minTime = s.arrivalSec; if (s.arrivalSec > maxTime) maxTime = s.arrivalSec; }
+      if (s.departureSec != null) { if (s.departureSec < minTime) minTime = s.departureSec; if (s.departureSec > maxTime) maxTime = s.departureSec; }
+    }
+  }
+
+  const paddingLeft = 40;
+  const paddingRight = 60;
+
+  // Zoom hooks — must be called before early returns to satisfy Rules of Hooks
+  const zoomRef = useRef(zoomLevel);
+  zoomRef.current = zoomLevel;
+  const baseWidthRef = useRef(800);
+
+  const handleWheel = useCallback((e: WheelEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Horizontal scroll (deltaX or shift+wheel) → pan along time axis natively
+    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+
+    // Vertical scroll → zoom time intervals
+    e.preventDefault();
+    const rect = container.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left + container.scrollLeft;
+    const curZoom = zoomRef.current;
+    const bw = baseWidthRef.current;
+    const oldTotal = paddingLeft + Math.round(bw * curZoom) + paddingRight;
+    const mouseRatio = mouseX / oldTotal;
+
+    const delta = e.deltaY > 0 ? 0.85 : 1.18;
+    const newZoom = Math.max(0.3, Math.min(8, curZoom * delta));
+    zoomRef.current = newZoom;
+    setZoomLevel(newZoom);
+
+    requestAnimationFrame(() => {
+      const newTotal = paddingLeft + Math.round(bw * newZoom) + paddingRight;
+      container.scrollLeft = Math.max(0, mouseRatio * newTotal - (e.clientX - rect.left));
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  if (minTime === Infinity) {
+    return <div className="rounded-md border p-4 text-sm text-muted-foreground text-center">No stop times available</div>;
+  }
+
+  const timeSpan = maxTime - minTime || 1;
+  const labelHeight = 70;
+  const laneHeight = 24;
+  const labelRows = 3;
+  const labelRowH = 14;
+  const laneLabelArea = labelRows * labelRowH + 8;
+  const laneGap = 8;
+  const dotR = 6;
+  const minGap = 60;
+
+  let smallestGap = timeSpan;
+  for (const { stops } of parsed) {
+    const times = stops
+      .map((s) => s.departureSec ?? s.arrivalSec)
+      .filter((t): t is number => t != null)
+      .sort((a, b) => a - b);
+    for (let i = 1; i < times.length; i++) {
+      const gap = times[i] - times[i - 1];
+      if (gap > 0 && gap < smallestGap) smallestGap = gap;
+    }
+  }
+  const baseChartWidth = Math.max(800, Math.round((timeSpan / smallestGap) * minGap));
+  baseWidthRef.current = baseChartWidth;
+  const chartWidth = Math.round(baseChartWidth * zoomLevel);
+  const totalWidth = paddingLeft + chartWidth + paddingRight;
+  const laneBlock = laneHeight + laneLabelArea + laneGap;
+  const totalHeight = labelHeight + parsed.length * laneBlock + 30;
+  const timeToX = (sec: number) => Math.round(paddingLeft + ((sec - minTime) / timeSpan) * chartWidth);
+  const xToTime = (x: number) => minTime + ((x - paddingLeft) / chartWidth) * timeSpan;
+
+  const stepSeconds = Math.max(300, Math.ceil(timeSpan / Math.max(8, Math.floor(chartWidth / 80)) / 300) * 300);
+  const axisTicks: number[] = [];
+  for (let t = Math.floor(minTime / stepSeconds) * stepSeconds; t <= maxTime + stepSeconds; t += stepSeconds) {
+    if (t >= minTime - stepSeconds / 2 && t <= maxTime + stepSeconds / 2) axisTicks.push(t);
+  }
+  const axisY = totalHeight - 20;
+
+  return (
+    <div className="rounded-md border shadow-sm overflow-hidden">
+      <div className="border-b px-4 py-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {trips.map(({ trip }, idx) => (
+            <span key={trip.trip_id} className="flex items-center gap-1.5">
+              <span className="rounded-full shrink-0" style={{ width: 8, height: 8, backgroundColor: TRIP_LINE_COLORS[idx % TRIP_LINE_COLORS.length] }} />
+              <span className="truncate max-w-[200px] font-medium">{trip.trip_headsign || trip.trip_id}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div ref={containerRef} className="overflow-x-auto relative">
+        <div
+          ref={tooltipRef}
+          className="absolute z-50 pointer-events-none rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md"
+          style={{ display: "none" }}
+        />
+
+        <svg width={totalWidth} height={totalHeight} className="block" onMouseLeave={hideTooltip}>
+          {/* Time axis */}
+          <line x1={paddingLeft} y1={axisY} x2={paddingLeft + chartWidth} y2={axisY} stroke="currentColor" strokeWidth={1} opacity={0.2} />
+          {axisTicks.map((t) => {
+            const x = timeToX(t);
+            return (
+              <g key={t}>
+                <line x1={x} y1={axisY - 4} x2={x} y2={axisY + 4} stroke="currentColor" strokeWidth={1} opacity={0.3} />
+                <line x1={x} y1={labelHeight - 10} x2={x} y2={axisY} stroke="currentColor" strokeWidth={0.5} strokeDasharray="3,4" opacity={0.08} />
+                <text x={x} y={axisY + 16} textAnchor="middle" fill="currentColor" fontSize={11} opacity={0.5}>{fmtTime(t)}</text>
+              </g>
+            );
+          })}
+
+          {/* Trip lanes */}
+          {parsed.map(({ trip, stops }, ti) => {
+            if (hiddenTripIndices?.has(ti)) return null;
+            const color = TRIP_LINE_COLORS[ti % TRIP_LINE_COLORS.length];
+            const laneY = labelHeight + ti * laneBlock + laneHeight / 2;
+            const labelBaseY = laneY + dotR + 10;
+            const pts = stops
+              .map((s, si) => ({ ...s, idx: si, timeSec: s.departureSec ?? s.arrivalSec }))
+              .filter((p) => p.timeSec != null) as Array<{ stopId: string; name: string; arrivalSec?: number; departureSec?: number; idx: number; timeSec: number }>;
+
+            const labelMinPx = 50;
+            const rowLastX: number[] = Array(labelRows).fill(-Infinity);
+            const labelOffsets = pts.map((p) => {
+              const x = timeToX(p.timeSec);
+              for (let r = 0; r < labelRows; r++) {
+                if (x - rowLastX[r] >= labelMinPx) {
+                  rowLastX[r] = x;
+                  return r;
+                }
+              }
+              let bestRow = 0;
+              let bestDist = 0;
+              for (let r = 0; r < labelRows; r++) {
+                const dist = x - rowLastX[r];
+                if (dist > bestDist) { bestDist = dist; bestRow = r; }
+              }
+              rowLastX[bestRow] = x;
+              return bestRow;
+            });
+
+            return (
+              <g key={trip.trip_id}>
+                <text x={paddingLeft - 6} y={laneY + 4} textAnchor="end" fill={color} fontSize={10} fontWeight={600} opacity={0.7}>
+                  {trips.length > 1 ? (ti + 1) : ""}
+                </text>
+
+                {/* Visible lines */}
+                {pts.map((p, pi) => {
+                  if (pi === 0) return null;
+                  return (
+                    <line key={`vl-${pi}`}
+                      x1={timeToX(pts[pi - 1].timeSec)} y1={laneY} x2={timeToX(p.timeSec)} y2={laneY}
+                      stroke={color} strokeWidth={2} opacity={0.3} />
+                  );
+                })}
+
+                {/* Visible dots */}
+                {pts.map((p, pi) => {
+                  const x = timeToX(p.timeSec);
+                  const isPrimarySelected = (selectedTripIdx != null ? selectedTripIdx === ti : ti === 0) && selectedStopIdx === p.idx;
+                  const isStopHighlighted = selectedStopIdx === p.idx; // highlight same stop across all trips
+                  const canClick = !!(onSelectStop || onSelectStopWithTrip);
+                  return (
+                    <g key={`d-${pi}`} data-stop-idx={p.idx}
+                      style={{ cursor: canClick ? "pointer" : undefined }}
+                      onClick={canClick ? (e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        if (isPrimarySelected) {
+                          onSelectStop?.(null);
+                          onSelectStopWithTrip?.(ti, null);
+                        } else {
+                          onSelectStop?.(p.idx);
+                          onSelectStopWithTrip?.(ti, p.idx);
+                        }
+                      } : undefined}>
+                      {p.arrivalSec != null && p.departureSec != null && p.departureSec !== p.arrivalSec && (
+                        <line x1={timeToX(p.arrivalSec)} y1={laneY} x2={timeToX(p.departureSec)} y2={laneY}
+                          stroke={isStopHighlighted ? "#f59e0b" : color} strokeWidth={6} opacity={isStopHighlighted ? 0.4 : 0.25} strokeLinecap="round" />
+                      )}
+                      <circle cx={x} cy={laneY} r={isStopHighlighted ? dotR + 2 : dotR}
+                        fill={isPrimarySelected ? "#f59e0b" : isStopHighlighted ? color : color}
+                        stroke={isStopHighlighted ? "#f59e0b" : "var(--background)"} strokeWidth={isStopHighlighted ? 2.5 : 2} />
+                    </g>
+                  );
+                })}
+
+                {/* Labels below the line */}
+                {pts.map((p, pi) => {
+                  const x = timeToX(p.timeSec);
+                  const row = labelOffsets[pi];
+                  const ly = labelBaseY + row * labelRowH;
+                  const idLabel = p.stopId.length > 10 ? p.stopId.slice(0, 8) + "..." : p.stopId;
+                  return (
+                    <g key={`lb-${pi}`}>
+                      <line x1={x} y1={laneY + dotR + 1} x2={x} y2={ly - 2}
+                        stroke="currentColor" strokeWidth={0.5} opacity={0.15} />
+                      <text x={x} y={ly + 9} textAnchor="middle"
+                        fill="currentColor" fontSize={9} fontWeight={500} opacity={0.6}
+                        style={{ pointerEvents: "none" }}>{idLabel}</text>
+                    </g>
+                  );
+                })}
+
+                {/* Hit areas: line segments */}
+                {pts.map((p, pi) => {
+                  if (pi === 0) return null;
+                  const prev = pts[pi - 1];
+                  const dur = Math.round((p.timeSec - prev.timeSec) / 60);
+                  return (
+                    <rect key={`hl-${pi}`}
+                      x={Math.min(timeToX(prev.timeSec), timeToX(p.timeSec))}
+                      y={laneY - 10} height={20}
+                      width={Math.max(4, Math.abs(timeToX(p.timeSec) - timeToX(prev.timeSec)))}
+                      fill="transparent" style={{ cursor: "crosshair" }}
+                      onMouseMove={(e) => {
+                        const container = containerRef.current;
+                        if (!container) return;
+                        const svgRect = container.querySelector("svg")?.getBoundingClientRect();
+                        if (!svgRect) return;
+                        const svgX = e.clientX - svgRect.left + container.scrollLeft;
+                        const hoverSec = xToTime(svgX);
+                        const clampedSec = Math.max(prev.timeSec, Math.min(p.timeSec, hoverSec));
+                        showTooltip(e, [
+                          fmtTime(clampedSec),
+                          `${prev.name} \u2192 ${p.name}`,
+                          `${fmtTime(prev.timeSec)} \u2192 ${fmtTime(p.timeSec)} (${dur} min)`,
+                        ]);
+                      }}
+                      onMouseLeave={hideTooltip}
+                    />
+                  );
+                })}
+
+                {/* Hit areas: dots */}
+                {pts.map((p, pi) => {
+                  const x = timeToX(p.timeSec);
+                  const arrStr = p.arrivalSec != null ? fmtTime(p.arrivalSec) : "";
+                  const depStr = p.departureSec != null && p.departureSec !== p.arrivalSec ? fmtTime(p.departureSec) : "";
+                  const timeLine = depStr ? `arr ${arrStr}  dep ${depStr}` : fmtTime(p.timeSec);
+                  const isPrimSel = (selectedTripIdx != null ? selectedTripIdx === ti : ti === 0) && selectedStopIdx === p.idx;
+                  const canClick = !!(onSelectStop || onSelectStopWithTrip);
+                  return (
+                    <circle key={`hp-${pi}`} cx={x} cy={laneY} r={dotR + 8}
+                      fill="transparent" style={{ cursor: canClick ? "pointer" : undefined }}
+                      onClick={canClick ? (e: React.MouseEvent<SVGCircleElement>) => {
+                        e.stopPropagation();
+                        if (isPrimSel) { onSelectStop?.(null); onSelectStopWithTrip?.(ti, null); }
+                        else { onSelectStop?.(p.idx); onSelectStopWithTrip?.(ti, p.idx); }
+                      } : undefined}
+                      onMouseMove={(e) => showTooltip(e, [p.name, timeLine])}
+                      onMouseLeave={hideTooltip}
+                    />
+                  );
+                })}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Timeline/index.tsx
+++ b/packages/web/src/client/Trips/components/Timeline/index.tsx
@@ -1,0 +1,57 @@
+import type { TripStopTime, TripInfo, EditableStop, RouteStopOption } from "@/lib/tripUtils";
+import { TripTimeline } from "./ReadOnlyTimeline";
+import { EditableTimeline } from "./EditableTimeline";
+
+type BaseProps = {
+  trips: Array<{ trip: TripInfo; stopTimes: TripStopTime[] }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  selectedTripIdx?: number;
+  onSelectStopWithTrip?: (tripIdx: number, stopIdx: number | null) => void;
+  hiddenTripIndices?: Set<number>;
+};
+
+type EditProps = {
+  editable: true;
+  trips: Array<{ trip: TripInfo; stops: EditableStop[] }>;
+  onUpdateStop: (tripIdx: number, stopIdx: number, field: "arrival_time" | "departure_time", value: string) => void;
+  onUpdateStopBoth?: (tripIdx: number, stopIdx: number, arrival: string, departure: string) => void;
+  routeStops?: RouteStopOption[];
+  onAddStop?: (stop: RouteStopOption, arrival: string, departure: string) => void;
+  onCreateStop?: () => void;
+  addStopPreview?: { name: string; arrival: string; departure: string; stopSequence?: number };
+  onAddArrivalChange?: (v: string) => void;
+  onAddDepartureChange?: (v: string) => void;
+  originalStops?: Array<{ stop_id?: string; arrival_time?: string; departure_time?: string }>;
+  onInsertAt?: (seq: number, arrival: string, departure: string) => void;
+  onDragStart?: () => void;
+};
+
+type ReadOnlyProps = BaseProps & { editable?: false };
+
+type TimelineProps = ReadOnlyProps | (Omit<BaseProps, "trips"> & EditProps);
+
+export function Timeline(props: TimelineProps) {
+  if (props.editable) {
+    const { editable: _, trips, selectedStopIdx, onSelectStop, ...editProps } = props;
+    return (
+      <EditableTimeline
+        trips={trips}
+        selectedStopIdx={selectedStopIdx}
+        onSelectStop={onSelectStop}
+        {...editProps}
+      />
+    );
+  }
+
+  return (
+    <TripTimeline
+      trips={props.trips}
+      selectedStopIdx={props.selectedStopIdx}
+      onSelectStop={props.onSelectStop}
+      selectedTripIdx={props.selectedTripIdx}
+      onSelectStopWithTrip={props.onSelectStopWithTrip}
+      hiddenTripIndices={props.hiddenTripIndices}
+    />
+  );
+}

--- a/packages/web/src/client/Trips/components/Timetable/EditableTimetable.tsx
+++ b/packages/web/src/client/Trips/components/Timetable/EditableTimetable.tsx
@@ -71,10 +71,13 @@ export function EditableTimetable({ stops, onUpdate, routeStops: _routeStops = [
               let seqOffset = 0;
 
               const stopStatus = new Map<number, string>();
+              // Detect if any reorder/add/delete happened
+              const structureChanged = originalStops
+                ? stops.length !== originalStops.length || stops.some((s, i) => s._idx !== i)
+                : false;
               if (originalStops) {
                 for (let i = 0; i < stops.length; i++) {
                   const st = stops[i];
-                  // Use _idx to find this stop's original data (identity-based, not position-based)
                   const origIdx = st._idx;
                   const orig = origIdx != null && origIdx < originalStops.length ? originalStops[origIdx] : undefined;
                   if (!orig) {
@@ -153,8 +156,10 @@ export function EditableTimetable({ stops, onUpdate, routeStops: _routeStops = [
                   const st = stops[i];
                   const seq = i + 1 + seqOffset;
                   const isSelected = selectedStopIdx === i;
-                  if (showOnlyChanged && stopStatus.size > 0 && !stopStatus.has(i) && !isSelected) {
-                    if (i === 0 || stopStatus.has(i - 1) || selectedStopIdx === i - 1) {
+                  if (showOnlyChanged && !structureChanged && stopStatus.size > 0 && !stopStatus.has(i) && !isSelected) {
+                    // Only collapse unchanged rows when no reorder/add/delete happened
+                    const prevWasVisible = i === 0 || stopStatus.has(i - 1) || selectedStopIdx === i - 1;
+                    if (prevWasVisible) {
                       rows.push(
                         <tr key={`skip-${i}`} className="border-t">
                           <td colSpan={8} className="px-3 py-1 text-center text-[10px] text-muted-foreground">

--- a/packages/web/src/client/Trips/components/Timetable/EditableTimetable.tsx
+++ b/packages/web/src/client/Trips/components/Timetable/EditableTimetable.tsx
@@ -1,0 +1,221 @@
+import { useRef, useState } from "react";
+import { BiGridVertical, BiX } from "react-icons/bi";
+import { EditIndicator } from "@/components/ui/EditIndicator";
+import { type EditableStop, type RouteStopOption, timeToSec } from "@/lib/tripUtils";
+
+export function EditableTimetable({ stops, onUpdate, routeStops: _routeStops = [], onCreateStop: _onCreateStop, addStopPreview, onInsertAt, originalStops, selectedStopIdx, onSelectStop, showOnlyChanged }: {
+  stops: EditableStop[];
+  onUpdate: (stops: EditableStop[]) => void;
+  routeStops?: RouteStopOption[];
+  onCreateStop?: () => void;
+  addStopPreview?: { name: string; stopId?: string; arrival: string; departure: string; stopSequence?: number };
+  onInsertAt?: (seq: number, arrival: string, departure: string) => void;
+  originalStops?: Array<{ stop_id?: string; arrival_time?: string; departure_time?: string }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  showOnlyChanged?: boolean;
+}) {
+  const dragIdx = useRef<number | null>(null);
+  const [dragOver, setDragOver] = useState<number | null>(null);
+
+  const handleDragStart = (e: React.DragEvent, idx: number) => {
+    dragIdx.current = idx;
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleDragOver = (e: React.DragEvent, idx: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOver(idx);
+  };
+
+  const handleDrop = (e: React.DragEvent, dropIdx: number) => {
+    e.preventDefault();
+    const fromIdx = dragIdx.current;
+    if (fromIdx == null || fromIdx === dropIdx) { setDragOver(null); return; }
+    const next = [...stops];
+    const [moved] = next.splice(fromIdx, 1);
+    next.splice(dropIdx, 0, moved);
+    onUpdate(next.map((s, i) => ({ ...s, stop_sequence: i + 1 })));
+    if (selectedStopIdx != null) {
+      if (selectedStopIdx === fromIdx) onSelectStop?.(dropIdx);
+      else if (fromIdx < selectedStopIdx && dropIdx >= selectedStopIdx) onSelectStop?.(selectedStopIdx - 1);
+      else if (fromIdx > selectedStopIdx && dropIdx <= selectedStopIdx) onSelectStop?.(selectedStopIdx + 1);
+    }
+    dragIdx.current = null;
+    setDragOver(null);
+  };
+
+  return (
+    <div className="rounded-md border shadow-sm overflow-hidden">
+      <div className="overflow-auto max-h-[60vh]">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-muted z-10">
+            <tr>
+              <th className="px-1 py-2 w-8"></th>
+              <th className="px-3 py-2 text-left text-xs font-medium">#</th>
+              <th className="px-3 py-2 text-left text-xs font-medium">Stop</th>
+              <th className="px-3 py-2 text-left text-xs font-medium">ID</th>
+              <th className="px-3 py-2 text-left text-xs font-medium">Arrival</th>
+              <th className="px-3 py-2 text-left text-xs font-medium">Departure</th>
+              <th className="px-3 py-2 text-left text-xs font-medium">Station</th>
+              <th className="px-1 py-2 w-8"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {(() => {
+              const previewIdx = addStopPreview?.stopSequence ? addStopPreview.stopSequence - 1 : -1;
+              const hasPreview = !!addStopPreview;
+              const canInsert = !!onInsertAt;
+              const rows: React.ReactNode[] = [];
+              let seqOffset = 0;
+
+              const stopStatus = new Map<number, string>();
+              if (originalStops) {
+                for (let i = 0; i < stops.length; i++) {
+                  const st = stops[i];
+                  // Use _idx to find this stop's original data (identity-based, not position-based)
+                  const origIdx = st._idx;
+                  const orig = origIdx != null && origIdx < originalStops.length ? originalStops[origIdx] : undefined;
+                  if (!orig) {
+                    stopStatus.set(i, "new");
+                  } else if (
+                    (st.stop_id || "") !== (orig.stop_id || "") ||
+                    st.arrival_time !== orig.arrival_time ||
+                    st.departure_time !== orig.departure_time
+                  ) {
+                    stopStatus.set(i, "edit");
+                  }
+                }
+              }
+
+              const midTime = (before: number, after: number): string => {
+                const mid = Math.round((before + after) / 2 / 60) * 60;
+                const mh = Math.floor(mid / 3600);
+                const mm = Math.floor((mid % 3600) / 60);
+                const ms = mid % 60;
+                return `${String(mh).padStart(2, "0")}:${String(mm).padStart(2, "0")}:${String(ms).padStart(2, "0")}`;
+              };
+
+              const handleInsertClick = (pos: number) => {
+                const prevStop = pos > 1 ? stops[pos - 2] : undefined;
+                const nextStop = pos <= stops.length ? stops[pos - 1] : undefined;
+                const prevSec = timeToSec(prevStop?.departure_time) ?? timeToSec(prevStop?.arrival_time);
+                const nextSec = timeToSec(nextStop?.arrival_time) ?? timeToSec(nextStop?.departure_time);
+                let time = "";
+                if (prevSec != null && nextSec != null) {
+                  time = midTime(prevSec, nextSec);
+                } else if (prevSec != null) {
+                  time = midTime(prevSec, prevSec + 300);
+                } else if (nextSec != null) {
+                  time = midTime(Math.max(0, nextSec - 300), nextSec);
+                }
+                onInsertAt?.(pos, time, time);
+              };
+
+              const insertRow = (pos: number) => (
+                <tr key={`insert-${pos}`}
+                  className="cursor-pointer group transition-colors hover:bg-amber-50/50 dark:hover:bg-amber-950/10"
+                  onClick={() => handleInsertClick(pos)}>
+                  <td colSpan={8} className="py-0">
+                    <div className="border-t-2 border-dashed border-transparent group-hover:border-amber-400 dark:group-hover:border-amber-600 flex items-center justify-center h-3">
+                      <span className="text-[10px] px-2 text-transparent group-hover:text-amber-500 dark:group-hover:text-amber-400 select-none">
+                        insert #{pos}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              );
+
+              const previewRow = (seq: number) => (
+                <tr key="preview" data-stop-preview="true" className="border-t border-dashed border-amber-400 bg-amber-50 dark:bg-amber-950/20 cursor-pointer hover:bg-amber-100 dark:hover:bg-amber-950/40 transition-colors"
+                  onClick={() => onInsertAt?.(seq, "", "")}>
+                  <td className="px-1 py-2 text-amber-500"><BiX className="h-4 w-4" /></td>
+                  <td className="px-3 py-2 text-amber-600 font-medium">{seq}</td>
+                  <td className="px-3 py-2 font-medium text-amber-700 dark:text-amber-400">{addStopPreview!.name || <span className="italic text-amber-500/60">Select stop...</span>}</td>
+                  <td className="px-3 py-2 text-amber-600/70 text-xs">{addStopPreview!.stopId || "\u2014"}</td>
+                  <td className="px-3 py-2 text-amber-600">{addStopPreview!.arrival || "\u2014"}</td>
+                  <td className="px-3 py-2 text-amber-600">{addStopPreview!.departure || "\u2014"}</td>
+                  <td className="px-3 py-2 text-muted-foreground text-xs">{"\u2014"}</td>
+                  <td className="px-1 py-2"></td>
+                </tr>
+              );
+
+              for (let i = 0; i <= stops.length; i++) {
+                if (hasPreview && i === previewIdx) {
+                  seqOffset = 1;
+                  rows.push(previewRow(i + 1));
+                } else if (canInsert) {
+                  rows.push(insertRow(i + 1));
+                }
+
+                if (i < stops.length) {
+                  const st = stops[i];
+                  const seq = i + 1 + seqOffset;
+                  const isSelected = selectedStopIdx === i;
+                  if (showOnlyChanged && stopStatus.size > 0 && !stopStatus.has(i) && !isSelected) {
+                    if (i === 0 || stopStatus.has(i - 1) || selectedStopIdx === i - 1) {
+                      rows.push(
+                        <tr key={`skip-${i}`} className="border-t">
+                          <td colSpan={8} className="px-3 py-1 text-center text-[10px] text-muted-foreground">
+                            ···
+                          </td>
+                        </tr>
+                      );
+                    }
+                    continue;
+                  }
+                  rows.push(
+                    <tr
+                      key={st._idx}
+                      data-stop-idx={i}
+                      draggable
+                      onDragStart={(e) => handleDragStart(e, i)}
+                      onDragOver={(e) => handleDragOver(e, i)}
+                      onDrop={(e) => handleDrop(e, i)}
+                      onDragLeave={() => setDragOver(null)}
+                      onClick={() => onSelectStop?.(isSelected ? null : i)}
+                      className={`border-t transition-colors cursor-pointer ${
+                        dragOver === i ? "border-t-2 border-t-primary bg-primary/5"
+                        : isSelected ? "bg-amber-50 dark:bg-amber-950/20 border-l-2 border-l-amber-400"
+                        : "hover:bg-muted/50"
+                      }`}
+                    >
+                      <td className="px-1 py-2 text-muted-foreground cursor-grab active:cursor-grabbing">
+                        <BiGridVertical className="h-4 w-4" />
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        <div className="flex items-center gap-1">
+                          {stopStatus.has(i) && <EditIndicator status={stopStatus.get(i)} className="h-3.5 w-3.5" />}
+                          <span>{seq}</span>
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 font-medium">{st.stop_name || "\u2014"}</td>
+                      <td className="px-3 py-2 text-muted-foreground text-xs">{st.stop_id || "\u2014"}</td>
+                      <td className="px-3 py-2 text-sm">{st.arrival_time || "\u2014"}</td>
+                      <td className="px-3 py-2 text-sm">{st.departure_time || "\u2014"}</td>
+                      <td className="px-3 py-2 text-muted-foreground text-xs">{st.station_name || "\u2014"}</td>
+                      <td className="px-1 py-2">
+                        <button onClick={(e) => { e.stopPropagation(); onUpdate(stops.filter((_, j) => j !== i).map((s, j) => ({ ...s, stop_sequence: j + 1 }))); if (selectedStopIdx === i) onSelectStop?.(null); }}
+                            className="text-muted-foreground hover:text-destructive transition-colors" title="Remove stop">
+                            <BiX className="h-4 w-4" />
+                          </button>
+                      </td>
+                    </tr>,
+                  );
+                }
+              }
+              if (hasPreview && previewIdx > stops.length) {
+                rows.push(previewRow(stops.length + 1));
+              }
+              if (rows.length === 0) {
+                rows.push(<tr key="empty"><td colSpan={8} className="px-3 py-4 text-center text-muted-foreground">No stop times available</td></tr>);
+              }
+              return rows;
+            })()}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Timetable/ReadOnlyTimetable.tsx
+++ b/packages/web/src/client/Trips/components/Timetable/ReadOnlyTimetable.tsx
@@ -1,0 +1,114 @@
+import { Link } from "@tanstack/react-router";
+import type { TripStopTime, TripInfo } from "@/lib/tripUtils";
+
+export function TripStopSequence({ stopTimes, view = "stops" }: { stopTimes: TripStopTime[]; view?: "stops" | "stations" }) {
+  if (view === "stations") {
+    const grouped: Array<{ station_name: string; station_id: string; isStation: boolean; sequence: number; stop_count: number; arrival_time: string; departure_time: string }> = [];
+    for (const st of stopTimes) {
+      const hasParent = st.parent_station && st.parent_station !== "" && st.parent_station !== st.stop_id;
+      const isStationType = st.location_type_name === "Station";
+      const name = st.station_name || st.stop_name || "Unknown";
+      const sid = hasParent ? st.parent_station! : (st.stop_id || "");
+      const last = grouped[grouped.length - 1];
+      if (last && last.station_name === name) { last.stop_count++; last.departure_time = st.departure_time || last.departure_time; }
+      else grouped.push({ station_name: name, station_id: sid, isStation: !!hasParent || isStationType, sequence: grouped.length + 1, stop_count: 1, arrival_time: st.arrival_time || "", departure_time: st.departure_time || "" });
+    }
+    return (
+      <div className="rounded-md border shadow-sm overflow-hidden">
+        <div className="overflow-auto max-h-[60vh]">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-muted z-10">
+              <tr><th className="px-3 py-2 text-left text-xs font-medium">#</th><th className="px-3 py-2 text-left text-xs font-medium">Station</th><th className="px-3 py-2 text-left text-xs font-medium">Arrival</th><th className="px-3 py-2 text-left text-xs font-medium">Departure</th></tr>
+            </thead>
+            <tbody>
+              {grouped.length > 0 ? grouped.map((g, i) => (
+                <tr key={i} className="border-t hover:bg-muted/50">
+                  <td className="px-3 py-2 text-muted-foreground">{g.sequence}</td>
+                  <td className="px-3 py-2 font-medium">
+                    {g.station_id ? (
+                      g.isStation ? (
+                        <Link to="/stations/info" search={{ selectedStationId: g.station_id }} onClick={(e) => e.stopPropagation()}
+                          className="inline-flex items-center rounded px-1.5 py-0.5 text-sm hover:bg-primary/10 text-primary/80 transition-colors">
+                          {g.station_name}
+                        </Link>
+                      ) : (
+                        <Link to="/stops/map" search={{ selectedStopId: g.station_id }} onClick={(e) => e.stopPropagation()}
+                          className="inline-flex items-center rounded px-1.5 py-0.5 text-sm hover:bg-primary/10 text-primary/80 transition-colors">
+                          {g.station_name}
+                        </Link>
+                      )
+                    ) : g.station_name}
+                    {g.stop_count > 1 ? <span className="ml-1.5 text-xs text-muted-foreground">({g.stop_count} stops)</span> : null}
+                  </td>
+                  <td className="px-3 py-2">{g.arrival_time || "\u2014"}</td><td className="px-3 py-2">{g.departure_time || "\u2014"}</td>
+                </tr>
+              )) : <tr><td colSpan={4} className="px-3 py-4 text-center text-muted-foreground">No stop times available</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border shadow-sm overflow-hidden">
+      <div className="overflow-auto max-h-[60vh]">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-muted z-10">
+            <tr><th className="px-3 py-2 text-left text-xs font-medium">#</th><th className="px-3 py-2 text-left text-xs font-medium">Stop</th><th className="px-3 py-2 text-left text-xs font-medium">ID</th><th className="px-3 py-2 text-left text-xs font-medium">Arrival</th><th className="px-3 py-2 text-left text-xs font-medium">Departure</th><th className="px-3 py-2 text-left text-xs font-medium">Station</th></tr>
+          </thead>
+          <tbody>
+            {stopTimes.length > 0 ? stopTimes.map((st, i) => {
+              const hasParent = st.parent_station && st.parent_station !== "" && st.parent_station !== st.stop_id;
+              const stationId = hasParent ? st.parent_station : undefined;
+              const linkClass = "inline-flex items-center rounded px-1.5 py-0.5 hover:bg-primary/10 text-primary/80 transition-colors";
+              return (
+                <tr key={i} className="border-t hover:bg-muted/50">
+                  <td className="px-3 py-2 text-muted-foreground">{st.stop_sequence ?? i + 1}</td>
+                  <td className="px-3 py-2 font-medium">
+                    {st.stop_id ? (
+                      (hasParent || st.location_type_name === "Station") ? (
+                        <Link to="/stations/info" search={{ selectedStationId: hasParent ? st.parent_station! : st.stop_id }} onClick={(e) => e.stopPropagation()}
+                          className={`${linkClass} text-sm`}>{st.stop_name || "\u2014"}</Link>
+                      ) : (
+                        <Link to="/stops/map" search={{ selectedStopId: st.stop_id }} onClick={(e) => e.stopPropagation()}
+                          className={`${linkClass} text-sm`}>{st.stop_name || "\u2014"}</Link>
+                      )
+                    ) : (st.stop_name || "\u2014")}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground text-xs">{st.stop_id || "\u2014"}</td>
+                  <td className="px-3 py-2">{st.arrival_time || "\u2014"}</td><td className="px-3 py-2">{st.departure_time || "\u2014"}</td>
+                  <td className="px-3 py-2 text-muted-foreground text-xs">
+                    {stationId ? (
+                      <Link to="/stations/info" search={{ selectedStationId: stationId }} onClick={(e) => e.stopPropagation()}
+                        className={`${linkClass} text-xs`}>{st.station_name || stationId}</Link>
+                    ) : "\u2014"}
+                  </td>
+                </tr>
+              );
+            }) : <tr><td colSpan={6} className="px-3 py-4 text-center text-muted-foreground">No stop times available</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function TripStopPanel({ trip, stopTimes, view = "stops" }: {
+  trip: TripInfo; stopTimes: TripStopTime[]; view?: "stops" | "stations";
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2 flex-wrap">
+        <span className="text-xs font-medium text-muted-foreground truncate">
+          {trip.trip_id}{trip.trip_headsign ? ` \u2014 ${trip.trip_headsign}` : ""}
+          {trip.direction_id !== undefined && trip.direction_id !== null ? (
+            <span className="ml-1 text-muted-foreground/60">(dir {trip.direction_id})</span>
+          ) : null}
+        </span>
+        {(trip as any).route_name && <span className="text-[10px] text-muted-foreground/70 truncate">{(trip as any).route_name}</span>}
+        {(trip as any).service_id && <span className="text-[10px] text-muted-foreground/50 truncate">{(trip as any).service_id}</span>}
+      </div>
+      <TripStopSequence stopTimes={stopTimes} view={view} />
+    </div>
+  );
+}

--- a/packages/web/src/client/Trips/components/Timetable/index.tsx
+++ b/packages/web/src/client/Trips/components/Timetable/index.tsx
@@ -1,0 +1,37 @@
+import type { TripStopTime, EditableStop, RouteStopOption } from "@/lib/tripUtils";
+import { TripStopSequence, TripStopPanel } from "./ReadOnlyTimetable";
+import { EditableTimetable } from "./EditableTimetable";
+
+export { TripStopPanel };
+
+type BaseProps = {
+  stopTimes: TripStopTime[];
+  view?: "stops" | "stations";
+};
+
+type EditProps = {
+  editable: true;
+  stops: EditableStop[];
+  onUpdate: (stops: EditableStop[]) => void;
+  routeStops?: RouteStopOption[];
+  onCreateStop?: () => void;
+  addStopPreview?: { name: string; stopId?: string; arrival: string; departure: string; stopSequence?: number };
+  onInsertAt?: (seq: number, arrival: string, departure: string) => void;
+  originalStops?: Array<{ stop_id?: string; arrival_time?: string; departure_time?: string }>;
+  selectedStopIdx?: number | null;
+  onSelectStop?: (idx: number | null) => void;
+  showOnlyChanged?: boolean;
+};
+
+type ReadOnlyProps = BaseProps & { editable?: false };
+
+type TimetableProps = ReadOnlyProps | (EditProps & { stopTimes?: never; view?: never });
+
+export function Timetable(props: TimetableProps) {
+  if (props.editable) {
+    const { editable: _, ...editProps } = props;
+    return <EditableTimetable {...editProps} />;
+  }
+
+  return <TripStopSequence stopTimes={props.stopTimes} view={props.view} />;
+}

--- a/packages/web/src/components/UpcomingFeatures.tsx
+++ b/packages/web/src/components/UpcomingFeatures.tsx
@@ -12,22 +12,16 @@ import { Sparkles, MessageSquare, Github } from "lucide-react";
 
 const upcomingFeatures = [
   {
-    title: "Trip Editor",
-    description:
-      "Create, edit, and delete trips with stop times, frequencies, and shape assignments directly in the browser",
-    category: "Editing",
-  },
-  {
     title: "Trip Analysis",
     description:
       "Compare trips side by side with service diagrams showing local vs express patterns, shared stops, and directional service",
     category: "Analysis",
   },
   {
-    title: "Schedule Timeline",
+    title: "Analysis Toolbox Refactor",
     description:
-      "Interactive timeline views showing trip schedules and frequencies",
-    category: "Visualization",
+      "Unified analysis toolbox for route, trip, and schedule analysis with cross-entity comparisons, performance metrics, and exportable reports",
+    category: "Analysis",
   },
 ];
 

--- a/packages/web/src/components/colorUtil.tsx
+++ b/packages/web/src/components/colorUtil.tsx
@@ -71,6 +71,9 @@ export const safeHexToRgb = (value: string | undefined, fallback = [79, 70, 229]
     return [(parsed >> 16) & 255, (parsed >> 8) & 255, parsed & 255];
 };
 
+/** Append alpha channel to an [R,G,B] array. */
+export const withAlpha = (color: number[], alpha: number): number[] => [color[0], color[1], color[2], alpha];
+
 export const ColorsRanges = [
     'rgb(252, 222, 156)',
     'rgb(250, 164, 118)',

--- a/packages/web/src/components/contact.tsx
+++ b/packages/web/src/components/contact.tsx
@@ -1,19 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { BiLogoGithub } from "react-icons/bi";
 
-export const GhnWebsite: React.FC = () => (
-  <div className="flex justify-center m-2">
-    <a
-      href="https://www.gabrielhn.com/"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-xs px-3 py-1.5 rounded-md bg-muted/50 text-muted-foreground hover:text-accent-foreground hover:bg-accent hover:shadow-[0_0_20px_hsl(46_74.1%_50%/0.6)] transition-all duration-200 no-underline"
-    >
-      by gabrielhn
-    </a>
-  </div>
-);
-
 export const GithubButton: React.FC = () => (
   <Button
     variant={"icon"}

--- a/packages/web/src/components/forms/EntityForm/index.tsx
+++ b/packages/web/src/components/forms/EntityForm/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import FormComponent from "@/components/forms/FormComponent";
 import FormPopup from "@/components/ui/formpopup";
 import { useEntityForm } from "@/components/forms/hooks/useEntityForm";
@@ -34,6 +35,7 @@ function EntityForm({
   showLevelField = false,
 }: EntityFormProps) {
   const mode = OpenValue.formType as "add" | "edit";
+  const [isMutating, setIsMutating] = useState(false);
 
   const formProps = useEntityForm({
     type,
@@ -44,7 +46,10 @@ function EntityForm({
       setOpenValue({ formType: null, state: false });
       setClickInfo(undefined);
     },
-    onFormMutatingChange,
+    onFormMutatingChange: (v: boolean) => {
+      setIsMutating(v);
+      onFormMutatingChange?.(v);
+    },
     parentStation,
     onZoomToLocation,
     showConversionActions,
@@ -58,7 +63,7 @@ function EntityForm({
   }
 
   return (
-    <FormPopup setOpenValue={setOpenValue} OpenValue={OpenValue}>
+    <FormPopup setOpenValue={setOpenValue} OpenValue={OpenValue} isBusy={isMutating}>
       <FormComponent {...formProps} />
     </FormPopup>
   );

--- a/packages/web/src/components/forms/RouteLineInput/index.tsx
+++ b/packages/web/src/components/forms/RouteLineInput/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import { BiHide, BiMap, BiTrash, BiUndo } from "react-icons/bi";
+import { BiHide, BiMap, BiReset, BiTrash, BiUndo } from "react-icons/bi";
 import { PathLayer, ScatterplotLayer } from "@deck.gl/layers";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
@@ -54,13 +54,22 @@ function RouteLineInput({
   const routeMapButtonLabel = isEditMode ? "Edit Route" : "Draw Route";
   const linePoints = useMemo(() => parseRouteLineValue(value), [value]);
   const linePointsRef = useRef(linePoints);
-  const lineColor = useMemo(() => hexToRgb(routeColor), [routeColor]);
+  const lineColor = useMemo(() => hexToRgb(routeColor) || [79, 70, 229], [routeColor]);
 
-  // Track original points for undo comparison in edit mode
+  // Track original points for reset in edit mode
   const originalPointsRef = useRef<string | null>(null);
   if (originalPointsRef.current === null && value) {
     originalPointsRef.current = typeof value === "string" ? value : JSON.stringify(value);
   }
+
+  // Undo stack (pushUndo defined here, handleUndoAction after updateLine)
+  const undoStackRef = useRef<Array<{ lat: number; lon: number }[]>>([]);
+  const [undoCount, setUndoCount] = useState(0);
+  const pushUndo = useCallback(() => {
+    undoStackRef.current = [...undoStackRef.current.slice(-19), linePointsRef.current.map((p) => ({ ...p }))];
+    setUndoCount(undoStackRef.current.length);
+  }, []);
+
   const hasChanges = useMemo(() => {
     if (!originalPointsRef.current) return linePoints.length > 0;
     const currentSerialized = serializeRouteLineValue(linePoints);
@@ -131,6 +140,15 @@ function RouteLineInput({
     [name, setValue, trigger],
   );
 
+  const handleUndoAction = useCallback(async () => {
+    if (undoStackRef.current.length === 0) return;
+    const last = undoStackRef.current[undoStackRef.current.length - 1];
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    setUndoCount(undoStackRef.current.length);
+    setSelectedPointIndex(null);
+    await updateLine(last);
+  }, [updateLine]);
+
   const handleMapClick = useCallback(
     async (event: any) => {
       if (!event?.coordinate || isLoading || isDraggingRef.current) return;
@@ -145,6 +163,7 @@ function RouteLineInput({
       if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
 
       if (selectedPointIndex !== null && isEndpoint) {
+        pushUndo();
         const newPoints = [...linePoints];
         if (selectedPointIndex === 0) {
           newPoints.unshift({ lat, lon });
@@ -155,6 +174,7 @@ function RouteLineInput({
         }
         await updateLine(newPoints);
       } else if (selectedPointIndex !== null) {
+        pushUndo();
         const newPoints = [...linePoints];
         newPoints[selectedPointIndex] = { lat, lon };
         await updateLine(newPoints);
@@ -163,7 +183,7 @@ function RouteLineInput({
         setSelectedPointIndex(0);
       }
     },
-    [isLoading, linePoints, updateLine, selectedPointIndex, isEndpoint],
+    [isLoading, linePoints, updateLine, selectedPointIndex, isEndpoint, pushUndo],
   );
 
   const handleDragStart = useCallback(
@@ -173,6 +193,7 @@ function RouteLineInput({
         info.layer?.id === "route-line-drawn-points" &&
         typeof info.object.pointIndex === "number"
       ) {
+        pushUndo();
         const pointIndex = info.object.pointIndex;
         isDraggingRef.current = true;
         draggingPointIndexRef.current = pointIndex;
@@ -181,7 +202,7 @@ function RouteLineInput({
       }
       return false;
     },
-    [],
+    [pushUndo],
   );
 
   const handleDrag = useCallback(
@@ -215,16 +236,18 @@ function RouteLineInput({
 
   const handleDeletePoint = useCallback(async () => {
     if (selectedPointIndex === null || selectedPointIndex >= linePoints.length) return;
+    pushUndo();
     const newPoints = linePoints.filter((_, i) => i !== selectedPointIndex);
     setSelectedPointIndex(null);
     await updateLine(newPoints);
-  }, [selectedPointIndex, linePoints, updateLine]);
+  }, [selectedPointIndex, linePoints, updateLine, pushUndo]);
 
   const indexedLinePoints = useMemo(() => {
     return linePoints.map((point, index) => ({ ...point, pointIndex: index }));
   }, [linePoints]);
 
   const layers = useMemo(() => {
+    if (!isMapVisible) return [];
     const nextLayers: any[] = [];
 
     if (contextPoints.length > 0) {
@@ -247,12 +270,13 @@ function RouteLineInput({
     }
 
     if (linePoints.length > 1) {
-      nextLayers.push(
+      const pathCoords = linePoints.map((point) => [point.lon, point.lat]).filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat));
+      if (pathCoords.length > 1) nextLayers.push(
         new PathLayer({
           id: "route-line-drawn-path",
-          data: [{ path: linePoints.map((point) => [point.lon, point.lat]) }],
+          data: [{ path: pathCoords }],
           getPath: (row: any) => row.path,
-          getColor: [...lineColor, 255],
+          getColor: [lineColor[0] || 79, lineColor[1] || 70, lineColor[2] || 229, 255] as [number, number, number, number],
           getWidth: 5,
           widthUnits: "pixels" as const,
           capRounded: true,
@@ -270,8 +294,8 @@ function RouteLineInput({
           getPosition: (point: any) => [point.lon, point.lat],
           getFillColor: (point: any) =>
             point.pointIndex === selectedPointIndex
-              ? [255, 80, 80, 255]
-              : [...lineColor, 255],
+              ? [255, 80, 80, 255] as [number, number, number, number]
+              : [...lineColor, 255] as [number, number, number, number],
           getLineColor: (point: any) =>
             point.pointIndex === selectedPointIndex
               ? [255, 255, 255, 255]
@@ -297,7 +321,7 @@ function RouteLineInput({
     }
 
     return nextLayers;
-  }, [contextPoints, handleDrag, handleDragEnd, handleDragStart, indexedLinePoints, lineColor, linePoints, selectedPointIndex, theme]);
+  }, [isMapVisible, contextPoints, handleDrag, handleDragEnd, handleDragStart, indexedLinePoints, lineColor, linePoints, selectedPointIndex, theme]);
 
   return (
     <FormField
@@ -350,21 +374,28 @@ function RouteLineInput({
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={() => {
-                    setSelectedPointIndex(null);
-                    if (isEditMode && originalPointsRef.current) {
-                      // Restore to original shape
-                      const original = parseRouteLineValue(originalPointsRef.current);
-                      updateLine(original);
-                    } else {
-                      updateLine(linePoints.slice(0, -1));
-                    }
-                  }}
-                  disabled={isLoading || !hasChanges}
+                  onClick={handleUndoAction}
+                  disabled={isLoading || undoCount === 0}
                 >
                   <BiUndo className="mr-2 h-4 w-4" />
-                  {isEditMode ? "Reset" : "Undo"}
+                  Undo
                 </Button>
+                {isEditMode && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={async () => {
+                      pushUndo();
+                      setSelectedPointIndex(null);
+                      const original = parseRouteLineValue(originalPointsRef.current || "");
+                      await updateLine(original);
+                    }}
+                    disabled={isLoading || !hasChanges}
+                  >
+                    <BiReset className="mr-2 h-4 w-4" />
+                    Reset
+                  </Button>
+                )}
                 {selectedPointIndex !== null && (
                   <Button
                     type="button"

--- a/packages/web/src/components/forms/shared/FormActions.tsx
+++ b/packages/web/src/components/forms/shared/FormActions.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface FormActionsProps {
+  isBusy: boolean;
+  /** Required fields are filled and valid */
+  isValid: boolean;
+  /** Form data has changed from initial state (for edit) or has data (for add) */
+  hasChanges: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+  saveLabel?: string;
+  busyLabel?: string;
+  cancelLabel?: string;
+  error?: string | null;
+  children?: ReactNode;
+}
+
+/**
+ * Shared form wrapper with save/cancel buttons and busy overlay.
+ * Save is enabled only when isValid AND hasChanges are both true.
+ * When busy, an overlay covers the entire form content and buttons.
+ */
+export function FormActions({
+  isBusy,
+  isValid,
+  hasChanges,
+  onSave,
+  onCancel,
+  saveLabel = "Save",
+  busyLabel = "Saving...",
+  cancelLabel = "Cancel",
+  error,
+  children,
+}: FormActionsProps) {
+  const canSave = isValid && hasChanges && !isBusy;
+
+  return (
+    <div className="relative min-h-0">
+      {children}
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive mt-2">
+          {error}
+        </div>
+      )}
+      <div className="flex gap-2 pt-2">
+        <Button onClick={onSave} disabled={!canSave} className="flex-1">
+          {saveLabel}
+        </Button>
+        <Button variant="outline" onClick={onCancel} disabled={isBusy}>{cancelLabel}</Button>
+      </div>
+      {isBusy && (
+        <div className="absolute inset-0 z-10 rounded-md bg-background/80 backdrop-blur-[2px]">
+          <div className="sticky top-1/3 flex items-center justify-center py-8">
+            <div className="rounded-md border bg-background px-5 py-3 text-sm font-medium shadow-md flex items-center gap-3">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              {busyLabel}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/forms/shared/FormShell.tsx
+++ b/packages/web/src/components/forms/shared/FormShell.tsx
@@ -37,36 +37,39 @@ function FormShell({
   return (
     <form onSubmit={onSubmit} className="space-y-2 relative">
       {isBusy && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-background/80 backdrop-blur-[1px]">
-          <div className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm">
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-background/80 backdrop-blur-[2px]">
+          <div className="rounded-md border bg-background px-5 py-3 text-sm font-medium shadow-md flex items-center gap-3">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
             {busyLabel}
           </div>
         </div>
       )}
       {!hideHeader && header && <h2 className="text-2xl font-bold mb-2">{header}</h2>}
       {children}
-      <div className="flex gap-2 pt-1">
-        <Button
-          type="submit"
-          variant="outline"
-          disabled={isSubmitDisabled || isBusy}
-          className={`px-6 ${error ? "bg-destructive text-destructive-foreground" : ""}`}
-        >
-          {isBusy ? busyLabel : error ? "Retry" : submitLabel}
-        </Button>
-        {onReset && (
+      {!isBusy && (
+        <div className="flex gap-2 pt-1">
           <Button
-            type="button"
-            variant="secondary"
-            onClick={onReset}
-            disabled={resetDisabled ?? isBusy}
-            className="px-6"
+            type="submit"
+            variant="outline"
+            disabled={isSubmitDisabled}
+            className={`px-6 ${error ? "bg-destructive text-destructive-foreground" : ""}`}
           >
-            Reset
+            {error ? "Retry" : submitLabel}
           </Button>
-        )}
-        {customActions}
-      </div>
+          {onReset && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onReset}
+              disabled={resetDisabled}
+              className="px-6"
+            >
+              Reset
+            </Button>
+          )}
+          {customActions}
+        </div>
+      )}
       {error && (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           {error}

--- a/packages/web/src/components/forms/shared/inputs/ColorInput.tsx
+++ b/packages/web/src/components/forms/shared/inputs/ColorInput.tsx
@@ -1,10 +1,10 @@
+import { forwardRef } from "react";
 import { Input } from "@/components/ui/input";
 import { normalizeHex } from "../colors";
 
 type ColorInputProps = {
   value: unknown;
   onChange: (value: string) => void;
-  ref?: any;
   disabled?: boolean;
   fallback?: string;
 };
@@ -13,26 +13,30 @@ type ColorInputProps = {
  * Color picker + hex text input combo.
  * Used for route_color and route_text_color fields.
  */
-function ColorInput({ value, onChange, ref, disabled, fallback = "#4f46e5" }: ColorInputProps) {
-  const displayValue = normalizeHex(value, fallback);
-  return (
-    <div className="flex items-center gap-2">
-      <Input
-        ref={ref}
-        type="color"
-        value={displayValue}
-        onChange={(event) => onChange(event.target.value)}
-        disabled={disabled}
-        className="h-10 w-14 p-1"
-      />
-      <Input
-        type="text"
-        value={displayValue}
-        onChange={(event) => onChange(event.target.value)}
-        disabled={disabled}
-      />
-    </div>
-  );
-}
+const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
+  ({ value, onChange, disabled, fallback = "#4f46e5" }, ref) => {
+    const displayValue = normalizeHex(value, fallback);
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          ref={ref}
+          type="color"
+          value={displayValue}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled}
+          className="h-10 w-14 p-1"
+        />
+        <Input
+          type="text"
+          value={displayValue}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled}
+        />
+      </div>
+    );
+  }
+);
+
+ColorInput.displayName = "ColorInput";
 
 export default ColorInput;

--- a/packages/web/src/components/maps/DeckglMap.tsx
+++ b/packages/web/src/components/maps/DeckglMap.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import DeckGL from "@deck.gl/react";
 import maplibregl from "maplibre-gl";
-
-import { Map } from "react-map-gl/maplibre";
 import { useThemeContext } from "@/context/theme.client";
+
+// Direct internal import avoids the barrel `export const Map` that shadows JS built-in Map
+import MapGLComponent from "react-map-gl/dist/esm/components/map";
 
 const MAP_STYLES = {
   light:
@@ -24,7 +25,7 @@ export default function DeckglMap({
   maxPitch = 60,
   setClickInfo,
   setHoverInfo,
-}) {
+}: any) {
   const { theme } = useThemeContext();
 
   const onRestrictStateChange = useCallback(
@@ -101,7 +102,7 @@ export default function DeckglMap({
       getTooltip={getTooltip}
       pickingRadius={5}
     >
-      <Map
+      <MapGLComponent
         mapLib={maplibregl}
         mapStyle={MAP_STYLES[theme]}
         reuseMaps={true}

--- a/packages/web/src/components/maps/DeckglMap.tsx
+++ b/packages/web/src/components/maps/DeckglMap.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useEffect, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useRef } from "react";
 
 import DeckGL from "@deck.gl/react";
 import maplibregl from "maplibre-gl";
 import { useThemeContext } from "@/context/theme.client";
 
-// Direct internal import avoids the barrel `export const Map` that shadows JS built-in Map
-import MapGLComponent from "react-map-gl/dist/esm/components/map";
+// Direct internal import avoids the barrel `export const Map` that shadows JS built-in Map.
+// The raw function expects (props, ref, defaultLib) and uses useImperativeHandle(ref),
+// so it must be wrapped in forwardRef for React to supply a proper ref.
+import _RawMapComponent from "react-map-gl/dist/esm/components/map";
+const MapGLComponent = forwardRef(function MapGLComponent(props: any, ref: any) {
+  return (_RawMapComponent as any)(props, ref, maplibregl);
+});
 
 const MAP_STYLES = {
   light:

--- a/packages/web/src/components/maps/MapClickPopup.tsx
+++ b/packages/web/src/components/maps/MapClickPopup.tsx
@@ -25,7 +25,6 @@ function MapClickPopup({
       className="bg-background border-2 rounded shadow-lg max-h-full flex flex-col relative"
       style={{ borderColor }}
     >
-      {}
       <button
         onClick={onClose}
         className="absolute top-2 right-2 p-1 hover:bg-accent rounded flex-shrink-0 z-10"
@@ -34,7 +33,6 @@ function MapClickPopup({
         <BiX className="h-4 w-4" />
       </button>
 
-      {}
       <div className="flex items-center gap-2 p-2 pr-10 border-b flex-shrink-0">
         <h2 className="font-semibold text-sm truncate">{title}</h2>
       </div>

--- a/packages/web/src/components/maps/MapContainer.tsx
+++ b/packages/web/src/components/maps/MapContainer.tsx
@@ -6,6 +6,7 @@ interface MapContainerProps {
   showLegend?: boolean;
   legendContent?: ReactNode;
   clickPopup?: ReactNode;
+  popupPosition?: "left" | "bottom-right";
 }
 
 function MapContainer({
@@ -14,43 +15,51 @@ function MapContainer({
   showLegend = false,
   legendContent,
   clickPopup,
+  popupPosition = "left",
 }: MapContainerProps) {
   return (
     <div className="flex flex-col h-full w-full">
-      {}
-      {clickPopup && (
+      {clickPopup && popupPosition === "left" && (
         <div className="w-full sm:hidden p-2 flex-shrink-0">
           {clickPopup}
         </div>
       )}
 
-      {}
       <div className="relative flex-1 min-h-0">
         <div className="h-full w-full border rounded overflow-hidden">
           {children}
         </div>
 
-        {}
         {instructionText && (
           <div className="absolute top-2 left-2 z-10 text-xs text-muted-foreground bg-background/80 backdrop-blur-sm px-2 py-1 rounded pointer-events-none">
             {instructionText}
           </div>
         )}
 
-        {}
-        {clickPopup && (
+        {clickPopup && popupPosition === "left" && (
           <div className="hidden sm:block absolute top-2 bottom-2 left-2 z-30 w-64 sm:w-72 overflow-hidden">
             {clickPopup}
           </div>
         )}
 
-        {}
+        {clickPopup && popupPosition === "bottom-right" && (
+          <div className="hidden sm:block absolute bottom-2 right-2 z-30 w-72 md:w-80 rounded-md border bg-background/95 backdrop-blur-sm shadow-lg">
+            {clickPopup}
+          </div>
+        )}
+
         {showLegend && legendContent && (
-          <div className="absolute bottom-2 right-2 z-20">
+          <div className={`absolute z-20 ${clickPopup && popupPosition === "bottom-right" ? "top-2 right-2" : "bottom-2 right-2"}`}>
             {legendContent}
           </div>
         )}
       </div>
+
+      {clickPopup && popupPosition === "bottom-right" && (
+        <div className="sm:hidden flex-shrink-0 rounded-md border bg-background shadow-sm mt-2 p-2">
+          {clickPopup}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/maps/PointsMapEditor.tsx
+++ b/packages/web/src/components/maps/PointsMapEditor.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PathLayer, ScatterplotLayer } from "@deck.gl/layers";
+import DeckglMap from "@/components/maps/DeckglMap.lazy";
+import MapContainer from "@/components/maps/MapContainer";
+import { fitBoundsToPoints, DEFAULT_BOUNDS } from "@/functions/mapComponent/fitBounds";
+import { useDuckDB } from "@/context/duckdb.client";
+import { useThemeContext } from "@/context/theme.client";
+import { BiReset, BiTrash, BiUndo } from "react-icons/bi";
+import { Button } from "@/components/ui/button";
+
+export type MapPoint = { lat: number; lon: number };
+
+interface PointsMapEditorProps {
+  points: MapPoint[];
+  onUpdatePoints: (pts: MapPoint[]) => void;
+  contextStops?: Array<{ stop_id: string; stop_name?: string; stop_lat: number; stop_lon: number; location_type_name?: string }>;
+  originalPoints?: MapPoint[];
+  height?: string;
+  showToolbar?: boolean;
+  instructionText?: string;
+}
+
+export function PointsMapEditor({
+  points,
+  onUpdatePoints,
+  contextStops = [],
+  originalPoints,
+  height = "h-56",
+  showToolbar = true,
+  instructionText,
+}: PointsMapEditorProps) {
+  const { theme } = useThemeContext();
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const [viewState, setViewState] = useState<any>(null);
+  const [boundBox, setBoundBox] = useState<[number[], number[]] | undefined>();
+  const [fitZoom, setFitZoom] = useState(4);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const isDraggingRef = useRef(false);
+  const dragIdxRef = useRef<number | null>(null);
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
+  const boundsFittedRef = useRef(false);
+
+  // Undo stack
+  const undoStackRef = useRef<MapPoint[][]>([]);
+  const [undoCount, setUndoCount] = useState(0);
+  const pushUndo = useCallback(() => {
+    undoStackRef.current = [...undoStackRef.current.slice(-19), pointsRef.current.map((p) => ({ ...p }))];
+    setUndoCount(undoStackRef.current.length);
+  }, []);
+  const handleUndo = useCallback(() => {
+    if (undoStackRef.current.length === 0) return;
+    const last = undoStackRef.current[undoStackRef.current.length - 1];
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    setUndoCount(undoStackRef.current.length);
+    onUpdatePoints(last);
+    setSelectedIdx(null);
+  }, [onUpdatePoints]);
+
+  // Fit bounds on first load
+  useEffect(() => {
+    if (boundsFittedRef.current || !conn) return;
+    const allPts = [
+      ...points.filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lon)),
+      ...contextStops
+        .filter((s) => Number.isFinite(Number(s.stop_lat)) && Number.isFinite(Number(s.stop_lon)))
+        .map((s) => ({ lat: Number(s.stop_lat), lon: Number(s.stop_lon) })),
+    ];
+    if (allPts.length === 0) return;
+    let cancelled = false;
+    fitBoundsToPoints(conn, allPts).then((fit) => {
+      if (cancelled || !fit) return;
+      boundsFittedRef.current = true;
+      setViewState(fit.viewState);
+      setBoundBox(fit.boundBox as [number[], number[]]);
+      setFitZoom(fit.viewState.zoom);
+    });
+    return () => { cancelled = true; };
+  }, [conn, contextStops, points]);
+
+  const layers = useMemo(() => {
+    const isDark = theme === "dark";
+    const ls: any[] = [];
+
+    if (contextStops.length > 0) {
+      const validStops = contextStops.filter((s) => Number.isFinite(Number(s.stop_lat)) && Number.isFinite(Number(s.stop_lon)));
+      ls.push(new ScatterplotLayer({
+        id: "shape-context-stops", data: validStops,
+        getPosition: (d: any) => [Number(d.stop_lon), Number(d.stop_lat)],
+        getFillColor: (d: any) => d.location_type_name === "Station"
+          ? (isDark ? [220, 220, 220, 200] : [80, 80, 80, 180])
+          : (isDark ? [180, 180, 180, 160] : [120, 120, 120, 150]),
+        getLineColor: isDark ? [60, 60, 60, 200] : [255, 255, 255, 220],
+        radiusUnits: "pixels" as const,
+        getRadius: (d: any) => d.location_type_name === "Station" ? 7 : 5,
+        radiusMinPixels: 4, stroked: true, getLineWidth: 1.5, lineWidthUnits: "pixels" as const,
+        pickable: false,
+      }));
+    }
+
+    if (points.length > 1) {
+      ls.push(new PathLayer({
+        id: "shape-path",
+        data: [{ path: points.map((p) => [p.lon, p.lat]) }],
+        getPath: (d: any) => d.path,
+        getColor: [59, 130, 246, 255],
+        getWidth: 4, widthUnits: "pixels" as const, capRounded: true, jointRounded: true, pickable: false,
+      }));
+    }
+
+    if (points.length > 0) {
+      const indexed = points.map((p, i) => ({ ...p, idx: i }));
+      ls.push(new ScatterplotLayer({
+        id: "shape-points", data: indexed,
+        getPosition: (d: any) => [d.lon, d.lat],
+        getFillColor: (d: any) => d.idx === selectedIdx ? [255, 80, 80, 255] : [59, 130, 246, 255],
+        getLineColor: [255, 255, 255, 230],
+        radiusUnits: "pixels" as const,
+        getRadius: (d: any) => d.idx === selectedIdx ? 9 : 5,
+        radiusMinPixels: 5, stroked: true,
+        getLineWidth: (d: any) => d.idx === selectedIdx ? 3 : 1,
+        lineWidthUnits: "pixels" as const, pickable: true,
+        onDragStart: (info: any) => {
+          if (info.object && typeof info.object.idx === "number") {
+            pushUndo();
+            isDraggingRef.current = true;
+            dragIdxRef.current = info.object.idx;
+            setSelectedIdx(info.object.idx);
+            return true;
+          }
+          return false;
+        },
+        onDrag: (info: any) => {
+          if (!isDraggingRef.current || dragIdxRef.current === null || !info.coordinate) return false;
+          const [lon, lat] = info.coordinate;
+          const np = [...pointsRef.current];
+          np[dragIdxRef.current] = { lat, lon };
+          pointsRef.current = np;
+          onUpdatePoints(np);
+          return true;
+        },
+        onDragEnd: () => {
+          if (isDraggingRef.current) { isDraggingRef.current = false; dragIdxRef.current = null; return true; }
+          return false;
+        },
+        updateTriggers: { getFillColor: [selectedIdx], getRadius: [selectedIdx], getLineWidth: [selectedIdx] },
+      }));
+    }
+    return ls;
+  }, [points, selectedIdx, onUpdatePoints, theme, contextStops]);
+
+  const handleClick = useCallback((event: any) => {
+    if (isDraggingRef.current) return;
+    if (event?.object && event.layer?.id === "shape-points") {
+      setSelectedIdx((prev) => prev === event.object.idx ? null : event.object.idx);
+      return;
+    }
+    if (!event?.coordinate) return;
+    const [lon, lat] = event.coordinate;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    if (selectedIdx !== null) {
+      pushUndo();
+      const np = [...pointsRef.current];
+      np[selectedIdx] = { lat, lon };
+      onUpdatePoints(np);
+    } else if (points.length === 0) {
+      onUpdatePoints([{ lat, lon }]);
+      setSelectedIdx(0);
+    }
+  }, [points.length, selectedIdx, onUpdatePoints, pushUndo]);
+
+  if (!viewState) {
+    return <div className={`${height} rounded-md border animate-pulse bg-muted`} />;
+  }
+
+  const defaultInstruction = selectedIdx !== null
+    ? "Click map to move selected point. Click point to deselect."
+    : "Click a point to select. Drag to move.";
+
+  const hasChanges = originalPoints
+    ? (points.length !== originalPoints.length || points.some((p, i) => !originalPoints[i] || p.lat !== originalPoints[i].lat || p.lon !== originalPoints[i].lon))
+    : undoCount > 0;
+
+  const handleReset = () => {
+    if (originalPoints) {
+      pushUndo();
+      onUpdatePoints([...originalPoints]);
+      setSelectedIdx(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {showToolbar && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{points.length} points</span>
+          {selectedIdx !== null && (
+            <Button type="button" variant="destructive" size="sm" className="h-6 text-[10px] px-2"
+              onClick={() => { pushUndo(); onUpdatePoints(points.filter((_, i) => i !== selectedIdx)); setSelectedIdx(null); }}>
+              <BiTrash className="mr-1 h-3 w-3" />Delete #{selectedIdx + 1}
+            </Button>
+          )}
+          <Button type="button" variant="ghost" size="sm" className="h-6 text-[10px] px-2"
+            disabled={undoCount === 0}
+            onClick={handleUndo}>
+            <BiUndo className="mr-1 h-3 w-3" />Undo
+          </Button>
+          {originalPoints && (
+            <Button type="button" variant="ghost" size="sm" className="h-6 text-[10px] px-2"
+              disabled={!hasChanges}
+              onClick={handleReset}>
+              <BiReset className="mr-1 h-3 w-3" />Reset
+            </Button>
+          )}
+        </div>
+      )}
+      <div className={`${height} rounded-md overflow-hidden border`}>
+        <MapContainer instructionText={instructionText || defaultInstruction}>
+          <DeckglMap
+            MinZoom={Math.max(1, fitZoom - 2)} dragRotate={false} maxPitch={0}
+            MapLayers={layers}
+            BoundBox={boundBox || DEFAULT_BOUNDS} BoundPadding={0.01}
+            viewState={viewState} setViewState={setViewState}
+            setClickInfo={handleClick} setHoverInfo={() => {}}
+          />
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/pathways/PathwayFlowEditor.tsx
+++ b/packages/web/src/components/pathways/PathwayFlowEditor.tsx
@@ -935,10 +935,6 @@ export const PathwayFlowEditor: React.FC<PathwayFlowEditorProps> = ({
   const onInit = useCallback((instance: any) => {
     reactFlowInstanceRef.current = instance;
     setIsFlowReady(true);
-    console.log("React Flow initialized", {
-      nodes: instance.getNodes().length,
-      edges: instance.getEdges().length,
-    });
   }, []);
 
   const focusNodeById = useCallback(

--- a/packages/web/src/components/table/index.tsx
+++ b/packages/web/src/components/table/index.tsx
@@ -16,18 +16,9 @@ import {
   SelectTrigger,
   SelectContent,
 } from "@/components/ui/select";
-import {
-  BiChevronUp,
-  BiChevronDown,
-  BiChevronRight,
-  BiChevronLeft,
-  BiChevronsRight,
-  BiChevronsLeft,
-  BiRightArrow,
-} from "react-icons/bi";
+import { BiChevronUp, BiChevronDown, BiChevronRight, BiChevronLeft, BiChevronsRight, BiChevronsLeft, BiRightArrow } from "react-icons/bi";
 import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { BiPencil } from "react-icons/bi";
+import { EditIndicator } from "@/components/ui/EditIndicator";
 
 function TableComponent({
   data,
@@ -208,13 +199,7 @@ function TableComponent({
                     onClick={() => handleRowClick(row.original)}
                   >
                     <TableCell className="w-8 px-2">
-                      {isEdited && (
-                        <Avatar>
-                          <AvatarFallback className="bg-primary">
-                            <BiPencil className="h-4 w-4" />
-                          </AvatarFallback>
-                        </Avatar>
-                      )}
+                      {isEdited && <EditIndicator status={row.original.status} className="h-5 w-5" />}
                     </TableCell>
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>

--- a/packages/web/src/components/ui/EditIndicator.tsx
+++ b/packages/web/src/components/ui/EditIndicator.tsx
@@ -1,44 +1,44 @@
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { BiPencil, BiPlus } from "react-icons/bi";
+import { BiPencil } from "react-icons/bi";
 
 interface EditIndicatorProps {
   status?: string;
   className?: string;
 }
 
-const getStatusKind = (status?: string | null): "edit" | "new" | null => {
+const getStatusKind = (status?: string | null): "edit" | "new" | "deleted" | null => {
   if (status === "new" || status === "new edit") return "new";
   if (status === "edit") return "edit";
+  if (status === "deleted") return "deleted";
   return null;
 };
 
 export function EditIndicator({
   status,
-  className = "h-6 w-6",
+  className = "h-5 w-5",
 }: EditIndicatorProps) {
   const statusKind = getStatusKind(status);
 
   if (!statusKind || !status) return null;
 
   return (
-    <span className="inline-block relative group shrink-0">
-      <Avatar className={className}>
-        <AvatarFallback
-          className={
-            statusKind === "new"
-              ? "bg-primary text-primary-foreground"
-              : "bg-secondary text-secondary-foreground"
-          }
-        >
-          {statusKind === "new" ? (
-            <BiPlus className="h-4 w-4" />
-          ) : (
-            <BiPencil className="h-4 w-4" />
-          )}
-        </AvatarFallback>
-      </Avatar>
+    <span className="inline-flex relative group shrink-0">
+      <span className={`inline-flex items-center justify-center rounded-full ${className} ${
+        statusKind === "new"
+          ? "bg-green-100 dark:bg-green-900/40"
+          : statusKind === "deleted"
+            ? "bg-red-100 dark:bg-red-900/40"
+            : "bg-amber-100 dark:bg-amber-900/40"
+      }`}>
+        {statusKind === "new" ? (
+          <span className="text-[9px] leading-none flex items-center justify-center">🆕</span>
+        ) : statusKind === "deleted" ? (
+          <BiPencil className="h-3 w-3 text-red-600 dark:text-red-400" />
+        ) : (
+          <BiPencil className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+        )}
+      </span>
       <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-2 py-1 bg-popover text-popover-foreground text-xs rounded whitespace-nowrap z-50 border shadow-md">
-        {statusKind === "new" ? "New" : "Edited"}
+        {statusKind === "new" ? "New" : statusKind === "deleted" ? "Deleted" : "Edited"}
       </span>
     </span>
   );

--- a/packages/web/src/components/ui/TimeInput.tsx
+++ b/packages/web/src/components/ui/TimeInput.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { parseTime } from "@/lib/tripUtils";
+
+const TIME_DATALIST_ID = "gtfs-time-suggestions";
+const TIME_SUGGESTIONS = (() => {
+  const opts: string[] = [];
+  for (let h = 0; h < 30; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      opts.push(`${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`);
+    }
+  }
+  return opts;
+})();
+
+export function TimeInput({ value, onChange, placeholder }: { value: string; onChange: (v: string) => void; placeholder?: string }) {
+  const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  // Sync from parent when not focused (external changes like timeline drag)
+  useEffect(() => {
+    if (!focused) setDraft(value);
+  }, [value, focused]);
+
+  const commit = (v: string) => {
+    const parsed = parseTime(v);
+    if (parsed) { onChange(parsed); setDraft(parsed); }
+    else if (v.trim() === "") { onChange(""); setDraft(""); }
+  };
+
+  return (
+    <>
+      <input
+        list={TIME_DATALIST_ID}
+        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        value={draft}
+        placeholder={placeholder || "HH:MM"}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={(e) => { setFocused(false); commit(e.target.value); }}
+        onKeyDown={(e) => { if (e.key === "Enter") commit(draft); }}
+      />
+      <datalist id={TIME_DATALIST_ID}>
+        {TIME_SUGGESTIONS.map((t) => <option key={t} value={t} />)}
+      </datalist>
+    </>
+  );
+}

--- a/packages/web/src/components/ui/accordion.tsx
+++ b/packages/web/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { BiChevronDown } from "react-icons/bi"
+import { BiChevronDown } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/components/ui/calendar.tsx
+++ b/packages/web/src/components/ui/calendar.tsx
@@ -1,0 +1,17 @@
+import { DayPicker } from "react-day-picker";
+import "react-day-picker/style.css";
+import { cn } from "@/lib/utils";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({ className, ...props }: CalendarProps) {
+  return (
+    <DayPicker
+      className={cn("p-3", className)}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = "Calendar";
+
+export { Calendar };

--- a/packages/web/src/components/ui/checkbox.tsx
+++ b/packages/web/src/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { BiCheck } from "react-icons/bi"
+import { BiCheck } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/components/ui/combobox.tsx
+++ b/packages/web/src/components/ui/combobox.tsx
@@ -106,7 +106,7 @@ export default function Combobox({
         </div>
       </div>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0">
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] min-w-[200px] p-0">
         <Command shouldFilter={true}>
           <CommandInput placeholder={Message} />
           <CommandList className="max-h-[300px]">

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
-import { BiSearch } from "react-icons/bi"
+import { BiSearch } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { BiX } from "react-icons/bi"
+import { BiX } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -31,8 +31,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideCloseButton?: boolean }
+>(({ className, children, hideCloseButton, ...props }, ref) => (
   <DialogPortal container={typeof document !== 'undefined' ? document.body : undefined}>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,10 +44,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-accent-foreground">
-        <BiX className="h-4 w-4 text-foreground" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-accent-foreground">
+          <BiX className="h-4 w-4 text-foreground" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/packages/web/src/components/ui/formpopup.tsx
+++ b/packages/web/src/components/ui/formpopup.tsx
@@ -14,7 +14,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog"
 
-const FormPopup = ({ children, setOpenValue, OpenValue }) => {
+const FormPopup = ({ children, setOpenValue, OpenValue, isBusy = false }) => {
   const isDesktop = useMediaQuery("(min-width: 768px)")
   const openedAtRef = React.useRef(0)
   const isOpen = OpenValue?.state === true;
@@ -26,13 +26,13 @@ const FormPopup = ({ children, setOpenValue, OpenValue }) => {
   }, [isOpen])
 
   const handleOpenChange = (open: boolean) => {
-    if (!open) {
+    if (!open && !isBusy) {
       setOpenValue({ formType: null, state: false })
     }
   }
 
-  const preventImmediateOutsideClose = (event: Event) => {
-    if (Date.now() - openedAtRef.current < 150) {
+  const preventCloseWhileBusy = (event: Event) => {
+    if (isBusy || Date.now() - openedAtRef.current < 150) {
       event.preventDefault()
     }
   }
@@ -41,8 +41,9 @@ const FormPopup = ({ children, setOpenValue, OpenValue }) => {
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
         className="max-w-2xl max-h-[85vh] flex flex-col overflow-visible p-0"
-        onPointerDownOutside={preventImmediateOutsideClose}
-        onInteractOutside={preventImmediateOutsideClose}
+        onPointerDownOutside={preventCloseWhileBusy}
+        onInteractOutside={preventCloseWhileBusy}
+        hideCloseButton={isBusy}
       >
         <DialogTitle className="hidden" />
         <DialogDescription className="hidden" />
@@ -55,7 +56,7 @@ const FormPopup = ({ children, setOpenValue, OpenValue }) => {
     <Drawer open={isOpen} onOpenChange={handleOpenChange}>
       <DrawerContent
         className="flex flex-col max-h-[90vh] overflow-visible"
-        onPointerDownOutside={preventImmediateOutsideClose}
+        onPointerDownOutside={preventCloseWhileBusy}
       >
         <DrawerHeader className="hidden">
           <DrawerTitle />

--- a/packages/web/src/components/ui/multiselect.tsx
+++ b/packages/web/src/components/ui/multiselect.tsx
@@ -1,11 +1,6 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
-import {
-  BiCheck,
-  BiXCircle,
-  BiChevronDown,
-  BiX,
-} from "react-icons/bi"
+import { BiCheck, BiXCircle, BiChevronDown, BiX } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"

--- a/packages/web/src/components/ui/navigation-menu.tsx
+++ b/packages/web/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import { BiChevronDown } from "react-icons/bi"
+import { BiChevronDown } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { BiCheck, BiChevronDown, BiChevronUp } from "react-icons/bi"
+import { BiCheck, BiChevronDown, BiChevronUp } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/components/ui/sheet.tsx
+++ b/packages/web/src/components/ui/sheet.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { BiX } from "react-icons/bi"
+import { BiX } from "react-icons/bi";
 
 import { cn } from "@/lib/utils"
 

--- a/packages/web/src/lib/cli/isCliSession.ts
+++ b/packages/web/src/lib/cli/isCliSession.ts
@@ -9,13 +9,15 @@ export const isCliSession = (): boolean => {
 
   const params = new URLSearchParams(window.location.search);
   if (params.has("gtfsSource") && params.has("cliSession") && params.has("cliApi")) {
+    // Persist CLI flag so new tabs/root navigation also detect CLI mode
+    try { window.localStorage.setItem("gtfs_viz_cli_session", "true"); } catch {}
     return true;
   }
 
   try {
-    const stored = window.sessionStorage.getItem("gtfs_viz_cli_launch_profile");
-    return stored !== null;
-  } catch {
-    return false;
-  }
+    if (window.sessionStorage.getItem("gtfs_viz_cli_launch_profile") !== null) return true;
+    if (window.localStorage.getItem("gtfs_viz_cli_session") === "true") return true;
+  } catch {}
+
+  return false;
 };

--- a/packages/web/src/lib/duckdb/DataEditing/editingFn.tsx
+++ b/packages/web/src/lib/duckdb/DataEditing/editingFn.tsx
@@ -1,9 +1,17 @@
 import {
     insertTableRow, editTableRow, editNewTableRow,
-    deleteEditRow, truncateTable
+    deleteEditRow, truncateTable, refreshMaterializedTable
 } from "@/lib/duckdb/DataEditing/insertData";
 import { formatSqlValue } from "@/lib/duckdb/QueryHelper";
 import { logger } from "@/lib/logger";
+
+const EDIT_TABLE_TO_MATERIALIZED: Record<string, string[]> = {
+    EditStopTable: ['StopsTable', 'StationsTable'],
+    EditRouteTable: ['RoutesTable'],
+    EditTripsTable: ['TripsTable'],
+    EditCalendarTable: ['CalendarTable'],
+    EditStopTimesTable: ['TripsTable'],
+};
 
 export const mutationEditStationFn = async ({conn, formData, SelectStation}) => {
     if ( SelectStation.status === '') {
@@ -97,6 +105,14 @@ export const mutationExportFn = async ({
     TableName,
     tableName,
     rowIdField = 'stop_id',
+}: {
+    conn: any;
+    mutateType: string;
+    SelectStation?: any;
+    selectedRow?: any;
+    TableName?: string;
+    tableName?: string;
+    rowIdField?: string;
 }) => {
     const rowToRevert = selectedRow ?? SelectStation;
     const targetTable = tableName ?? TableName;
@@ -116,7 +132,12 @@ export const mutationExportFn = async ({
             conn,
             table: targetTable
         })
-    } 
+    }
+    // Refresh materialized tables affected by this edit table
+    const toRefresh = EDIT_TABLE_TO_MATERIALIZED[targetTable] || [];
+    for (const t of toRefresh) {
+        await refreshMaterializedTable(conn, t);
+    }
 }
 
 export const mutationUpgradeToStationFn = async ({conn, SelectStation}) => {

--- a/packages/web/src/lib/duckdb/DataEditing/insertData.tsx
+++ b/packages/web/src/lib/duckdb/DataEditing/insertData.tsx
@@ -102,3 +102,24 @@ export const truncateTable = async (props) => {
         throw error;
     }
 }
+
+/**
+ * Refresh a materialized table by re-running its source macro.
+ * Call after edits to keep materialized tables in sync with views.
+ */
+export const refreshMaterializedTable = async (conn, tableName) => {
+    const macroMap: Record<string, string> = {
+        TripsTable: 'get_trips_table_data',
+        CalendarTable: 'get_calendar_table_data',
+        StopsTable: 'get_stops_table_data',
+        StationsTable: 'get_stations_table_data',
+        RoutesTable: 'get_routes_table_data',
+    };
+    const macro = macroMap[tableName];
+    if (!macro) return;
+    try {
+        await executeQuery(conn, `CREATE OR REPLACE TABLE ${tableName} AS SELECT * FROM ${macro}()`);
+    } catch (error) {
+        logger.error(`Error refreshing ${tableName}:`, error);
+    }
+};

--- a/packages/web/src/lib/duckdb/DataExporting/exportingData.tsx
+++ b/packages/web/src/lib/duckdb/DataExporting/exportingData.tsx
@@ -49,6 +49,49 @@ const Datafiles = [
       merge_id: "route_id"
     },
   },
+  {
+    orgTable: {
+      name: "stop_times",
+      file: "stop_times.csv",
+      removeList: [
+        "row_id", "status"
+      ]
+    },
+    editTable: {
+      name: "EditStopTimesTable",
+      editQuery: EditMergeQuery,
+      merge_id: "row_id"
+    },
+  },
+  {
+    orgTable: {
+      name: "calendar",
+      file: "calendar.csv",
+      removeList: [
+        "row_id", "status"
+      ]
+    },
+    editTable: {
+      name: "EditCalendarTable",
+      editQuery: EditMergeQuery,
+      merge_id: "service_id"
+    },
+  },
+  {
+    orgTable: {
+      name: "trips",
+      file: "trips.csv",
+      removeList: [
+        "row_id", "route_name", "route_type_name",
+        "route_color_hex", "route_text_color_hex", "status"
+      ]
+    },
+    editTable: {
+      name: "EditTripsTable",
+      editQuery: EditMergeQuery,
+      merge_id: "trip_id"
+    },
+  },
 ];
 
 const isCliNativeConn = (conn: any): boolean =>

--- a/packages/web/src/lib/duckdb/DataFetching/fetchExportData.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/fetchExportData.tsx
@@ -1,0 +1,108 @@
+import { formatSqlValue } from "../QueryHelper";
+import { logger } from "@/lib/logger";
+
+/**
+ * Generic: fetch original rows from a source table by ID for comparison in export view.
+ * Returns a map of idField → row.
+ */
+export const fetchOriginalRows = async (
+  conn: any,
+  table: string,
+  idField: string,
+  ids: string[],
+) => {
+  if (ids.length === 0) return {};
+  try {
+    const idList = ids.map((id) => formatSqlValue(id)).join(", ");
+    const castKey = idField === "row_id" ? `CAST(${idField} AS TEXT)` : idField;
+    const result = await conn.query(`SELECT * FROM ${table} WHERE ${castKey} IN (${idList})`);
+    const rows = result.toArray().map((row: any) => row.toJSON());
+    const map: Record<string, any> = {};
+    for (const row of rows) map[String(row[idField])] = row;
+    return map;
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Fetch original pathway rows for comparison in export view.
+ */
+export const fetchOriginalPathways = async (conn: any, pathwayIds: string[]) =>
+  fetchOriginalRows(conn, "pathways", "pathway_id", pathwayIds);
+
+/**
+ * Fetch original route shape points grouped by route_id for export comparison.
+ * Picks the shape with the most points per route.
+ */
+export const fetchOriginalRouteShapes = async (conn: any, routeIds: string[]) => {
+  if (routeIds.length === 0) return {};
+  try {
+    const ids = routeIds.map((id) => formatSqlValue(id)).join(", ");
+    const result = await conn.query(`
+      WITH shape_ranked AS (
+        SELECT t.route_id, t.shape_id, COUNT(*) as pt_count,
+          ROW_NUMBER() OVER (PARTITION BY t.route_id ORDER BY COUNT(*) DESC) as rn
+        FROM (
+          SELECT DISTINCT route_id, shape_id
+          FROM trips
+          WHERE route_id IN (${ids}) AND shape_id IS NOT NULL AND shape_id != ''
+        ) t
+        JOIN shapes s ON s.shape_id = t.shape_id
+        GROUP BY t.route_id, t.shape_id
+      )
+      SELECT sr.route_id, s.shape_pt_lat, s.shape_pt_lon, s.shape_pt_sequence
+      FROM shapes s
+      JOIN shape_ranked sr ON s.shape_id = sr.shape_id
+      WHERE sr.rn = 1
+      ORDER BY sr.route_id, s.shape_pt_sequence
+    `);
+    const rows = result.toArray().map((row: any) => row.toJSON());
+    const shapeMap: Record<string, { lat: number; lon: number }[]> = {};
+    for (const row of rows) {
+      const routeId = row.route_id;
+      if (!shapeMap[routeId]) shapeMap[routeId] = [];
+      const lat = Number(row.shape_pt_lat);
+      const lon = Number(row.shape_pt_lon);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        shapeMap[routeId].push({ lat, lon });
+      }
+    }
+    return shapeMap;
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Fetch stop metadata (name, parent_station, location_type) for pathway export view.
+ * Prefers edited stops over originals.
+ */
+export const fetchStopMetadataForPathways = async (conn: any, stopIds: string[]) => {
+  if (stopIds.length === 0) return {};
+  try {
+    const ids = stopIds.map((id) => formatSqlValue(id)).join(", ");
+    const result = await conn.query(`
+      SELECT edt.stop_id, edt.stop_name, edt.parent_station, edt.location_type_name
+      FROM EditStopTable edt
+      WHERE edt.stop_id IN (${ids})
+        AND edt.status IN ('new', 'edit', 'new edit')
+      UNION ALL
+      SELECT st.stop_id, st.stop_name, st.parent_station, st.location_type_name
+      FROM stops st
+      WHERE st.stop_id IN (${ids})
+        AND NOT EXISTS (
+          SELECT 1 FROM EditStopTable edt
+          WHERE edt.stop_id = st.stop_id
+            AND edt.status IN ('new', 'edit', 'new edit')
+        )
+    `);
+    const rows = result.toArray().map((row: any) => row.toJSON());
+    const map: Record<string, any> = {};
+    for (const row of rows) map[row.stop_id] = row;
+    return map;
+  } catch (err) {
+    logger.error("Error fetching stop metadata:", err);
+    return {};
+  }
+};

--- a/packages/web/src/lib/duckdb/DataFetching/fetchGTFSData.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/fetchGTFSData.tsx
@@ -2,6 +2,7 @@ import {
   executeQuery,
   buildAndQuery,
   executeColumnQuery,
+  fetchDistinctColumnValues,
 } from "@/lib/duckdb/QueryHelper";
 import { logger } from "@/lib/logger";
 
@@ -88,49 +89,13 @@ export const fetchStationsData = async (
   }
 };
 
-export const fetchPathwaysStatusData = async (
-  props
-): Promise<string[]> => {
+// Generic distinct column fetcher — all 4 variants below use this
+const fetchDistinctWithFilters = async (props: any, column: string) => {
   const { conn, table } = props;
-  let baseQuery = `SELECT DISTINCT pathways_status FROM ${table}`;
-  const conditions = addConditions(props);
-
-  const query = buildAndQuery(baseQuery, conditions);
-
-  return executeColumnQuery(conn, query, "pathways_status");
+  return fetchDistinctColumnValues(conn, table, column, addConditions(props));
 };
 
-export const fetchStopsIdData = async (
-  props
-): Promise<string[]> => {
-  const { conn, table } = props;
-  let baseQuery = `SELECT DISTINCT stop_id FROM ${table}`;
-  const conditions = addConditions(props);
-
-  const query = buildAndQuery(baseQuery, conditions);
-  return executeColumnQuery(conn, query, "stop_id");
-};
-
-export const fetchStopsNamesData = async (
-  props
-): Promise<string[]> => {
-  const { conn, table } = props;
-  let baseQuery = `SELECT DISTINCT stop_name FROM ${table}`;
-  const conditions = addConditions(props);
-
-  const query = buildAndQuery(baseQuery, conditions);
-
-  return executeColumnQuery(conn, query, "stop_name");
-};
-
-export const fetchWheelchairStatusData = async (
-  props
-): Promise<string[]> => {
-  const { conn, table } = props;
-  let baseQuery = `SELECT DISTINCT wheelchair_status FROM ${table}`;
-  const conditions = addConditions(props);
-
-  const query = buildAndQuery(baseQuery, conditions);
-
-  return executeColumnQuery(conn, query, "wheelchair_status");
-};
+export const fetchPathwaysStatusData = (props: any) => fetchDistinctWithFilters(props, "pathways_status");
+export const fetchStopsIdData = (props: any) => fetchDistinctWithFilters(props, "stop_id");
+export const fetchStopsNamesData = (props: any) => fetchDistinctWithFilters(props, "stop_name");
+export const fetchWheelchairStatusData = (props: any) => fetchDistinctWithFilters(props, "wheelchair_status");

--- a/packages/web/src/lib/duckdb/DataFetching/fetchRouteData.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/fetchRouteData.tsx
@@ -1,4 +1,5 @@
-import { executeQuery } from "@/lib/duckdb/QueryHelper";
+import { executeQuery, escapeSql } from "@/lib/duckdb/QueryHelper";
+import { insertTableRow, deleteEditRow, refreshMaterializedTable } from "@/lib/duckdb/DataEditing/insertData";
 import { logger } from "@/lib/logger";
 import { getPathfindingFunctions } from "./pathways/hybridPathfinding";
 
@@ -30,7 +31,6 @@ export const fetchRouteData = async (props) => {
   }
 };
 
-const escapeSql = (value: string) => value.replace(/'/g, "''");
 
 const routeIdListSql = (routeIds: string[]) => {
   return `[${routeIds.map((id) => `'${escapeSql(id)}'`).join(", ")}]`;
@@ -75,7 +75,7 @@ const ensureServiceTables = async (conn: any) => {
 };
 
 export const fetchServiceRouteServicesData = async (conn: any, routeId: string) => {
-  await ensureServiceTables(conn);
+  try { await ensureServiceTables(conn); } catch { /* tables may already exist */ }
   return executeQuery(
     conn,
     `
@@ -88,6 +88,15 @@ export const fetchServiceRouteServicesData = async (conn: any, routeId: string) 
         WHERE route_id = '${escapeSql(routeId)}'
           AND service_id IS NOT NULL AND service_id != ''
         GROUP BY route_id, service_id
+      ),
+      all_services AS (
+        SELECT rs.route_id, rs.service_id, rs.trip_count, rs.shape_count, rs.block_count, rs.headsign_count
+        FROM route_services rs
+        UNION ALL
+        SELECT '${escapeSql(routeId)}' AS route_id, cv.service_id, 0 AS trip_count, 0 AS shape_count, 0 AS block_count, 0 AS headsign_count
+        FROM CalendarView cv
+        WHERE cv.status IN ('new', 'new edit')
+          AND NOT EXISTS (SELECT 1 FROM route_services rs WHERE rs.service_id = cv.service_id)
       ),
       date_summary AS (
         SELECT service_id,
@@ -116,8 +125,8 @@ export const fetchServiceRouteServicesData = async (conn: any, routeId: string) 
              ds.last_exception_date,
              ds.added_exception_dates,
              ds.removed_exception_dates
-      FROM route_services rs
-      LEFT JOIN calendar c ON c.service_id = rs.service_id
+      FROM all_services rs
+      LEFT JOIN CalendarView c ON c.service_id = rs.service_id
       LEFT JOIN date_summary ds ON ds.service_id = rs.service_id
       ORDER BY rs.service_id
     `,
@@ -136,18 +145,14 @@ export const fetchServiceRouteTripsForServiceData = async (
         SELECT trip_id,
                NULLIF(arrival_time, '') AS arrival_time,
                NULLIF(departure_time, '') AS departure_time,
-               CASE
-                 WHEN NULLIF(departure_time, '') IS NULL THEN NULL
-                 ELSE COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 1) AS INTEGER), 0) * 3600
-                    + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 2) AS INTEGER), 0) * 60
-                    + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 3) AS INTEGER), 0)
-               END AS departure_seconds,
-               CASE
-                 WHEN NULLIF(arrival_time, '') IS NULL THEN NULL
-                 ELSE COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 1) AS INTEGER), 0) * 3600
-                    + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 2) AS INTEGER), 0) * 60
-                    + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 3) AS INTEGER), 0)
-               END AS arrival_seconds
+               CASE WHEN NULLIF(departure_time, '') IS NULL THEN NULL
+                    ELSE COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 1) AS INTEGER), 0) * 3600
+                       + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 2) AS INTEGER), 0) * 60
+                       + COALESCE(TRY_CAST(SPLIT_PART(departure_time, ':', 3) AS INTEGER), 0) END AS departure_seconds,
+               CASE WHEN NULLIF(arrival_time, '') IS NULL THEN NULL
+                    ELSE COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 1) AS INTEGER), 0) * 3600
+                       + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 2) AS INTEGER), 0) * 60
+                       + COALESCE(TRY_CAST(SPLIT_PART(arrival_time, ':', 3) AS INTEGER), 0) END AS arrival_seconds
         FROM stop_times
         WHERE trip_id IS NOT NULL AND trip_id != ''
       ),
@@ -182,7 +187,7 @@ export const fetchServiceTripStopTimesData = async (conn: any, tripId: string) =
              COALESCE(station.stop_name, sv.stop_name) AS station_name,
              st.stop_headsign, st.pickup_type, st.drop_off_type, st.shape_dist_traveled,
              sv.stop_lat, sv.stop_lon
-      FROM stop_times st
+      FROM StopTimesView st
       LEFT JOIN StopsView sv ON sv.stop_id = st.stop_id
       LEFT JOIN StopsView station
         ON station.stop_id = COALESCE(NULLIF(sv.parent_station, ''), sv.stop_id)
@@ -191,6 +196,173 @@ export const fetchServiceTripStopTimesData = async (conn: any, tripId: string) =
       ORDER BY st.stop_sequence, st.arrival_time, st.departure_time, st.stop_id
     `,
   );
+};
+
+export const fetchAllTripsData = async (conn: any) => {
+  return executeQuery(conn, "SELECT * FROM TripsTable");
+};
+
+export const saveCalendarEdit = async (conn: any, data: {
+  service_id: string; monday: number; tuesday: number; wednesday: number; thursday: number;
+  friday: number; saturday: number; sunday: number; start_date: string; end_date: string;
+}, isNew: boolean) => {
+  const id = data.service_id.replace(/'/g, "''");
+  let status = "new";
+  if (!isNew) {
+    // Check if this was a previously added new service
+    const existing = await executeQuery(conn, `SELECT status FROM EditCalendarTable WHERE service_id = '${id}'`);
+    const prevStatus = existing.length > 0 ? String(existing[0].status) : null;
+    status = prevStatus === "new" ? "new edit" : "edit";
+    await conn.query(`DELETE FROM EditCalendarTable WHERE service_id = '${id}'`);
+  }
+  const mon = Number(data.monday) || 0;
+  const tue = Number(data.tuesday) || 0;
+  const wed = Number(data.wednesday) || 0;
+  const thu = Number(data.thursday) || 0;
+  const fri = Number(data.friday) || 0;
+  const sat = Number(data.saturday) || 0;
+  const sun = Number(data.sunday) || 0;
+  await conn.query(`
+    INSERT INTO EditCalendarTable (row_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date, status)
+    VALUES ('edit_${id}', '${id}', ${mon}, ${tue}, ${wed}, ${thu},
+            ${fri}, ${sat}, ${sun}, '${(data.start_date || '').replace(/'/g, "''")}', '${(data.end_date || '').replace(/'/g, "''")}', '${status}')
+  `);
+  await refreshMaterializedTable(conn, "CalendarTable");
+};
+
+export const deleteCalendar = async (conn: any, serviceId: string) => {
+  const id = serviceId.replace(/'/g, "''");
+  await conn.query(`DELETE FROM EditCalendarTable WHERE service_id = '${id}'`);
+  await conn.query(`INSERT INTO EditCalendarTable (row_id, service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date, status)
+    VALUES ('del_${id}', '${id}', 0, 0, 0, 0, 0, 0, 0, '', '', 'deleted')`);
+  await refreshMaterializedTable(conn, "CalendarTable");
+};
+
+export const saveTripEdit = async (conn: any, data: {
+  trip_id: string; route_id: string; service_id: string; trip_headsign?: string;
+  direction_id?: number; shape_id?: string;
+}, isNew: boolean) => {
+  const tid = data.trip_id.replace(/'/g, "''");
+  let status = "new";
+  if (!isNew) {
+    const existing = await executeQuery(conn, `SELECT status FROM EditTripsTable WHERE trip_id = '${tid}'`);
+    const prevStatus = existing.length > 0 ? String(existing[0].status) : null;
+    status = prevStatus === "new" ? "new edit" : "edit";
+    await conn.query(`DELETE FROM EditTripsTable WHERE trip_id = '${tid}'`);
+  }
+  await conn.query(`
+    INSERT INTO EditTripsTable (row_id, route_id, service_id, trip_id, trip_headsign, trip_short_name, direction_id, block_id, shape_id, wheelchair_accessible, bikes_allowed, status)
+    VALUES ('edit_${tid}', '${data.route_id.replace(/'/g, "''")}', '${data.service_id.replace(/'/g, "''")}', '${tid}',
+            ${data.trip_headsign ? `'${data.trip_headsign.replace(/'/g, "''")}'` : 'NULL'},
+            NULL, ${data.direction_id != null ? Number(data.direction_id) : 'NULL'}, NULL, ${data.shape_id ? `'${data.shape_id.replace(/'/g, "''")}'` : 'NULL'},
+            NULL, NULL, '${status}')
+  `);
+  await refreshMaterializedTable(conn, "TripsTable");
+};
+
+export const deleteTrip = async (conn: any, tripId: string) => {
+  const tid = tripId.replace(/'/g, "''");
+  await conn.query(`DELETE FROM EditTripsTable WHERE trip_id = '${tid}'`);
+  await conn.query(`INSERT INTO EditTripsTable (row_id, route_id, service_id, trip_id, status)
+    VALUES ('del_${tid}', '', '', '${tid}', 'deleted')`);
+  await refreshMaterializedTable(conn, "TripsTable");
+};
+
+export const fetchTripsTimeBounds = async (conn: any) => {
+  const rows = await executeQuery(conn, "SELECT * FROM get_trips_time_bounds()");
+  const row = rows[0];
+  if (!row || row.min_time == null || row.max_time == null) return null;
+  return { minTime: Number(row.min_time), maxTime: Number(row.max_time) };
+};
+
+export const saveStopTimesEdits = async (
+  conn: any,
+  tripId: string,
+  stops: Array<{ stop_sequence: number; stop_id?: string; arrival_time?: string; departure_time?: string; stop_headsign?: string; pickup_type?: number; drop_off_type?: number; shape_dist_traveled?: number }>,
+) => {
+  // Clear previous edits for this trip
+  await deleteEditRow({ conn, table: "EditStopTimesTable", column: "trip_id", formData: { trip_id: tripId } });
+
+  // Get original stop times to compare
+  const origRows = await executeQuery(conn, `SELECT row_id, stop_id, stop_sequence, arrival_time, departure_time FROM stop_times WHERE trip_id = '${escapeSql(tripId)}' ORDER BY stop_sequence`);
+
+  // Check if anything actually changed
+  let hasChanges = origRows.length !== stops.length;
+  if (!hasChanges) {
+    for (let i = 0; i < stops.length; i++) {
+      const orig = origRows[i];
+      const cur = stops[i];
+      if (String(orig.stop_id || "") !== (cur.stop_id || "") ||
+          String(orig.arrival_time || "") !== (cur.arrival_time || "") ||
+          String(orig.departure_time || "") !== (cur.departure_time || "")) {
+        hasChanges = true;
+        break;
+      }
+    }
+  }
+  if (!hasChanges) return;
+
+  // Determine per-stop status using multiset matching
+  const origIdCounts = new Map<string, number>();
+  for (const r of origRows) origIdCounts.set(String(r.stop_id || ""), (origIdCounts.get(String(r.stop_id || "")) || 0) + 1);
+  const usedCounts = new Map<string, number>();
+
+  for (const s of stops) {
+    const id = s.stop_id || "";
+    const used = usedCounts.get(id) || 0;
+    const isNew = used >= (origIdCounts.get(id) || 0);
+    usedCounts.set(id, used + 1);
+
+    await insertTableRow({
+      conn,
+      table: "EditStopTimesTable",
+      formData: {
+        row_id: `edit_${tripId}_${s.stop_sequence}`,
+        trip_id: tripId,
+        stop_sequence: s.stop_sequence,
+        stop_id: s.stop_id || "",
+        arrival_time: s.arrival_time || "",
+        departure_time: s.departure_time || "",
+        stop_headsign: s.stop_headsign || null,
+        pickup_type: s.pickup_type ?? null,
+        drop_off_type: s.drop_off_type ?? null,
+        shape_dist_traveled: s.shape_dist_traveled ?? null,
+        status: isNew ? "new" : "new edit",
+      },
+    });
+  }
+
+  // Insert 'deleted' rows for removed original stops
+  const newIdCounts = new Map<string, number>();
+  for (const s of stops) newIdCounts.set(s.stop_id || "", (newIdCounts.get(s.stop_id || "") || 0) + 1);
+  const toDelete = new Map<string, number>();
+  for (const [id, origCount] of origIdCounts) {
+    const diff = origCount - (newIdCounts.get(id) || 0);
+    if (diff > 0) toDelete.set(id, diff);
+  }
+  for (const r of origRows) {
+    const id = String(r.stop_id || "");
+    const left = toDelete.get(id) || 0;
+    if (left > 0) {
+      toDelete.set(id, left - 1);
+      await insertTableRow({
+        conn,
+        table: "EditStopTimesTable",
+        formData: {
+          row_id: String(r.row_id),
+          trip_id: tripId,
+          stop_sequence: Number(r.stop_sequence),
+          stop_id: id,
+          arrival_time: String(r.arrival_time || ""),
+          departure_time: String(r.departure_time || ""),
+          status: "deleted",
+        },
+      });
+    }
+  }
+
+  // Refresh materialized tables that depend on stop times
+  await refreshMaterializedTable(conn, "TripsTable");
 };
 
 export const fetchServiceRouteStationsData = async (conn: any, routeId: string) => {
@@ -209,6 +381,12 @@ export const fetchServiceRouteStopsData = async (conn: any, routeIds: string[]) 
     conn,
     `SELECT * FROM get_route_stops_for_routes(${routeIdListSql(routeIds)})`,
   );
+};
+
+export const fetchFitZoom = async (conn: any, minLon: number, maxLon: number, minLat: number, maxLat: number) => {
+  const result = await conn.query(`SELECT fit_zoom(${minLon}, ${maxLon}, ${minLat}, ${maxLat}) AS zoom`);
+  const row = result.toArray()[0];
+  return Number(row?.zoom ?? row?.toJSON?.()?.zoom ?? 10);
 };
 
 const boundsRowToFit = (rawRow: any) => {
@@ -337,4 +515,115 @@ export const fetchServiceRouteShapesData = async (
       ORDER BY route_id, shape_id, shape_pt_sequence
     `,
   );
+};
+
+// ─── Edit status queries ──────────────────────────────────────────
+
+export const fetchEditedTripStatuses = async (conn: any) => {
+  const stRows = await executeQuery(conn, "SELECT trip_id, status FROM EditStopTimesTable");
+  const tRows = await executeQuery(conn, "SELECT trip_id, status FROM EditTripsTable");
+  const m = new Map<string, string>();
+  const tripStatuses = new Map<string, Set<string>>();
+  for (const r of stRows) {
+    const id = String(r.trip_id);
+    if (!tripStatuses.has(id)) tripStatuses.set(id, new Set());
+    tripStatuses.get(id)!.add(String(r.status));
+  }
+  for (const [id, statuses] of tripStatuses) {
+    if (statuses.has("new") && !statuses.has("new edit") && !statuses.has("edit")) m.set(id, "new");
+    else m.set(id, "edit");
+  }
+  for (const r of tRows) m.set(String(r.trip_id), String(r.status));
+  return m;
+};
+
+export const fetchEditedCalendarStatuses = async (conn: any) => {
+  const rows = await executeQuery(conn, "SELECT service_id, status FROM EditCalendarTable");
+  const m = new Map<string, string>();
+  for (const r of rows) m.set(String(r.service_id), String(r.status));
+  return m;
+};
+
+export const fetchEditedTripStatusesForRoute = async (conn: any) => {
+  const rows = await executeQuery(conn, "SELECT trip_id, status FROM EditTripsTable");
+  const stRows = await executeQuery(conn, "SELECT DISTINCT trip_id FROM EditStopTimesTable");
+  const m = new Map<string, string>();
+  for (const r of rows) m.set(String(r.trip_id), String(r.status));
+  for (const r of stRows) { if (!m.has(String(r.trip_id))) m.set(String(r.trip_id), "edit"); }
+  return m;
+};
+
+export const fetchStopsWithRouteFlag = async (conn: any, routeId: string) => {
+  const escapedId = routeId.replace(/'/g, "''");
+  return executeQuery(conn, `
+    SELECT s.stop_id, s.stop_name, s.stop_lat, s.stop_lon, s.location_type_name, s.parent_station,
+           CASE WHEN rs.stop_id IS NOT NULL THEN true ELSE false END AS on_route
+    FROM StopsView s
+    LEFT JOIN RouteStopsTable rs ON rs.stop_id = s.stop_id AND rs.route_id = '${escapedId}'
+  `);
+};
+
+export const fetchRouteStopsForShape = async (conn: any, routeId: string) => {
+  const escapedId = routeId.replace(/'/g, "''");
+  return executeQuery(conn, `
+    SELECT DISTINCT s.stop_id, s.stop_name, CAST(s.stop_lat AS DOUBLE) AS stop_lat, CAST(s.stop_lon AS DOUBLE) AS stop_lon, s.location_type_name
+    FROM RouteStopsView rs
+    JOIN StopsView s ON s.stop_id = rs.stop_id
+    WHERE rs.route_id = '${escapedId}' AND s.stop_lat IS NOT NULL AND s.stop_lon IS NOT NULL
+  `);
+};
+
+export const fetchTripMapBounds = async (conn: any, tripId: string) => {
+  const rows = await executeQuery(conn, `SELECT * FROM get_trip_map_bounds('${tripId.replace(/'/g, "''")}')`);
+  return boundsRowToFit(rows[0]);
+};
+
+export const checkTripIdExists = async (conn: any, tripId: string) => {
+  if (!tripId.trim()) return false;
+  const rows = await executeQuery(conn, `SELECT 1 FROM TripsView WHERE trip_id = '${tripId.replace(/'/g, "''")}' LIMIT 1`);
+  return rows.length > 0;
+};
+
+export const fetchTripsForService = async (conn: any, serviceId: string) => {
+  const esc = serviceId.replace(/'/g, "''");
+  return executeQuery(conn, `SELECT trip_id, route_id, service_id FROM TripsView WHERE service_id = '${esc}'`);
+};
+
+export const deleteServiceCascade = async (conn: any, serviceId: string, routeId: string) => {
+  const esc = serviceId.replace(/'/g, "''");
+  const tripsForService = await executeQuery(conn, `SELECT trip_id, route_id, service_id FROM TripsView WHERE service_id = '${esc}'`);
+  for (const t of tripsForService) {
+    const tid = String(t.trip_id).replace(/'/g, "''");
+    const rid = String(t.route_id || routeId).replace(/'/g, "''");
+    const sid = String(t.service_id || serviceId).replace(/'/g, "''");
+    // Mark stop times as deleted
+    await conn.query(`DELETE FROM EditStopTimesTable WHERE trip_id = '${tid}'`);
+    try {
+      await conn.query(`
+        INSERT INTO EditStopTimesTable (row_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time, status)
+        SELECT 'del_' || CAST(row_id AS VARCHAR), trip_id, stop_sequence, stop_id, arrival_time, departure_time, 'deleted'
+        FROM stop_times WHERE trip_id = '${tid}'
+      `);
+    } catch { /* stop_times may not exist */ }
+    // Mark trip as deleted
+    await conn.query(`DELETE FROM EditTripsTable WHERE trip_id = '${tid}'`);
+    await conn.query(`INSERT INTO EditTripsTable (row_id, route_id, service_id, trip_id, status) VALUES ('del_${tid}', '${rid}', '${sid}', '${tid}', 'deleted')`);
+  }
+  await deleteCalendar(conn, serviceId);
+  await refreshMaterializedTable(conn, "TripsTable");
+};
+
+export const deleteTripCascade = async (conn: any, tripId: string) => {
+  const tid = tripId.replace(/'/g, "''");
+  // Remove any existing edit rows for this trip's stop times
+  await conn.query(`DELETE FROM EditStopTimesTable WHERE trip_id = '${tid}'`);
+  // Insert "deleted" markers for all original stop times
+  try {
+    await conn.query(`
+      INSERT INTO EditStopTimesTable (row_id, trip_id, stop_sequence, stop_id, arrival_time, departure_time, status)
+      SELECT 'del_' || CAST(row_id AS VARCHAR), trip_id, stop_sequence, stop_id, arrival_time, departure_time, 'deleted'
+      FROM stop_times WHERE trip_id = '${tid}'
+    `);
+  } catch { /* stop_times table may not exist */ }
+  await deleteTrip(conn, tripId);
 };

--- a/packages/web/src/lib/duckdb/DataFetching/fetchStationInfoData.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/fetchStationInfoData.tsx
@@ -1,12 +1,12 @@
 import { FetchProps } from "@/types/objectTypes";
-import { buildAndQuery, executeQuery, executeColumnQuery } from "@/lib/duckdb/QueryHelper";
+import { buildAndQuery, executeQuery, executeColumnQuery, checkTablesExist } from "@/lib/duckdb/QueryHelper";
 import { logger } from "@/lib/logger";
 import { recreateStopsView } from "@/lib/extensions";
 
 let viewRecreated = false;
 
 const ensureProceduresLoaded = async (conn: any) => {
-  
+
   if (!viewRecreated) {
     await recreateStopsView(conn);
     viewRecreated = true;
@@ -16,20 +16,6 @@ const ensureProceduresLoaded = async (conn: any) => {
 
 export const resetStationInfoProceduresFlag = () => {
   viewRecreated = false;
-};
-
-const checkTablesExist = async (conn: any): Promise<boolean> => {
-  try {
-    const result = await conn.query(`
-      SELECT COUNT(*) as count
-      FROM information_schema.tables
-      WHERE table_name IN ('stops', 'pathways')
-    `);
-    const count = result.toArray()[0]?.count || 0;
-    return Number(count) >= 1; 
-  } catch (error) {
-    return false;
-  }
 };
 
 const addConditions = (props: FetchProps): string[] => {
@@ -148,7 +134,7 @@ export const fetchCheckStationInfo = async (props) => {
 
   try {
     
-    const tablesExist = await checkTablesExist(conn);
+    const tablesExist = await checkTablesExist(conn, ["stops"]);
     if (!tablesExist) {
       logger.log('⚠️ Required tables (stops, pathways) do not exist yet');
       return null;

--- a/packages/web/src/lib/duckdb/DataFetching/pathways/fetchPathwayMapRoute.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/pathways/fetchPathwayMapRoute.tsx
@@ -1,30 +1,6 @@
-import { executeQuery } from "@/lib/duckdb/QueryHelper";
+import { executeQuery, toSqlString, toSqlNumber, toSqlStringList } from "@/lib/duckdb/QueryHelper";
 import { logger } from "@/lib/logger";
 import { getPathwayRouteFilterData } from "@/lib/pathways/routeFilterGraph";
-
-const toSqlString = (value?: string | null) => {
-  if (value == null || value === "") {
-    return "NULL";
-  }
-
-  return `'${String(value).replace(/'/g, "''")}'`;
-};
-
-const toSqlNumber = (value?: number | null) => {
-  if (value == null || Number.isNaN(value)) {
-    return "NULL";
-  }
-
-  return String(value);
-};
-
-const toSqlStringList = (values?: string[] | null) => {
-  if (!values || values.length === 0) {
-    return "NULL";
-  }
-
-  return `[${values.map((value) => toSqlString(value)).join(", ")}]`;
-};
 
 export const fetchPathwayMapRouteData = async ({
   conn,

--- a/packages/web/src/lib/duckdb/DataFetching/pathways/fetchStationPathways.tsx
+++ b/packages/web/src/lib/duckdb/DataFetching/pathways/fetchStationPathways.tsx
@@ -1,6 +1,6 @@
 
 
-import { executeQuery } from "@/lib/duckdb/QueryHelper";
+import { executeQuery, checkTablesExist } from "@/lib/duckdb/QueryHelper";
 import { logger } from "@/lib/logger";
 import { TimeIntervalColors } from "@/components/style";
 import {
@@ -45,20 +45,6 @@ const ensureProceduresLoaded = async (conn: any) => {
 
 export const resetProceduresFlag = () => {
   viewRecreated = false;
-};
-
-const checkTablesExist = async (conn: any): Promise<boolean> => {
-  try {
-    const result = await conn.query(`
-      SELECT COUNT(*) as count
-      FROM information_schema.tables
-      WHERE table_name IN ('pathways', 'stops')
-    `);
-    const count = result.toArray()[0]?.count || 0;
-    return Number(count) === 2; 
-  } catch (error) {
-    return false;
-  }
 };
 
 export interface StationPathwaysData {
@@ -114,7 +100,7 @@ export const fetchStationPathwaysComplete = async (props: {
 
     logger.log(`🔍 Fetching pathways for station ${stationId}`);
 
-    const tablesExist = await checkTablesExist(conn);
+    const tablesExist = await checkTablesExist(conn, ["pathways", "stops"]);
     if (!tablesExist) {
       logger.log('⚠️ Required tables (pathways, stops) do not exist yet');
       return {

--- a/packages/web/src/lib/duckdb/QueryHelper.tsx
+++ b/packages/web/src/lib/duckdb/QueryHelper.tsx
@@ -131,6 +131,55 @@ export const generateDynamicSelectQuery = async (
   return filterList;
 };
 
+/** Escape a string for safe SQL interpolation */
+export const escapeSql = (value: string) => value.replace(/'/g, "''");
+
+/** Format a value for SQL: strings are quoted+escaped, null/undefined/empty → NULL */
+export const toSqlString = (value?: string | null) => {
+  if (value === null || value === undefined || value === "") return "NULL";
+  return `'${escapeSql(value)}'`;
+};
+
+/** Format a number for SQL: null/undefined → NULL */
+export const toSqlNumber = (value?: number | null) => {
+  if (value === null || value === undefined) return "NULL";
+  return String(value);
+};
+
+/** Format a string array for SQL list: ['a','b'] */
+export const toSqlStringList = (values?: string[] | null) => {
+  if (!values || values.length === 0) return "NULL";
+  return `[${values.map((v) => toSqlString(v)).join(", ")}]`;
+};
+
+/** Check if required tables exist in DuckDB */
+export const checkTablesExist = async (conn: any, tables: string[]): Promise<boolean> => {
+  try {
+    const placeholders = tables.map((t) => `'${escapeSql(t)}'`).join(", ");
+    const result = await conn.query(`
+      SELECT COUNT(*) AS cnt
+      FROM information_schema.tables
+      WHERE table_name IN (${placeholders})
+    `);
+    const count = Number(result.toArray()[0]?.cnt ?? 0);
+    return count >= tables.length;
+  } catch {
+    return false;
+  }
+};
+
+/** Fetch distinct values from a column with optional conditions */
+export const fetchDistinctColumnValues = async (
+  conn: any,
+  table: string,
+  column: string,
+  conditions: string[] = [],
+): Promise<{ label: string; value: string }[]> => {
+  const baseQuery = `SELECT DISTINCT ${column} FROM ${table}`;
+  const query = buildAndQuery(baseQuery, conditions);
+  return executeColumnQuery(conn, query, column);
+};
+
 export const EditMergeQuery = (
   columns: string[],
   mappedColumns: string[],

--- a/packages/web/src/lib/extensions.ts
+++ b/packages/web/src/lib/extensions.ts
@@ -13,6 +13,7 @@ import {
   recreatePathwaysView as _recreatePathwaysView,
 } from "@gtfs-viz/duckdb-extension";
 import type { SqlExecutor } from "@gtfs-viz/duckdb-extension";
+import { logger } from "@/lib/logger";
 
 function createExecutor(conn: any): SqlExecutor {
   return async (sql: string) => {
@@ -87,7 +88,7 @@ export const reloadQueryMacros = async (conn: any): Promise<void> => {
       await installInit(createExecutor(conn));
     }
   } catch (error) {
-    console.warn("Could not check for pathway_network view:", error);
+    logger.warn("Could not check for pathway_network view:", error);
   }
 };
 

--- a/packages/web/src/lib/gtfs-ingestion/macros.ts
+++ b/packages/web/src/lib/gtfs-ingestion/macros.ts
@@ -46,4 +46,14 @@ CREATE OR REPLACE MACRO bidirectional_to_direction(is_bidirectional) AS (
     ELSE 'unknown'
   END
 );
+
+-- gtfs_time_to_seconds: Convert GTFS time string (HH:MM:SS, supports >24h) to seconds
+CREATE OR REPLACE MACRO gtfs_time_to_seconds(time_str) AS (
+  CASE
+    WHEN NULLIF(time_str, '') IS NULL THEN NULL
+    ELSE COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 1) AS INTEGER), 0) * 3600
+       + COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 2) AS INTEGER), 0) * 60
+       + COALESCE(TRY_CAST(SPLIT_PART(time_str, ':', 3) AS INTEGER), 0)
+  END
+);
 `;

--- a/packages/web/src/lib/gtfsDateUtils.ts
+++ b/packages/web/src/lib/gtfsDateUtils.ts
@@ -1,0 +1,56 @@
+import { format, parse } from "date-fns";
+
+export const DAY_LABELS = [
+  ["monday", "Mon"],
+  ["tuesday", "Tue"],
+  ["wednesday", "Wed"],
+  ["thursday", "Thu"],
+  ["friday", "Fri"],
+  ["saturday", "Sat"],
+  ["sunday", "Sun"],
+] as const;
+
+export const normalizeGtfsDate = (value?: string) =>
+  String(value || "").replace(/-/g, "").trim();
+
+export const gtfsDateToDay = (dateStr?: string) => {
+  const normalized = normalizeGtfsDate(dateStr);
+  if (!normalized || normalized.length !== 8) return undefined;
+  const y = parseInt(normalized.substring(0, 4));
+  const m = parseInt(normalized.substring(4, 6)) - 1;
+  const d = parseInt(normalized.substring(6, 8));
+  const ts = Date.UTC(y, m, d);
+  return Number.isFinite(ts) ? Math.floor(ts / 86400000) : undefined;
+};
+
+export const dayToDisplay = (dayNum: number) => {
+  const date = new Date(dayNum * 86400000);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit", timeZone: "UTC" });
+};
+
+export const serviceDays = (service: Record<string, any>) => {
+  const days = DAY_LABELS
+    .filter(([key]) => Number(service[key] || 0) === 1)
+    .map(([, label]) => label);
+  return days.length > 0 ? days.join(", ") : "Dates only";
+};
+
+export const serviceInDateRange = (service: Record<string, any>, range: [number, number]) => {
+  const startDay = gtfsDateToDay(service.start_date);
+  const endDay = gtfsDateToDay(service.end_date);
+  if (startDay === undefined && endDay === undefined) return true;
+  const sStart = startDay ?? endDay!;
+  const sEnd = endDay ?? startDay!;
+  return sStart <= range[1] && sEnd >= range[0];
+};
+
+export const parseGtfsDate = (gtfs?: string | Date): Date | undefined => {
+  if (!gtfs) return undefined;
+  if (gtfs instanceof Date) return Number.isNaN(gtfs.getTime()) ? undefined : gtfs;
+  const str = String(gtfs);
+  if (str.length < 8) return undefined;
+  const normalized = str.replace(/-/g, "");
+  return parse(normalized, "yyyyMMdd", new Date());
+};
+
+export const toGtfsDate = (d: Date): string => format(d, "yyyyMMdd");

--- a/packages/web/src/lib/tripUtils.ts
+++ b/packages/web/src/lib/tripUtils.ts
@@ -1,0 +1,121 @@
+// ─── Types ────────────────────────────────────────────────────────
+export type TripStopTime = {
+  trip_id: string;
+  stop_sequence?: number;
+  arrival_time?: string;
+  departure_time?: string;
+  stop_id?: string;
+  stop_name?: string;
+  station_name?: string;
+  location_type_name?: string;
+  parent_station?: string;
+  stop_headsign?: string;
+  pickup_type?: number;
+  drop_off_type?: number;
+  stop_lat?: number;
+  stop_lon?: number;
+};
+
+export type TripInfo = {
+  trip_id: string;
+  trip_headsign?: string;
+  direction_id?: number;
+  first_departure_seconds?: number;
+  last_arrival_seconds?: number;
+};
+
+export type EditableStop = TripStopTime & { _idx: number };
+
+export type RouteStopOption = {
+  stop_id: string;
+  stop_name: string;
+  stop_lat?: number;
+  stop_lon?: number;
+  on_route?: boolean;
+};
+
+// ─── Constants ────────────────────────────────────────────────────
+export const TRIP_COLORS = ["bg-primary", "bg-orange-500", "bg-violet-500", "bg-teal-500", "bg-rose-500"];
+export const TRIP_LINE_COLORS = ["#3b82f6", "#f97316", "#8b5cf6", "#14b8a6", "#f43f5e"];
+
+const STATION_ROUTE_TYPES = new Set(["Subway, Metro", "Rail", "Tram, Streetcar, Light rail", "Monorail", "Funicular"]);
+export const defaultStopView = (rt?: string): "stops" | "stations" =>
+  rt && STATION_ROUTE_TYPES.has(rt) ? "stations" : "stops";
+
+// ─── Utilities ────────────────────────────────────────────────────
+export const secondsValue = (value?: number | string) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+export const formatTripTime = (value?: number | string) => {
+  const s = secondsValue(value);
+  if (s === undefined) return "";
+  return `${Math.floor(s / 3600)}:${String(Math.floor((s % 3600) / 60)).padStart(2, "0")}`;
+};
+
+export const formatTimeRange = (v: [number, number]) =>
+  `${formatTripTime(v[0])} - ${formatTripTime(v[1])}`;
+
+// ─── Time Parsing ─────────────────────────────────────────────────
+const TIME_RE = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
+
+export const parseTime = (val: string): string | null => {
+  const m = val.trim().match(TIME_RE);
+  if (!m) return null;
+  const h = parseInt(m[1]);
+  const min = parseInt(m[2]);
+  const sec = parseInt(m[3] ?? "0");
+  if (min > 59 || sec > 59) return null;
+  return `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+};
+
+export const timeToSec = (t?: string) => {
+  if (!t) return undefined;
+  const m = t.match(TIME_RE);
+  if (!m) return undefined;
+  return parseInt(m[1]) * 3600 + parseInt(m[2]) * 60 + parseInt(m[3] ?? "0");
+};
+
+export const secToTime = (sec: number) => {
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+};
+
+export const fmtTime = (sec: number) =>
+  `${Math.floor(sec / 3600)}:${String(Math.floor((sec % 3600) / 60)).padStart(2, "0")}`;
+
+export const validateStopTimes = (stops: EditableStop[]): string[] => {
+  const errors: string[] = [];
+  for (let i = 0; i < stops.length; i++) {
+    const s = stops[i];
+    const arr = timeToSec(s.arrival_time);
+    const dep = timeToSec(s.departure_time);
+    if (arr != null && dep != null && dep < arr) {
+      errors.push(`Stop ${i + 1} (${s.stop_name || s.stop_id}): departure before arrival`);
+    }
+    if (i > 0) {
+      const prevDep = timeToSec(stops[i - 1].departure_time) ?? timeToSec(stops[i - 1].arrival_time);
+      const curArr = arr ?? dep;
+      if (prevDep != null && curArr != null && curArr < prevDep) {
+        errors.push(`Stop ${i + 1} (${s.stop_name || s.stop_id}): arrives before previous stop departs`);
+      }
+    }
+  }
+  return errors;
+};
+
+// ─── Time Options ─────────────────────────────────────────────────
+export const TIME_OPTIONS = (() => {
+  const opts: Array<{ value: string; label: string }> = [];
+  for (let h = 0; h < 30; h++) {
+    for (let m = 0; m < 60; m += 5) {
+      const t = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:00`;
+      const label = `${h}:${String(m).padStart(2, "0")}`;
+      opts.push({ value: t, label });
+    }
+  }
+  return opts;
+})();

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -11,9 +11,12 @@ const queryClient = new QueryClient();
 
 const router = createRouter({
   routeTree,
+  defaultPreload: "intent",
+  defaultPreloadStaleTime: 30_000,
   scrollRestoration: ({ location }) =>
     !location.pathname.startsWith("/stations/pathways"),
   scrollRestorationBehavior: "instant",
+  context: { queryClient },
 });
 
 declare module "@tanstack/react-router" {

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -11,10 +11,12 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as LayoutTripsIndexRouteImport } from './routes/_layout/trips/index'
 import { Route as LayoutStopsIndexRouteImport } from './routes/_layout/stops/index'
 import { Route as LayoutStationsIndexRouteImport } from './routes/_layout/stations/index'
 import { Route as LayoutRoutesIndexRouteImport } from './routes/_layout/routes/index'
 import { Route as LayoutExportIndexRouteImport } from './routes/_layout/export/index'
+import { Route as LayoutTripsTableRouteImport } from './routes/_layout/trips/table'
 import { Route as LayoutStopsTableRouteImport } from './routes/_layout/stops/table'
 import { Route as LayoutStopsMapRouteImport } from './routes/_layout/stops/map'
 import { Route as LayoutStationsTableRouteImport } from './routes/_layout/stations/table'
@@ -28,6 +30,8 @@ import { Route as LayoutRoutesTableRouteImport } from './routes/_layout/routes/t
 import { Route as LayoutRoutesServiceRouteImport } from './routes/_layout/routes/service'
 import { Route as LayoutRoutesMapRouteImport } from './routes/_layout/routes/map'
 import { Route as LayoutRoutesInfoRouteImport } from './routes/_layout/routes/info'
+import { Route as LayoutTripsTripsRoutesIndexRouteImport } from './routes/_layout/trips/trips-routes/index'
+import { Route as LayoutTripsTripsRoutesTableRouteImport } from './routes/_layout/trips/trips-routes/table'
 import { Route as LayoutStationsStationStationIdRouteImport } from './routes/_layout/stations/station/$stationId'
 import { Route as LayoutStationsPathwaysFlowRouteImport } from './routes/_layout/stations/pathways/flow'
 import { Route as LayoutStationsPartsTableRouteImport } from './routes/_layout/stations/parts/table'
@@ -58,6 +62,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LayoutTripsIndexRoute = LayoutTripsIndexRouteImport.update({
+  id: '/trips/',
+  path: '/trips/',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutStopsIndexRoute = LayoutStopsIndexRouteImport.update({
   id: '/stops/',
   path: '/stops/',
@@ -78,6 +87,13 @@ const LayoutExportIndexRoute = LayoutExportIndexRouteImport.update({
   path: '/export/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutTripsTableRoute = LayoutTripsTableRouteImport.update({
+  id: '/trips/table',
+  path: '/trips/table',
+  getParentRoute: () => LayoutRoute,
+} as any).lazy(() =>
+  import('./routes/_layout/trips/table.lazy').then((d) => d.Route),
+)
 const LayoutStopsTableRoute = LayoutStopsTableRouteImport.update({
   id: '/stops/table',
   path: '/stops/table',
@@ -143,6 +159,22 @@ const LayoutRoutesInfoRoute = LayoutRoutesInfoRouteImport.update({
   path: '/routes/info',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutTripsTripsRoutesIndexRoute =
+  LayoutTripsTripsRoutesIndexRouteImport.update({
+    id: '/trips/trips-routes/',
+    path: '/trips/trips-routes/',
+    getParentRoute: () => LayoutRoute,
+  } as any)
+const LayoutTripsTripsRoutesTableRoute =
+  LayoutTripsTripsRoutesTableRouteImport.update({
+    id: '/trips/trips-routes/table',
+    path: '/trips/trips-routes/table',
+    getParentRoute: () => LayoutRoute,
+  } as any).lazy(() =>
+    import('./routes/_layout/trips/trips-routes/table.lazy').then(
+      (d) => d.Route,
+    ),
+  )
 const LayoutStationsStationStationIdRoute =
   LayoutStationsStationStationIdRouteImport.update({
     id: '/stations/station/$stationId',
@@ -278,15 +310,19 @@ export interface FileRoutesByFullPath {
   '/stations/table': typeof LayoutStationsTableRoute
   '/stops/map': typeof LayoutStopsMapRoute
   '/stops/table': typeof LayoutStopsTableRoute
+  '/trips/table': typeof LayoutTripsTableRoute
   '/export/': typeof LayoutExportIndexRoute
   '/routes/': typeof LayoutRoutesIndexRoute
   '/stations/': typeof LayoutStationsIndexRoute
   '/stops/': typeof LayoutStopsIndexRoute
+  '/trips/': typeof LayoutTripsIndexRoute
   '/routes/route/$routeId': typeof LayoutRoutesRouteRouteIdRouteWithChildren
   '/stations/parts/map': typeof LayoutStationsPartsMapRoute
   '/stations/parts/table': typeof LayoutStationsPartsTableRoute
   '/stations/pathways/flow': typeof LayoutStationsPathwaysFlowRouteWithChildren
   '/stations/station/$stationId': typeof LayoutStationsStationStationIdRouteWithChildren
+  '/trips/trips-routes/table': typeof LayoutTripsTripsRoutesTableRoute
+  '/trips/trips-routes/': typeof LayoutTripsTripsRoutesIndexRoute
   '/routes/route/$routeId/info': typeof LayoutRoutesRouteRouteIdInfoRoute
   '/routes/route/$routeId/trips': typeof LayoutRoutesRouteRouteIdTripsRoute
   '/stations/pathways/flow/column': typeof LayoutStationsPathwaysFlowColumnRoute
@@ -318,12 +354,16 @@ export interface FileRoutesByTo {
   '/stations/table': typeof LayoutStationsTableRoute
   '/stops/map': typeof LayoutStopsMapRoute
   '/stops/table': typeof LayoutStopsTableRoute
+  '/trips/table': typeof LayoutTripsTableRoute
   '/export': typeof LayoutExportIndexRoute
   '/routes': typeof LayoutRoutesIndexRoute
   '/stations': typeof LayoutStationsIndexRoute
   '/stops': typeof LayoutStopsIndexRoute
+  '/trips': typeof LayoutTripsIndexRoute
   '/stations/parts/map': typeof LayoutStationsPartsMapRoute
   '/stations/parts/table': typeof LayoutStationsPartsTableRoute
+  '/trips/trips-routes/table': typeof LayoutTripsTripsRoutesTableRoute
+  '/trips/trips-routes': typeof LayoutTripsTripsRoutesIndexRoute
   '/routes/route/$routeId/info': typeof LayoutRoutesRouteRouteIdInfoRoute
   '/routes/route/$routeId/trips': typeof LayoutRoutesRouteRouteIdTripsRoute
   '/stations/pathways/flow/column': typeof LayoutStationsPathwaysFlowColumnRoute
@@ -356,15 +396,19 @@ export interface FileRoutesById {
   '/_layout/stations/table': typeof LayoutStationsTableRoute
   '/_layout/stops/map': typeof LayoutStopsMapRoute
   '/_layout/stops/table': typeof LayoutStopsTableRoute
+  '/_layout/trips/table': typeof LayoutTripsTableRoute
   '/_layout/export/': typeof LayoutExportIndexRoute
   '/_layout/routes/': typeof LayoutRoutesIndexRoute
   '/_layout/stations/': typeof LayoutStationsIndexRoute
   '/_layout/stops/': typeof LayoutStopsIndexRoute
+  '/_layout/trips/': typeof LayoutTripsIndexRoute
   '/_layout/routes/route/$routeId': typeof LayoutRoutesRouteRouteIdRouteWithChildren
   '/_layout/stations/parts/map': typeof LayoutStationsPartsMapRoute
   '/_layout/stations/parts/table': typeof LayoutStationsPartsTableRoute
   '/_layout/stations/pathways/flow': typeof LayoutStationsPathwaysFlowRouteWithChildren
   '/_layout/stations/station/$stationId': typeof LayoutStationsStationStationIdRouteWithChildren
+  '/_layout/trips/trips-routes/table': typeof LayoutTripsTripsRoutesTableRoute
+  '/_layout/trips/trips-routes/': typeof LayoutTripsTripsRoutesIndexRoute
   '/_layout/routes/route/$routeId/info': typeof LayoutRoutesRouteRouteIdInfoRoute
   '/_layout/routes/route/$routeId/trips': typeof LayoutRoutesRouteRouteIdTripsRoute
   '/_layout/stations/pathways/flow/column': typeof LayoutStationsPathwaysFlowColumnRoute
@@ -398,15 +442,19 @@ export interface FileRouteTypes {
     | '/stations/table'
     | '/stops/map'
     | '/stops/table'
+    | '/trips/table'
     | '/export/'
     | '/routes/'
     | '/stations/'
     | '/stops/'
+    | '/trips/'
     | '/routes/route/$routeId'
     | '/stations/parts/map'
     | '/stations/parts/table'
     | '/stations/pathways/flow'
     | '/stations/station/$stationId'
+    | '/trips/trips-routes/table'
+    | '/trips/trips-routes/'
     | '/routes/route/$routeId/info'
     | '/routes/route/$routeId/trips'
     | '/stations/pathways/flow/column'
@@ -438,12 +486,16 @@ export interface FileRouteTypes {
     | '/stations/table'
     | '/stops/map'
     | '/stops/table'
+    | '/trips/table'
     | '/export'
     | '/routes'
     | '/stations'
     | '/stops'
+    | '/trips'
     | '/stations/parts/map'
     | '/stations/parts/table'
+    | '/trips/trips-routes/table'
+    | '/trips/trips-routes'
     | '/routes/route/$routeId/info'
     | '/routes/route/$routeId/trips'
     | '/stations/pathways/flow/column'
@@ -475,15 +527,19 @@ export interface FileRouteTypes {
     | '/_layout/stations/table'
     | '/_layout/stops/map'
     | '/_layout/stops/table'
+    | '/_layout/trips/table'
     | '/_layout/export/'
     | '/_layout/routes/'
     | '/_layout/stations/'
     | '/_layout/stops/'
+    | '/_layout/trips/'
     | '/_layout/routes/route/$routeId'
     | '/_layout/stations/parts/map'
     | '/_layout/stations/parts/table'
     | '/_layout/stations/pathways/flow'
     | '/_layout/stations/station/$stationId'
+    | '/_layout/trips/trips-routes/table'
+    | '/_layout/trips/trips-routes/'
     | '/_layout/routes/route/$routeId/info'
     | '/_layout/routes/route/$routeId/trips'
     | '/_layout/stations/pathways/flow/column'
@@ -522,6 +578,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_layout/trips/': {
+      id: '/_layout/trips/'
+      path: '/trips'
+      fullPath: '/trips/'
+      preLoaderRoute: typeof LayoutTripsIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/stops/': {
       id: '/_layout/stops/'
       path: '/stops'
@@ -548,6 +611,13 @@ declare module '@tanstack/react-router' {
       path: '/export'
       fullPath: '/export/'
       preLoaderRoute: typeof LayoutExportIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/trips/table': {
+      id: '/_layout/trips/table'
+      path: '/trips/table'
+      fullPath: '/trips/table'
+      preLoaderRoute: typeof LayoutTripsTableRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/stops/table': {
@@ -639,6 +709,20 @@ declare module '@tanstack/react-router' {
       path: '/routes/info'
       fullPath: '/routes/info'
       preLoaderRoute: typeof LayoutRoutesInfoRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/trips/trips-routes/': {
+      id: '/_layout/trips/trips-routes/'
+      path: '/trips/trips-routes'
+      fullPath: '/trips/trips-routes/'
+      preLoaderRoute: typeof LayoutTripsTripsRoutesIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/trips/trips-routes/table': {
+      id: '/_layout/trips/trips-routes/table'
+      path: '/trips/trips-routes/table'
+      fullPath: '/trips/trips-routes/table'
+      preLoaderRoute: typeof LayoutTripsTripsRoutesTableRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/stations/station/$stationId': {
@@ -914,12 +998,16 @@ interface LayoutRouteChildren {
   LayoutStationsTableRoute: typeof LayoutStationsTableRoute
   LayoutStopsMapRoute: typeof LayoutStopsMapRoute
   LayoutStopsTableRoute: typeof LayoutStopsTableRoute
+  LayoutTripsTableRoute: typeof LayoutTripsTableRoute
   LayoutExportIndexRoute: typeof LayoutExportIndexRoute
   LayoutRoutesIndexRoute: typeof LayoutRoutesIndexRoute
   LayoutStationsIndexRoute: typeof LayoutStationsIndexRoute
   LayoutStopsIndexRoute: typeof LayoutStopsIndexRoute
+  LayoutTripsIndexRoute: typeof LayoutTripsIndexRoute
   LayoutRoutesRouteRouteIdRoute: typeof LayoutRoutesRouteRouteIdRouteWithChildren
   LayoutStationsStationStationIdRoute: typeof LayoutStationsStationStationIdRouteWithChildren
+  LayoutTripsTripsRoutesTableRoute: typeof LayoutTripsTripsRoutesTableRoute
+  LayoutTripsTripsRoutesIndexRoute: typeof LayoutTripsTripsRoutesIndexRoute
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
@@ -936,13 +1024,17 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutStationsTableRoute: LayoutStationsTableRoute,
   LayoutStopsMapRoute: LayoutStopsMapRoute,
   LayoutStopsTableRoute: LayoutStopsTableRoute,
+  LayoutTripsTableRoute: LayoutTripsTableRoute,
   LayoutExportIndexRoute: LayoutExportIndexRoute,
   LayoutRoutesIndexRoute: LayoutRoutesIndexRoute,
   LayoutStationsIndexRoute: LayoutStationsIndexRoute,
   LayoutStopsIndexRoute: LayoutStopsIndexRoute,
+  LayoutTripsIndexRoute: LayoutTripsIndexRoute,
   LayoutRoutesRouteRouteIdRoute: LayoutRoutesRouteRouteIdRouteWithChildren,
   LayoutStationsStationStationIdRoute:
     LayoutStationsStationStationIdRouteWithChildren,
+  LayoutTripsTripsRoutesTableRoute: LayoutTripsTripsRoutesTableRoute,
+  LayoutTripsTripsRoutesIndexRoute: LayoutTripsTripsRoutesIndexRoute,
 }
 
 const LayoutRouteWithChildren =

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -1,11 +1,12 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
 import { DuckDBProvider, useDuckDB } from "@/context/duckdb.client";
 import { ThemeProvider } from "@/context/theme.client";
 import { LoadingOverlay } from "@/components/ui/LoadingOverlay";
 import CliQueryBridge from "@/lib/cli/CliQueryBridge";
 import "@/styles/index.css";
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   component: RootComponent,
 });
 

--- a/packages/web/src/routes/_layout/routes/map.tsx
+++ b/packages/web/src/routes/_layout/routes/map.tsx
@@ -70,7 +70,7 @@ const ToggleTabs = [
 function RoutesMapPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
   const queryClient = useQueryClient();
 
   const [ClickInfo, setClickInfo] = useState<any>();

--- a/packages/web/src/routes/_layout/routes/service.tsx
+++ b/packages/web/src/routes/_layout/routes/service.tsx
@@ -17,18 +17,15 @@ import {
 type RouteServiceSearchParams = {
   selectedRouteId?: string;
   selectedServiceId?: string;
-  selectedTripId?: string;
-  compareTripIds?: string;
 };
 
 export const Route = createFileRoute("/_layout/routes/service")({
   component: RouteServicePage,
   validateSearch: (search: Record<string, unknown>): RouteServiceSearchParams => {
+    const strip = (v: unknown) => v != null ? String(v).replace(/^"|"$/g, "") || undefined : undefined;
     return {
-      selectedRouteId: search.selectedRouteId as string | undefined,
-      selectedServiceId: search.selectedServiceId as string | undefined,
-      selectedTripId: search.selectedTripId as string | undefined,
-      compareTripIds: search.compareTripIds as string | undefined,
+      selectedRouteId: strip(search.selectedRouteId),
+      selectedServiceId: strip(search.selectedServiceId),
     };
   },
   beforeLoad: ({ search }) => {
@@ -130,14 +127,11 @@ function RouteServicePage() {
         routeId={routeId}
         services={services}
         selectedServiceId={search.selectedServiceId}
-        selectedTripId={hasStopTimes ? search.selectedTripId : undefined}
-        initialCompareTripIds={search.compareTripIds}
         routeTypeName={routeData.route_type_name}
         hasStopTimes={hasStopTimes}
-        onSelectionChange={(serviceId, tripId) =>
+        onSelectionChange={(serviceId) =>
           updateSearch({
             selectedServiceId: serviceId || undefined,
-            selectedTripId: hasStopTimes ? (tripId || undefined) : undefined,
           })
         }
       />

--- a/packages/web/src/routes/_layout/stations/info.tsx
+++ b/packages/web/src/routes/_layout/stations/info.tsx
@@ -5,7 +5,7 @@ import { fetchCheckStationInfo } from "@/lib/duckdb/DataFetching/fetchStationInf
 import { Skeleton } from "@/components/ui/skeleton";
 import { TabHeader } from "@/components/ui/tab-header";
 import PageFooter from "@/components/PageFooter";
-import { BiInfoCircle, BiMapAlt, BiGridAlt } from "react-icons/bi";
+import { BiInfoCircle, BiMap, BiGridAlt } from "react-icons/bi";
 import StationInfo from "@/client/Stations/SelectedStations/StationInfo";
 import { EditIndicator } from "@/components/ui/EditIndicator";
 
@@ -105,7 +105,7 @@ function StationInfoPage() {
     {
       value: "pathways",
       label: "Pathways",
-      icon: <BiMapAlt />,
+      icon: <BiMap />,
       path: pathwayTabPath,
     },
   ];

--- a/packages/web/src/routes/_layout/stations/map.tsx
+++ b/packages/web/src/routes/_layout/stations/map.tsx
@@ -57,7 +57,7 @@ const ToggleTabs = [
 function StationsMapPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
 
   const [Open, setOpen] = useState({ formType: null, state: false });
   const [ClickInfo, setClickInfo] = useState();

--- a/packages/web/src/routes/_layout/stations/parts.tsx
+++ b/packages/web/src/routes/_layout/stations/parts.tsx
@@ -7,13 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { useState, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  BiMap,
-  BiTable,
-  BiInfoCircle,
-  BiMapAlt,
-  BiGridAlt,
-} from "react-icons/bi";
+import { BiMap, BiTable, BiInfoCircle, BiGridAlt } from "react-icons/bi";
 import { useDuckDB } from "@/context/duckdb.client";
 import {
   fetchCheckStationData,
@@ -187,7 +181,7 @@ function StationPartsLayout() {
     {
       value: "pathways",
       label: "Pathways",
-      icon: <BiMapAlt />,
+      icon: <BiMap />,
       path: pathwayTabPath,
     },
   ];

--- a/packages/web/src/routes/_layout/stations/parts/map.tsx
+++ b/packages/web/src/routes/_layout/stations/parts/map.tsx
@@ -51,7 +51,7 @@ export const Route = createFileRoute("/_layout/stations/parts/map")({
 function PartsMapPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
 
   const [Open, setOpen] = useState({ formType: null, state: false });
   const [ClickInfo, setClickInfo] = useState();

--- a/packages/web/src/routes/_layout/stations/parts/table.tsx
+++ b/packages/web/src/routes/_layout/stations/parts/table.tsx
@@ -51,7 +51,7 @@ export const Route = createFileRoute("/_layout/stations/parts/table")({
 function PartsTablePage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
 
   const [Open, setOpen] = useState({ formType: null, state: false });
   const [ClickInfo, setClickInfo] = useState();

--- a/packages/web/src/routes/_layout/stations/pathways.tsx
+++ b/packages/web/src/routes/_layout/stations/pathways.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 import { useState, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { BiMap, BiTable, BiInfoCircle, BiMapAlt, BiGridAlt, BiNetworkChart } from "react-icons/bi";
+import { BiMap, BiTable, BiInfoCircle, BiGridAlt, BiNetworkChart } from "react-icons/bi";
 import { useDuckDB } from "@/context/duckdb.client";
 import { fetchCheckStationInfo } from "@/lib/duckdb/DataFetching/fetchStationInfoData";
 import { fetchStationPathwaysComplete } from "@/lib/duckdb/DataFetching/pathways";
@@ -227,7 +227,7 @@ function StationPathwaysLayout() {
   MainTabs.push({
     value: "pathways",
     label: "Pathways",
-    icon: <BiMapAlt />,
+    icon: <BiMap />,
     path: pathwaysTabPath,
   });
 

--- a/packages/web/src/routes/_layout/stations/pathways/map/directional.tsx
+++ b/packages/web/src/routes/_layout/stations/pathways/map/directional.tsx
@@ -21,7 +21,7 @@ import { fetchPathwayMapRouteData } from "@/lib/duckdb/DataFetching/pathways/fet
 import { getPathwayRouteFilterData } from "@/lib/pathways/routeFilterGraph";
 import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
-import { BiEdit, BiReset } from "react-icons/bi";
+import { BiPencil, BiReset } from "react-icons/bi";
 import { usePathwaysNavigate } from "../-usePathwaysNavigate";
 import { getPathwayMapTargetViewState } from "./-pathwayMapViewState";
 
@@ -455,7 +455,7 @@ function DirectionalMapPage() {
                 onClick={() => handleEditStopInFlow(clickData?.stop_id)}
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>
@@ -518,7 +518,7 @@ function DirectionalMapPage() {
                 }
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>

--- a/packages/web/src/routes/_layout/stations/pathways/map/pathwayTypes.tsx
+++ b/packages/web/src/routes/_layout/stations/pathways/map/pathwayTypes.tsx
@@ -17,7 +17,7 @@ import { fetchPathwayMapRouteData } from "@/lib/duckdb/DataFetching/pathways/fet
 import { getPathwayRouteFilterData } from "@/lib/pathways/routeFilterGraph";
 import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
-import { BiEdit, BiReset } from "react-icons/bi";
+import { BiPencil, BiReset } from "react-icons/bi";
 import { usePathwaysNavigate } from "../-usePathwaysNavigate";
 import { getPathwayMapTargetViewState } from "./-pathwayMapViewState";
 
@@ -349,7 +349,7 @@ function PathwayTypesMapPage() {
                 onClick={() => handleEditStopInFlow(clickData?.stop_id)}
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>
@@ -389,7 +389,7 @@ function PathwayTypesMapPage() {
                 }
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>

--- a/packages/web/src/routes/_layout/stations/pathways/map/timeInterval.tsx
+++ b/packages/web/src/routes/_layout/stations/pathways/map/timeInterval.tsx
@@ -17,7 +17,7 @@ import { fetchPathwayMapRouteData } from "@/lib/duckdb/DataFetching/pathways/fet
 import { getPathwayRouteFilterData } from "@/lib/pathways/routeFilterGraph";
 import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
-import { BiEdit, BiReset } from "react-icons/bi";
+import { BiPencil, BiReset } from "react-icons/bi";
 import { usePathwaysNavigate } from "../-usePathwaysNavigate";
 import { getPathwayMapTargetViewState } from "./-pathwayMapViewState";
 
@@ -415,7 +415,7 @@ function TimeIntervalMapPage() {
                 onClick={() => handleEditStopInFlow(clickData?.stop_id)}
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>
@@ -455,7 +455,7 @@ function TimeIntervalMapPage() {
                 }
                 className="w-full justify-center"
               >
-                <BiEdit className="mr-2 h-4 w-4 shrink-0" />
+                <BiPencil className="mr-2 h-4 w-4 shrink-0" />
                 edit
               </Button>
             </div>

--- a/packages/web/src/routes/_layout/stations/station/$stationId.tsx
+++ b/packages/web/src/routes/_layout/stations/station/$stationId.tsx
@@ -10,7 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useDuckDB } from "@/context/duckdb.client";
 import { fetchCheckStationInfo } from "@/lib/duckdb/DataFetching/fetchStationInfoData";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BiInfoCircle, BiMapAlt, BiGridAlt } from "react-icons/bi";
+import { BiInfoCircle, BiMap, BiGridAlt } from "react-icons/bi";
 import PageFooter from "@/components/PageFooter";
 import { logger } from "@/lib/logger";
 import { EditIndicator } from "@/components/ui/EditIndicator";
@@ -96,7 +96,7 @@ function StationLayout() {
     ToggleTabs.push({
       value: "pathways",
       label: "Pathways",
-      icon: <BiMapAlt />,
+      icon: <BiMap />,
       path: `/stations/station/${stationId}/pathways`,
     });
   }

--- a/packages/web/src/routes/_layout/stations/station/$stationId/parts.tsx
+++ b/packages/web/src/routes/_layout/stations/station/$stationId/parts.tsx
@@ -28,7 +28,7 @@ function StationPartsLayout() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
 
   const [Open, setOpen] = useState({ formType: null, state: false });
   const [ClickInfo, setClickInfo] = useState();

--- a/packages/web/src/routes/_layout/stations/table.tsx
+++ b/packages/web/src/routes/_layout/stations/table.tsx
@@ -55,7 +55,7 @@ const ToggleTabs = [
 function StationsTablePage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
 
   const [Open, setOpen] = useState({ formType: null, state: false });
   const [ClickInfo, setClickInfo] = useState();

--- a/packages/web/src/routes/_layout/stops/map.tsx
+++ b/packages/web/src/routes/_layout/stops/map.tsx
@@ -59,7 +59,7 @@ const ToggleTabs = [
 function StopsMapPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
   const { theme } = useThemeContext();
 
   const [Open, setOpen] = useState({ formType: null, state: false });

--- a/packages/web/src/routes/_layout/stops/table.tsx
+++ b/packages/web/src/routes/_layout/stops/table.tsx
@@ -57,7 +57,7 @@ const ToggleTabs = [
 function StopsTablePage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const { conn } = useDuckDB();
+  const { conn } = useDuckDB() ?? {};
   const { theme } = useThemeContext();
 
   const [Open, setOpen] = useState({ formType: null, state: false });

--- a/packages/web/src/routes/_layout/trips/index.tsx
+++ b/packages/web/src/routes/_layout/trips/index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { isCliSession } from "@/lib/cli/isCliSession";
+
+export const Route = createFileRoute("/_layout/trips/")({
+  beforeLoad: () => {
+    if (!isCliSession()) {
+      const initialized = localStorage.getItem("gtfs_data_initialized") === "true";
+      const hasTrips = localStorage.getItem("gtfs_has_trips") === "true";
+
+      if (!initialized || !hasTrips) {
+        throw redirect({ to: "/" });
+      }
+    }
+
+    throw redirect({ to: "/trips/table" });
+  },
+});

--- a/packages/web/src/routes/_layout/trips/table.lazy.tsx
+++ b/packages/web/src/routes/_layout/trips/table.lazy.tsx
@@ -1,0 +1,97 @@
+import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useDuckDB } from "@/context/duckdb.client";
+import { Skeleton } from "@/components/ui/skeleton";
+import PageFooter from "@/components/PageFooter";
+import AllTrips from "@/client/Trips/AllTrips";
+import {
+  fetchAllTripsData,
+  fetchTripsTimeBounds,
+} from "@/lib/duckdb/DataFetching/fetchRouteData";
+
+export const Route = createLazyFileRoute("/_layout/trips/table")({
+  component: TripsTablePage,
+});
+
+function TripsTablePage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const initialized = duckDB?.initialized ?? false;
+  const hasStopTimes = duckDB?.hasStopTimes ?? false;
+
+  const { data: allTrips = [], isLoading: tripsLoading } = useQuery({
+    queryKey: ["fetchAllTripsData"],
+    queryFn: async () => fetchAllTripsData(conn),
+    enabled: !!conn && initialized,
+    staleTime: 30_000,
+  });
+
+  const { data: timeBounds, isLoading: boundsLoading } = useQuery({
+    queryKey: ["fetchTripsTimeBounds"],
+    queryFn: async () => fetchTripsTimeBounds(conn),
+    enabled: !!conn && initialized && hasStopTimes,
+    staleTime: Infinity,
+  });
+
+  const isLoading = tripsLoading || (hasStopTimes && boundsLoading);
+  const tripTimeBounds: [number, number] = timeBounds
+    ? [timeBounds.minTime, timeBounds.maxTime]
+    : [0, 86400];
+
+  const updateSearch = (next: Partial<Record<string, unknown>>) => {
+    navigate({
+      to: "/trips/table",
+      search: (prev) => ({ ...prev, ...next }),
+      resetScroll: false,
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex flex-col gap-4">
+        {isLoading ? (
+          <div className="space-y-4 mt-2">
+            {/* Filter inputs — responsive grid */}
+            <div className={`grid grid-cols-1 sm:grid-cols-2 ${hasStopTimes ? "lg:grid-cols-4" : "lg:grid-cols-3"} gap-2 mb-1`}>
+              <Skeleton className="h-10 w-full rounded-md" />
+              <Skeleton className="h-10 w-full rounded-md" />
+              <Skeleton className="h-10 w-full rounded-md" />
+              {hasStopTimes && <Skeleton className="h-10 w-full rounded-md" />}
+            </div>
+            {/* Reset button */}
+            <Skeleton className="h-10 w-full md:w-28 rounded-md" />
+            {/* Table */}
+            <div className="rounded-md border overflow-hidden">
+              <div className="border-b px-4 py-3">
+                <div className="flex gap-4 overflow-hidden">
+                  {Array.from({ length: 7 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 flex-1 min-w-[60px] max-w-[100px] rounded" />
+                  ))}
+                </div>
+              </div>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex gap-4 px-4 py-3 border-b last:border-0">
+                  <Skeleton className="h-5 w-5 rounded-full shrink-0" />
+                  {Array.from({ length: 6 }).map((_, j) => (
+                    <Skeleton key={j} className="h-4 flex-1 min-w-[40px] max-w-[100px] rounded" />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <AllTrips
+            allTrips={allTrips}
+            tripTimeBounds={tripTimeBounds}
+            hasStopTimes={hasStopTimes}
+            search={search}
+            updateSearch={updateSearch}
+          />
+        )}
+        <PageFooter />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/routes/_layout/trips/table.tsx
+++ b/packages/web/src/routes/_layout/trips/table.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+type TripsTableSearchParams = {
+  tripId?: string;
+  routeId?: string;
+  routeType?: string[];
+  selectedTripId?: string;
+  view?: string;
+  compareTripIds?: string;
+};
+
+export const Route = createFileRoute("/_layout/trips/table")({
+  validateSearch: (search: Record<string, unknown>): TripsTableSearchParams => {
+    return {
+      tripId: search.tripId as string | undefined,
+      routeId: search.routeId as string | undefined,
+      routeType: Array.isArray(search.routeType)
+        ? (search.routeType as string[])
+        : search.routeType
+          ? [search.routeType as string]
+          : undefined,
+      selectedTripId: search.selectedTripId as string | undefined,
+      view: search.view as string | undefined,
+      compareTripIds: search.compareTripIds as string | undefined,
+    };
+  },
+});

--- a/packages/web/src/routes/_layout/trips/trips-routes/index.tsx
+++ b/packages/web/src/routes/_layout/trips/trips-routes/index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { isCliSession } from "@/lib/cli/isCliSession";
+
+export const Route = createFileRoute("/_layout/trips/trips-routes/")({
+  beforeLoad: () => {
+    if (!isCliSession()) {
+      const initialized = localStorage.getItem("gtfs_data_initialized") === "true";
+      const hasTrips = localStorage.getItem("gtfs_has_trips") === "true";
+
+      if (!initialized || !hasTrips) {
+        throw redirect({ to: "/" });
+      }
+    }
+
+    throw redirect({ to: "/trips/table" });
+  },
+});

--- a/packages/web/src/routes/_layout/trips/trips-routes/table.lazy.tsx
+++ b/packages/web/src/routes/_layout/trips/trips-routes/table.lazy.tsx
@@ -1,0 +1,97 @@
+import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useDuckDB } from "@/context/duckdb.client";
+import { Skeleton } from "@/components/ui/skeleton";
+import PageFooter from "@/components/PageFooter";
+import AllTrips from "@/client/Trips/AllTrips";
+import {
+  fetchAllTripsData,
+  fetchTripsTimeBounds,
+} from "@/lib/duckdb/DataFetching/fetchRouteData";
+
+export const Route = createLazyFileRoute("/_layout/trips/trips-routes/table")({
+  component: TripsTablePage,
+});
+
+function TripsTablePage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+  const duckDB = useDuckDB();
+  const conn = duckDB?.conn;
+  const initialized = duckDB?.initialized ?? false;
+  const hasStopTimes = duckDB?.hasStopTimes ?? false;
+
+  const { data: allTrips = [], isLoading: tripsLoading } = useQuery({
+    queryKey: ["fetchAllTripsData"],
+    queryFn: async () => fetchAllTripsData(conn),
+    enabled: !!conn && initialized,
+    staleTime: 30_000,
+  });
+
+  const { data: timeBounds, isLoading: boundsLoading } = useQuery({
+    queryKey: ["fetchTripsTimeBounds"],
+    queryFn: async () => fetchTripsTimeBounds(conn),
+    enabled: !!conn && initialized && hasStopTimes,
+    staleTime: Infinity,
+  });
+
+  const isLoading = tripsLoading || (hasStopTimes && boundsLoading);
+  const tripTimeBounds: [number, number] = timeBounds
+    ? [timeBounds.minTime, timeBounds.maxTime]
+    : [0, 86400];
+
+  const updateSearch = (next: Partial<Record<string, unknown>>) => {
+    navigate({
+      to: "/trips/table",
+      search: (prev) => ({ ...prev, ...next }),
+      resetScroll: false,
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex flex-col gap-4">
+        {isLoading ? (
+          <div className="space-y-4 mt-2">
+            {/* Filter inputs — responsive grid */}
+            <div className={`grid grid-cols-1 sm:grid-cols-2 ${hasStopTimes ? "lg:grid-cols-4" : "lg:grid-cols-3"} gap-2 mb-1`}>
+              <Skeleton className="h-10 w-full rounded-md" />
+              <Skeleton className="h-10 w-full rounded-md" />
+              <Skeleton className="h-10 w-full rounded-md" />
+              {hasStopTimes && <Skeleton className="h-10 w-full rounded-md" />}
+            </div>
+            {/* Reset button */}
+            <Skeleton className="h-10 w-full md:w-28 rounded-md" />
+            {/* Table */}
+            <div className="rounded-md border overflow-hidden">
+              <div className="border-b px-4 py-3">
+                <div className="flex gap-4 overflow-hidden">
+                  {Array.from({ length: 7 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 flex-1 min-w-[60px] max-w-[100px] rounded" />
+                  ))}
+                </div>
+              </div>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex gap-4 px-4 py-3 border-b last:border-0">
+                  <Skeleton className="h-5 w-5 rounded-full shrink-0" />
+                  {Array.from({ length: 6 }).map((_, j) => (
+                    <Skeleton key={j} className="h-4 flex-1 min-w-[40px] max-w-[100px] rounded" />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <AllTrips
+            allTrips={allTrips}
+            tripTimeBounds={tripTimeBounds}
+            hasStopTimes={hasStopTimes}
+            search={search}
+            updateSearch={updateSearch}
+          />
+        )}
+        <PageFooter />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/routes/_layout/trips/trips-routes/table.tsx
+++ b/packages/web/src/routes/_layout/trips/trips-routes/table.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+type TripsTableSearchParams = {
+  tripId?: string;
+  routeId?: string;
+  routeType?: string[];
+  selectedTripId?: string;
+  view?: string;
+  compareTripIds?: string;
+};
+
+export const Route = createFileRoute("/_layout/trips/trips-routes/table")({
+  validateSearch: (search: Record<string, unknown>): TripsTableSearchParams => {
+    return {
+      tripId: search.tripId as string | undefined,
+      routeId: search.routeId as string | undefined,
+      routeType: Array.isArray(search.routeType)
+        ? (search.routeType as string[])
+        : search.routeType
+          ? [search.routeType as string]
+          : undefined,
+      selectedTripId: search.selectedTripId as string | undefined,
+      view: search.view as string | undefined,
+      compareTripIds: search.compareTripIds as string | undefined,
+    };
+  },
+});

--- a/packages/web/src/routes/index.tsx
+++ b/packages/web/src/routes/index.tsx
@@ -4,9 +4,12 @@ import Intro from "@/client/Intro";
 
 export const Route = createFileRoute("/")({
   beforeLoad: () => {
-    // CLI sessions should never see the import page — redirect to data views
     if (isCliSession()) {
-      throw redirect({ to: "/stations/map" });
+      throw redirect({ to: "/routes/table" });
+    }
+    // Non-CLI: check if data was already imported via browser
+    if (typeof window !== "undefined" && localStorage.getItem("gtfs_data_initialized") === "true") {
+      throw redirect({ to: "/routes/table" });
     }
   },
   component: Intro,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "tanstack-router": {
+      "source": "tanstack-skills/tanstack-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/tanstack-router/skills/tanstack-router/SKILL.md",
+      "computedHash": "24beccc4016f91bab65547209cfd849ea5e66f3d5d92820683a9dd84669ced56"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,12 +4,12 @@
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
+  resolved "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
 "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.28.5"
@@ -18,12 +18,12 @@
 
 "@babel/compat-data@^7.28.6":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
 "@babel/core@^7.23.7", "@babel/core@^7.28.5":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
   dependencies:
     "@babel/code-frame" "^7.29.0"
@@ -44,7 +44,7 @@
 
 "@babel/generator@^7.28.5", "@babel/generator@^7.29.0":
   version "7.29.1"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz"
   integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
   dependencies:
     "@babel/parser" "^7.29.0"
@@ -55,7 +55,7 @@
 
 "@babel/helper-compilation-targets@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz"
   integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
   dependencies:
     "@babel/compat-data" "^7.28.6"
@@ -66,12 +66,12 @@
 
 "@babel/helper-globals@^7.28.0":
   version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
+  resolved "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
 "@babel/helper-module-imports@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz"
   integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
   dependencies:
     "@babel/traverse" "^7.28.6"
@@ -79,7 +79,7 @@
 
 "@babel/helper-module-transforms@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz"
   integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
   dependencies:
     "@babel/helper-module-imports" "^7.28.6"
@@ -88,27 +88,27 @@
 
 "@babel/helper-plugin-utils@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz"
   integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
 "@babel/helpers@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz"
   integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
   dependencies:
     "@babel/template" "^7.28.6"
@@ -116,33 +116,33 @@
 
 "@babel/parser@^7.23.6", "@babel/parser@^7.28.5", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz"
   integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
   dependencies:
     "@babel/types" "^7.29.0"
 
 "@babel/plugin-syntax-jsx@^7.27.1":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz#f8ca28bbd84883b5fea0e447c635b81ba73997ee"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz"
   integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-typescript@^7.27.1":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz#c7b2ddf1d0a811145b1de800d1abd146af92e3a2"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz"
   integrity sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.3.1":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
 "@babel/template@^7.27.2", "@babel/template@^7.28.6":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
   integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
   dependencies:
     "@babel/code-frame" "^7.28.6"
@@ -151,7 +151,7 @@
 
 "@babel/traverse@^7.23.7", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz"
   integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
   dependencies:
     "@babel/code-frame" "^7.29.0"
@@ -164,15 +164,20 @@
 
 "@babel/types@^7.23.6", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
   integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@date-fns/tz@^1.4.1":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz"
+  integrity sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==
+
 "@deck.gl/aggregation-layers@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/aggregation-layers/-/aggregation-layers-8.9.34.tgz#959aaedd0640b0c5501ea210b820208da71d4652"
+  resolved "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.9.34.tgz"
   integrity sha512-/JEDlj5MNFX8yHWPO5ljooGMdA2EPuZydbT6wrQD1WMydgp8dcEF+zVRLXTDWH1Mq+HLj6JHT1IhENHXN5TZFA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -183,7 +188,7 @@
 
 "@deck.gl/carto@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/carto/-/carto-8.9.34.tgz#acf0194b2de5745042faf28870caa35da28b7201"
+  resolved "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.9.34.tgz"
   integrity sha512-LJe2Ipd8AKCL1GQiAHRmwa3ubVrlpHVaSAscwGUt5fnFM0J4gTIk5LysTwXBxg5owyCEd4yOgXK3m1PZ+CHu3w==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -205,7 +210,7 @@
 
 "@deck.gl/core@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/core/-/core-8.9.34.tgz#eaf08295225d2a317acebd944306734fcb4f7169"
+  resolved "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.34.tgz"
   integrity sha512-VDne26NevBBvD9Xq6pIBuBt2ffZhzW1COU3IogqhJLhejECiC3RQhWtDRWQqUZpQYKTU2SlyKZcu+Nj7kaLBWA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -226,7 +231,7 @@
 
 "@deck.gl/core@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/core/-/core-8.9.36.tgz#1b4f9c013354eb5763a74c51d5792257205ef2d6"
+  resolved "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.36.tgz"
   integrity sha512-mkIv4/fY1jE+iehqSJzUQi75l9cgfx2ZBa1s1AifgLu0TCkCZgRgISV3UnDBECDCmTZ9Cqk+oKq3OGay3Bz1RQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -247,7 +252,7 @@
 
 "@deck.gl/extensions@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/extensions/-/extensions-8.9.34.tgz#9ad3aa38402763643037618b4fc1e27d0f3282a1"
+  resolved "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.9.34.tgz"
   integrity sha512-at2CSs1TXgOM035LWf+fk03r8yXMnokFBVd0QXlECj1izdBvehvhC7npgpqUJooKg0UMWmqUYkUH3uSrkfyIeA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -255,7 +260,7 @@
 
 "@deck.gl/extensions@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/extensions/-/extensions-8.9.36.tgz#dd40384aedb22473b39c3deafb296f8fe4c92ea8"
+  resolved "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.9.36.tgz"
   integrity sha512-BoHjJOK9Ue/zH+YkXiFli7ebS+I21fyL4YeCUzw2a6OOo36SZV/4S0gZSSkaaltO72aZsDsvduWPAbmXY2slqA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -263,7 +268,7 @@
 
 "@deck.gl/geo-layers@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/geo-layers/-/geo-layers-8.9.34.tgz#3da2db3e5927ca7f6db4d64c65582ff598a04621"
+  resolved "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.9.34.tgz"
   integrity sha512-oXOdNByo8QHNrqjREeIX0btVzsj3aFzJcplatBpdLg6vr/iV8ZdsbRv8WO4CJJI3N6oVKIug2gHWogdIjpxHTg==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -286,7 +291,7 @@
 
 "@deck.gl/geo-layers@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/geo-layers/-/geo-layers-8.9.36.tgz#ae376405bd5b926067aa3b46748bd244743a933f"
+  resolved "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.9.36.tgz"
   integrity sha512-OmJhbRpNK2MPVfEWqWR45Q1e8Sz90fGuFOkcl8Ecl6HZJV7IWcAlnybtaAeJNWO2OohN2TI53UdRKUNGFYS4AQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -309,14 +314,14 @@
 
 "@deck.gl/google-maps@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/google-maps/-/google-maps-8.9.34.tgz#64ecdfc5eac5918f87e32cfaf677173185b98e0b"
+  resolved "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.9.34.tgz"
   integrity sha512-w3MjIPHtEfV4/4TCa07mgqzxlZ7UV03xRRCdJE0iWiFTwIUcEFxFKZgyZV+4cinaf2gp53tVpcBZD6nHDPr33Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
 "@deck.gl/json@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/json/-/json-8.9.34.tgz#c5c39e767d342030adbf22ae3be67332edc17220"
+  resolved "https://registry.npmjs.org/@deck.gl/json/-/json-8.9.34.tgz"
   integrity sha512-+Svypau/H5B7dOUVW5iDOCRowqRNKQMGHSDUoSVcTcEV9Ca0vex9LeWmWWVUwYc6o1RcpyPi38TTyZdRe14sKw==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -325,7 +330,7 @@
 
 "@deck.gl/layers@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/layers/-/layers-8.9.34.tgz#4ba052c4ae9eef958a07fa1a42c32d65e3f9462f"
+  resolved "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.34.tgz"
   integrity sha512-kc9Wzk8Zf2XwdG/V0Md6dh6mlJjStkWHKCKQLJOwj9GDwP4KihzYY2xC98CMCgi2/H/lH03xYm3e5EHvwIENww==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -340,7 +345,7 @@
 
 "@deck.gl/layers@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/layers/-/layers-8.9.36.tgz#1f8a224fba4568d6fa3a4afec2f9a0b2f9ecdbf6"
+  resolved "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.36.tgz"
   integrity sha512-sr/QKELXZ4W0ZHb12QC2+EV1bZJOM6cU6kAfOJD5jOVixOcyccr+FnPPGn39VK9cl/VFY0S339ZPs9reyhDFVg==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -355,7 +360,7 @@
 
 "@deck.gl/mapbox@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/mapbox/-/mapbox-8.9.34.tgz#fe6c2e66ba4d46ef741ab4b605ddb7474f1a904e"
+  resolved "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.9.34.tgz"
   integrity sha512-3s34yFRmTe1KUK8TDWGw+1jATHwOpxpTrMjSWSZpR9AMqZ6ykOAkCziAUD4T+KgpqzzP5QJn+twt0mxPBoQ3eg==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -363,7 +368,7 @@
 
 "@deck.gl/mesh-layers@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/mesh-layers/-/mesh-layers-8.9.34.tgz#43bf49654b5ed04a69e8de431f673bf13160010f"
+  resolved "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.9.34.tgz"
   integrity sha512-BJClDfB86+zgWOyXjLNfVBgZ8BlaSXWDHWj0vS7UuV79h/6PAdwMBfi28/PNO9A89cCtUd94MkB73G0ni56iTA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -374,7 +379,7 @@
 
 "@deck.gl/mesh-layers@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/mesh-layers/-/mesh-layers-8.9.36.tgz#d1d3005f0403f441f25cf9abef7fdb94a217beb3"
+  resolved "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.9.36.tgz"
   integrity sha512-xQ+OSdU3z3HIgaHJfxbcNIxmWYPUBMJZAM+fAbynojGVzGYLJo2MUjUJLtCsw0Ejs3YtnocyuFRM+zObB0I3jw==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -385,21 +390,21 @@
 
 "@deck.gl/react@8.9.34":
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/@deck.gl/react/-/react-8.9.34.tgz#10001604f53968e546fbe23e7aeae189dfd2ea20"
+  resolved "https://registry.npmjs.org/@deck.gl/react/-/react-8.9.34.tgz"
   integrity sha512-kelU3otxmEtNYQ7gVrVSLvju+StuqqSkDrcJU82igjNalOvjjPGst1H7blQTgk1lEbfHNeddusIYGipefyuImw==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
 "@deck.gl/react@^8.9.14":
   version "8.9.36"
-  resolved "https://registry.yarnpkg.com/@deck.gl/react/-/react-8.9.36.tgz#6fb0daef9b3f7c146aab082107875d90e969a985"
+  resolved "https://registry.npmjs.org/@deck.gl/react/-/react-8.9.36.tgz"
   integrity sha512-/WIvHK0aJwppLnpA6GZrOhfanx5WVWihx/o6U88kX53VsyJQMZU10+EXKc1FkI3nd5/jsLbLc8fC0dUtiXiSVw==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
 "@duckdb/duckdb-wasm@^1.29.0":
   version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz#199ebbca6c302eba7bb0a458aacd34ccf8518335"
+  resolved "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz"
   integrity sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==
   dependencies:
     apache-arrow "^17.0.0"
@@ -446,12 +451,12 @@
 
 "@esbuild/darwin-arm64@0.27.3":
   version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz"
   integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
 
 "@esbuild/darwin-arm64@0.28.0":
   version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz"
   integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
 
 "@esbuild/darwin-x64@0.27.3":
@@ -666,14 +671,14 @@
 
 "@floating-ui/core@^1.7.4":
   version "1.7.4"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.4.tgz#4a006a6e01565c0f87ba222c317b056a2cffd2f4"
+  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz"
   integrity sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==
   dependencies:
     "@floating-ui/utils" "^0.2.10"
 
 "@floating-ui/dom@^1.7.5":
   version "1.7.5"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.5.tgz#60bfc83a4d1275b2a90db76bf42ca2a5f2c231c2"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz"
   integrity sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==
   dependencies:
     "@floating-ui/core" "^1.7.4"
@@ -681,24 +686,24 @@
 
 "@floating-ui/react-dom@^2.0.0":
   version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.7.tgz#529475cc16ee4976ba3387968117e773d9aa703e"
+  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz"
   integrity sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==
   dependencies:
     "@floating-ui/dom" "^1.7.5"
 
 "@floating-ui/utils@^0.2.10":
   version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
+  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
 "@hookform/resolvers@^3.10.0":
   version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.10.0.tgz#7bfd18113daca4e57e27e1205b7d5a2d371aa59a"
+  resolved "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz"
   integrity sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
   integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
@@ -706,7 +711,7 @@
 
 "@jridgewell/remapping@^2.3.5":
   version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  resolved "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz"
   integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.5"
@@ -714,12 +719,12 @@
 
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
 "@jridgewell/source-map@^0.3.3":
   version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.11.tgz#b21835cbd36db656b857c2ad02ebd413cc13a9ba"
+  resolved "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz"
   integrity sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.5"
@@ -727,12 +732,12 @@
 
 "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
@@ -740,7 +745,7 @@
 
 "@loaders.gl/3d-tiles@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/3d-tiles/-/3d-tiles-3.4.15.tgz#453f3f8e52f9330ed2f2521679f38175fc14d09b"
+  resolved "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.15.tgz"
   integrity sha512-JR67bEfLrD7Lzb6pWyEIRg2L6W3n6y43DKcWofRLpwPqLA7qHuY7SlO7E72Lz7Tniye8VhawqY1wO8gCx8T72Q==
   dependencies:
     "@loaders.gl/draco" "3.4.15"
@@ -754,7 +759,7 @@
 
 "@loaders.gl/core@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-3.4.15.tgz#668099beabb79cab0eaa25c36a6f66667a8bfc9a"
+  resolved "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.15.tgz"
   integrity sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -764,7 +769,7 @@
 
 "@loaders.gl/draco@3.4.15":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-3.4.15.tgz#f53eba0745bf9a8b43837067ef55edc550ef2b58"
+  resolved "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.15.tgz"
   integrity sha512-SStmyP0ZnS4JbWZb2NhrfiHW65uy3pVTTzQDTgXfkR5cD9oDAEu4nCaHbQ8x38/m39FHliCPgS9b1xWvLKQo8w==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -775,7 +780,7 @@
 
 "@loaders.gl/gis@3.4.15", "@loaders.gl/gis@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-3.4.15.tgz#b6548bd867c4aec2d8edc63fe3ad43e43efc96c1"
+  resolved "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.15.tgz"
   integrity sha512-h+LJI35P6ze8DFPSUylTKuml0l4HIfHMczML6u+ZXG6E2w5tbdM3Eh5AzHjXGQPuwUnaYPn3Mq/2t2N1rz98pg==
   dependencies:
     "@loaders.gl/loader-utils" "3.4.15"
@@ -786,7 +791,7 @@
 
 "@loaders.gl/gltf@3.4.15", "@loaders.gl/gltf@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-3.4.15.tgz#9743adac8914dd9359e97eb2a3f4603f61137bba"
+  resolved "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.15.tgz"
   integrity sha512-Y6kMNPLiHQPr6aWQw/4BMTxgPHWx3fcib4LPpZCbhyfM8PRn6pOqATVngUXdoOf5XY0QtdKVld6N1kxlr4pJtw==
   dependencies:
     "@loaders.gl/draco" "3.4.15"
@@ -797,14 +802,14 @@
 
 "@loaders.gl/images@3.4.15", "@loaders.gl/images@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-3.4.15.tgz#7a0eafc537df38fee0d021d630086f374aad957b"
+  resolved "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.15.tgz"
   integrity sha512-QpjYhEetHabY/z9mWZYJXZZp4XJAxa38f9Ii/DjPlnJErepzY5GLBUTDHMu4oZ6n99gGImtuGFicDnFV6mb60g==
   dependencies:
     "@loaders.gl/loader-utils" "3.4.15"
 
 "@loaders.gl/loader-utils@3.4.15", "@loaders.gl/loader-utils@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz#5bee08aa6cbaa327722eb603d9b9e9bb4fe67340"
+  resolved "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz"
   integrity sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -813,7 +818,7 @@
 
 "@loaders.gl/math@3.4.15":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/math/-/math-3.4.15.tgz#bc8c4990775788f3f2ea9cf418df4c4f5acf6d92"
+  resolved "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.15.tgz"
   integrity sha512-zTN8BUU/1fcppyVc8WzvdZcCyNGVYmNinxcn/A+a7mi1ug4OBGwEsZOj09Wjg0/s52c/cAL3h9ylPIZdjntscQ==
   dependencies:
     "@loaders.gl/images" "3.4.15"
@@ -822,7 +827,7 @@
 
 "@loaders.gl/mvt@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/mvt/-/mvt-3.4.15.tgz#bde73029fa63a0f66cbc8b6d008a0ef3e043af02"
+  resolved "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.15.tgz"
   integrity sha512-Q8e1ZyfNkJtPF/C4WSZ2qhWDEbzOvquP7OyG1NzQ2cp8R6eUfbexu48IgcnL/oAu8VPql3zIxQ+bQUyDReyN5g==
   dependencies:
     "@loaders.gl/gis" "3.4.15"
@@ -833,14 +838,14 @@
 
 "@loaders.gl/schema@3.4.15", "@loaders.gl/schema@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/schema/-/schema-3.4.15.tgz#316565b4fcbffb135b52e25e96cee4ac5c541713"
+  resolved "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.15.tgz"
   integrity sha512-8oRtstz0IsqES7eZd2jQbmCnmExCMtL8T6jWd1+BfmnuyZnQ0B6TNccy++NHtffHdYuzEoQgSELwcdmhSApYew==
   dependencies:
     "@types/geojson" "^7946.0.7"
 
 "@loaders.gl/terrain@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/terrain/-/terrain-3.4.15.tgz#cde45a693d26b0458de74cfe36c3ae4ce8787832"
+  resolved "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.15.tgz"
   integrity sha512-ouv41J84uOnLEtXLM+iPEPFfeq7aRgIOls6esdvhBx2/dXJRNkt8Mx0wShXAi8VNHz77D+gZFrKARa7wqjmftg==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -851,7 +856,7 @@
 
 "@loaders.gl/textures@3.4.15":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/textures/-/textures-3.4.15.tgz#1729271e602df41661db767262116cc449e358b9"
+  resolved "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.15.tgz"
   integrity sha512-QHnmxBYtLvTdG1uMz2KWcxVY8KPb1+XyPJUoZV9GMcQkulz+CwFB8BaX8nROfMDz9KKYoPfksCzjig0LZ0WBJQ==
   dependencies:
     "@loaders.gl/images" "3.4.15"
@@ -863,7 +868,7 @@
 
 "@loaders.gl/tiles@3.4.15", "@loaders.gl/tiles@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/tiles/-/tiles-3.4.15.tgz#3be32c74996095e4fa571506e9bdc0e337a4c9b2"
+  resolved "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.15.tgz"
   integrity sha512-o85aRSXq+YeVSK2ndW9aBwTMi5FhEsQ7k18J4DG+T5Oc+zz3tKui5X1SuBDiKbQN+kYtFpj0oYO1QG3ndNI6jg==
   dependencies:
     "@loaders.gl/loader-utils" "3.4.15"
@@ -876,7 +881,7 @@
 
 "@loaders.gl/wms@^3.4.13":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/wms/-/wms-3.4.15.tgz#2b60c273f08840be6c7b17411c61542fc91af9f0"
+  resolved "https://registry.npmjs.org/@loaders.gl/wms/-/wms-3.4.15.tgz"
   integrity sha512-zY++Oxx+cNGF9ptuSTFxCmEnpRbR5VZYjvyLraylaRbuynZv+JiWrehymFzEfq3hJcQ/cGvIjaG6rSVtPuqCIA==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -890,14 +895,14 @@
 
 "@loaders.gl/worker-utils@3.4.15":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz#28dc1dcc526648fd68e317d8a8b7aa482d9e8198"
+  resolved "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz"
   integrity sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
 "@loaders.gl/xml@3.4.15":
   version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/xml/-/xml-3.4.15.tgz#83c53d7bdc623a057856b39c36a4fbac9f0ea3d0"
+  resolved "https://registry.npmjs.org/@loaders.gl/xml/-/xml-3.4.15.tgz"
   integrity sha512-iMWHaDzYSe8JoS8W5k9IbxQ6S3VHPr7M+UBejIVeYGCp1jzWF0ri498olwJWWDRvg4kqAWolrkj8Pcgkg8Jf8A==
   dependencies:
     "@babel/runtime" "^7.3.1"
@@ -907,12 +912,12 @@
 
 "@luma.gl/constants@8.5.21", "@luma.gl/constants@^8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-8.5.21.tgz#81825e9bd9bdf4a9449bcface8b504389f65f634"
+  resolved "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz"
   integrity sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA==
 
 "@luma.gl/core@^8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/core/-/core-8.5.21.tgz#dc630f1ea18900287ac8da60724d0d8f783b31b1"
+  resolved "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.21.tgz"
   integrity sha512-11jQJQEMoR/IN2oIsd4zFxiQJk6FE+xgVIMUcsCTBuzafTtQZ8Po9df8mt+MVewpDyBlTVs6g8nxHRH4np1ukA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -924,7 +929,7 @@
 
 "@luma.gl/engine@8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/engine/-/engine-8.5.21.tgz#bc8e55371fb95e33fec195c08abf35598c55da42"
+  resolved "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.21.tgz"
   integrity sha512-IG3WQSKXFNUEs8QG7ZjHtGiOtsakUu+BAxtJ6997A6/F06yynZ44tPe5NU70jG9Yfu3kV0LykPZg7hO3vXZDiA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -939,7 +944,7 @@
 
 "@luma.gl/experimental@^8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/experimental/-/experimental-8.5.21.tgz#1ab5ad084202ae3c05e16b7e4b430c791f86a50d"
+  resolved "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.21.tgz"
   integrity sha512-uFKPChGofyihOKxtqJy78QCQCDFnuMTK4QHrUX/qiTnvFSO8BgtTUevKvWGN9lBvq+uDD0lSieeF9yBzhQfAzw==
   dependencies:
     "@luma.gl/constants" "8.5.21"
@@ -948,7 +953,7 @@
 
 "@luma.gl/gltools@8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/gltools/-/gltools-8.5.21.tgz#1077305a30712f20cd904c2e4cbe5b9263b7d138"
+  resolved "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.21.tgz"
   integrity sha512-6qZ0LaT2Mxa4AJT5F44TFoaziokYiHUwO45vnM/NYUOIu9xevcmS6VtToawytMEACGL6PDeDyVqP3Y80SDzq5g==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -959,7 +964,7 @@
 
 "@luma.gl/shadertools@8.5.21", "@luma.gl/shadertools@^8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/shadertools/-/shadertools-8.5.21.tgz#9a8e087e39e34f055f9fdda9fac527c04f637b4e"
+  resolved "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.21.tgz"
   integrity sha512-WQah7yFDJ8cNCLPYpIm3r0wSlXLvjoA279fcknmATvvkW3/i8PcCJ/nYEBJO3hHEwwMQxD16+YZu/uwGiifLMg==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -967,7 +972,7 @@
 
 "@luma.gl/webgl@8.5.21", "@luma.gl/webgl@^8.5.21":
   version "8.5.21"
-  resolved "https://registry.yarnpkg.com/@luma.gl/webgl/-/webgl-8.5.21.tgz#fe67bf19a41231840ca677ae702969c7a9a5d7a0"
+  resolved "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.21.tgz"
   integrity sha512-ZVLO4W5UuaOlzZIwmFWhnmZ1gYoU97a+heMqxLrSSmCUAsSu3ZETUex9gOmzdM1WWxcdWaa3M68rvKCNEgwz0Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -978,7 +983,7 @@
 
 "@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
+  resolved "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz"
   integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
   dependencies:
     get-stream "^6.0.1"
@@ -986,51 +991,51 @@
 
 "@mapbox/jsonlint-lines-primitives@^2.0.2", "@mapbox/jsonlint-lines-primitives@~2.0.2":
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
+  resolved "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz"
   integrity sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==
 
 "@mapbox/martini@^0.2.0":
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/martini/-/martini-0.2.0.tgz#1af70211fbe994abf26e37f1388ca69c02cd43b4"
+  resolved "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz"
   integrity sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==
 
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  resolved "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz"
   integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
 
 "@mapbox/tile-cover@3.0.1":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/tile-cover/-/tile-cover-3.0.1.tgz#ad0dbe69d02e4e9ff74bf228b3ee8fa533034210"
+  resolved "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.1.tgz"
   integrity sha512-R8aoFY/87HWBOL9E2eBqzOY2lpfWYXCcTNgBpIxAv67rqQeD4IfnHD0iPXg/Z1cqXrklegEYZCp/7ZR/RsWqBQ==
   dependencies:
     tilebelt "^1.0.1"
 
 "@mapbox/tiny-sdf@^2.0.5", "@mapbox/tiny-sdf@^2.0.6":
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz#0d67d65a43195003b282764f2297c619736bbc6e"
+  resolved "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz"
   integrity sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==
 
 "@mapbox/unitbezier@^0.0.1":
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
+  resolved "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz"
   integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
 
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
+  resolved "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz"
   integrity sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==
   dependencies:
     "@mapbox/point-geometry" "~0.1.0"
 
 "@mapbox/whoots-js@^3.1.0":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
+  resolved "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
 "@maplibre/maplibre-gl-style-spec@^19.2.1":
   version "19.3.3"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz#a106248bd2e25e77c963a362aeaf630e00f924e9"
+  resolved "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz"
   integrity sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "~2.0.2"
@@ -1042,7 +1047,7 @@
 
 "@maplibre/maplibre-gl-style-spec@^20.3.1":
   version "20.4.0"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz#408339e051fb51e022b40af2235e0beb037937ea"
+  resolved "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz"
   integrity sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "~2.0.2"
@@ -1055,7 +1060,7 @@
 
 "@math.gl/core@3.6.3", "@math.gl/core@^3.5.0", "@math.gl/core@^3.5.1", "@math.gl/core@^3.6.2":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/core/-/core-3.6.3.tgz#a6bf796ed421093099749d609de8d99a3ac20a53"
+  resolved "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz"
   integrity sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==
   dependencies:
     "@babel/runtime" "^7.12.0"
@@ -1064,7 +1069,7 @@
 
 "@math.gl/culling@^3.5.1", "@math.gl/culling@^3.6.2":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.6.3.tgz#91cdfa496748e8873a2e6261415a27a27b6af5f2"
+  resolved "https://registry.npmjs.org/@math.gl/culling/-/culling-3.6.3.tgz"
   integrity sha512-3UERXHbaPlM6pnTk2MI7LeQ5CoelDZzDzghTTcv+HdQCZsT/EOEuEdYimETHtSxiyiOmsX2Un65UBLYT/rbKZg==
   dependencies:
     "@babel/runtime" "^7.12.0"
@@ -1073,7 +1078,7 @@
 
 "@math.gl/geospatial@^3.5.1":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.6.3.tgz#011ebbe8d1660ff79020a81ed218886c353a62e1"
+  resolved "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.6.3.tgz"
   integrity sha512-6xf657lJnaecSarSzn02t0cnsCSkWb+39m4+im96v20dZTrLCWZ2glDQVzfuL91meDnDXjH4oyvynp12Mj5MFg==
   dependencies:
     "@babel/runtime" "^7.12.0"
@@ -1082,26 +1087,26 @@
 
 "@math.gl/polygon@^3.5.1", "@math.gl/polygon@^3.6.2":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.6.3.tgz#0c19c0b059cedde1cd760cc3796e9180f75bcbde"
+  resolved "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz"
   integrity sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==
   dependencies:
     "@math.gl/core" "3.6.3"
 
 "@math.gl/sun@^3.6.2":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/sun/-/sun-3.6.3.tgz#30c15612313b56349c568f21f39c0e0f0e77b2df"
+  resolved "https://registry.npmjs.org/@math.gl/sun/-/sun-3.6.3.tgz"
   integrity sha512-mrx6CGYYeTNSQttvcw0KVUy+35YDmnjMqpO/o0t06Vcghrt0HNruB/ScRgUSbJrgkbOg1Vcqm23HBd++clzQzw==
   dependencies:
     "@babel/runtime" "^7.12.0"
 
 "@math.gl/types@3.6.3":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/types/-/types-3.6.3.tgz#9fa9866feabcbb76de107d78ff3a89c0243ac374"
+  resolved "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz"
   integrity sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==
 
 "@math.gl/web-mercator@^3.5.1", "@math.gl/web-mercator@^3.6.2":
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz#ef91168e030eecffc788618d686e8a6c1d7a0bf8"
+  resolved "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz"
   integrity sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==
   dependencies:
     "@babel/runtime" "^7.12.0"
@@ -1109,7 +1114,7 @@
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
@@ -1117,12 +1122,12 @@
 
 "@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
@@ -1130,12 +1135,12 @@
 
 "@oxc-project/runtime@=0.115.0":
   version "0.115.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/runtime/-/runtime-0.115.0.tgz#5e8350088964e1d8e0c73cfccfc1d71ca2e2f4a2"
+  resolved "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz"
   integrity sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==
 
 "@oxc-project/types@=0.115.0":
   version "0.115.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.115.0.tgz#92a599543529bce45f8f2da77f40a124d63349dc"
+  resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz"
   integrity sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==
 
 "@oxfmt/binding-android-arm-eabi@0.39.0":
@@ -1150,7 +1155,7 @@
 
 "@oxfmt/binding-darwin-arm64@0.39.0":
   version "0.39.0"
-  resolved "https://registry.yarnpkg.com/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.39.0.tgz#b7a6e6f7fd5d414acba1d5a0c1db23afd965cb43"
+  resolved "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.39.0.tgz"
   integrity sha512-dKT57QEyVcXKVdZSPiAh3zHzzXYHwxWH6kZf/7p3bEZURtL/2XPA/9DKhxaOTM15fzGSqRdArW0JAWZf61Vqlw==
 
 "@oxfmt/binding-darwin-x64@0.39.0":
@@ -1235,7 +1240,7 @@
 
 "@oxlint-tsgolint/darwin-arm64@0.16.0":
   version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.16.0.tgz#d03363cdf89bf50faac558a7768e05cd2ab2d507"
+  resolved "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.16.0.tgz"
   integrity sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==
 
 "@oxlint-tsgolint/darwin-x64@0.16.0":
@@ -1275,7 +1280,7 @@
 
 "@oxlint/binding-darwin-arm64@1.54.0":
   version "1.54.0"
-  resolved "https://registry.yarnpkg.com/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.54.0.tgz#e0eb52cc106be517bcd83a3ff61c75f287520dfd"
+  resolved "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.54.0.tgz"
   integrity sha512-tUQ+vn/AL2P2Rz6cl3gsFA+4pMBFMRR0e6AVePoezV9iGTSMZUXIf0YWHq203bwNDXcY04vSXDqPB6E1b9WULA==
 
 "@oxlint/binding-darwin-x64@1.54.0":
@@ -1360,26 +1365,26 @@
 
 "@playwright/test@^1.59.1":
   version "1.59.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
   integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
   dependencies:
     playwright "1.59.1"
 
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
-  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  resolved "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
 "@probe.gl/env@3.6.0", "@probe.gl/env@^3.5.0":
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@probe.gl/env/-/env-3.6.0.tgz#33343fd9041a14d21374c1911826d4a2f9d9a35d"
+  resolved "https://registry.npmjs.org/@probe.gl/env/-/env-3.6.0.tgz"
   integrity sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
 "@probe.gl/log@^3.5.0":
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@probe.gl/log/-/log-3.6.0.tgz#c645bfd22b4769dc65161caa17f13bd2b231e413"
+  resolved "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz"
   integrity sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -1387,31 +1392,31 @@
 
 "@probe.gl/stats@^3.5.0":
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@probe.gl/stats/-/stats-3.6.0.tgz#a1bb12860fa6f40b9c028f9eb575d7ada0b4dbdd"
+  resolved "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz"
   integrity sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
 "@radix-ui/number@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.1.1.tgz#7b2c9225fbf1b126539551f5985769d0048d9090"
+  resolved "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz"
   integrity sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==
 
 "@radix-ui/primitive@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  resolved "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz"
   integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/primitive@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  resolved "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz"
   integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
 
 "@radix-ui/react-accordion@^1.2.3":
   version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz#1fd70d4ef36018012b9e03324ff186de7a29c13f"
+  resolved "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz"
   integrity sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1426,14 +1431,14 @@
 
 "@radix-ui/react-arrow@1.1.7":
   version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz#e14a2657c81d961598c5e72b73dd6098acc04f09"
+  resolved "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz"
   integrity sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
 "@radix-ui/react-avatar@^1.1.11":
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz#3e24b70d636a12e2806abb2b4ce4b15df395f9c9"
+  resolved "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz"
   integrity sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==
   dependencies:
     "@radix-ui/react-context" "1.1.3"
@@ -1444,7 +1449,7 @@
 
 "@radix-ui/react-checkbox@^1.1.3":
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz#db45ca8a6d5c056a92f74edbb564acee05318b79"
+  resolved "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz"
   integrity sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1458,7 +1463,7 @@
 
 "@radix-ui/react-collapsible@1.1.12", "@radix-ui/react-collapsible@^1.1.2":
   version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz#e2cc69a4490a2920f97c3c3150b0bf21281e3c49"
+  resolved "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz"
   integrity sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1472,7 +1477,7 @@
 
 "@radix-ui/react-collection@1.1.7":
   version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
+  resolved "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz"
   integrity sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
@@ -1482,36 +1487,36 @@
 
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  resolved "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz"
   integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-compose-refs@1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  resolved "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
 
 "@radix-ui/react-context@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  resolved "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz"
   integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-context@1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  resolved "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz"
   integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
 "@radix-ui/react-context@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
+  resolved "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz"
   integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
 
 "@radix-ui/react-dialog@1.0.5":
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz#71657b1b116de6c7a0b03242d7d43e01062c7300"
+  resolved "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz"
   integrity sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1532,7 +1537,7 @@
 
 "@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.15":
   version "1.1.15"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
+  resolved "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz"
   integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1552,12 +1557,12 @@
 
 "@radix-ui/react-direction@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
+  resolved "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz"
   integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
 
 "@radix-ui/react-dismissable-layer@1.0.5":
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz#3f98425b82b9068dfbab5db5fff3df6ebf48b9d4"
+  resolved "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz"
   integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1569,7 +1574,7 @@
 
 "@radix-ui/react-dismissable-layer@1.1.11":
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz#e33ab6f6bdaa00f8f7327c408d9f631376b88b37"
+  resolved "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz"
   integrity sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1580,19 +1585,19 @@
 
 "@radix-ui/react-focus-guards@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
+  resolved "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz"
   integrity sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-focus-guards@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz#2a5669e464ad5fde9f86d22f7fdc17781a4dfa7f"
+  resolved "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz"
   integrity sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==
 
 "@radix-ui/react-focus-scope@1.0.4":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz#2ac45fce8c5bb33eb18419cdc1905ef4f1906525"
+  resolved "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz"
   integrity sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1602,7 +1607,7 @@
 
 "@radix-ui/react-focus-scope@1.1.7":
   version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz#dfe76fc103537d80bf42723a183773fd07bfb58d"
+  resolved "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz"
   integrity sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
@@ -1611,7 +1616,7 @@
 
 "@radix-ui/react-id@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"
+  resolved "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz"
   integrity sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1619,21 +1624,21 @@
 
 "@radix-ui/react-id@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  resolved "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz"
   integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-label@^2.1.1":
   version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.1.8.tgz#d93b7c063ef2ea034df143a2464bfc0548e4b7e5"
+  resolved "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz"
   integrity sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==
   dependencies:
     "@radix-ui/react-primitive" "2.1.4"
 
 "@radix-ui/react-navigation-menu@^1.2.3":
   version "1.2.14"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz#4e6d1172be3c89752e564f8721706f78574ad7dd"
+  resolved "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz"
   integrity sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1653,7 +1658,7 @@
 
 "@radix-ui/react-popover@^1.1.4":
   version "1.1.15"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"
+  resolved "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz"
   integrity sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1674,7 +1679,7 @@
 
 "@radix-ui/react-popper@1.2.8":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.8.tgz#a79f39cdd2b09ab9fb50bf95250918422c4d9602"
+  resolved "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz"
   integrity sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==
   dependencies:
     "@floating-ui/react-dom" "^2.0.0"
@@ -1690,7 +1695,7 @@
 
 "@radix-ui/react-portal@1.0.4":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.4.tgz#df4bfd353db3b1e84e639e9c63a5f2565fb00e15"
+  resolved "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz"
   integrity sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1698,7 +1703,7 @@
 
 "@radix-ui/react-portal@1.1.9":
   version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
+  resolved "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz"
   integrity sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
@@ -1706,7 +1711,7 @@
 
 "@radix-ui/react-presence@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  resolved "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz"
   integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1715,7 +1720,7 @@
 
 "@radix-ui/react-presence@1.1.5":
   version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  resolved "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz"
   integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
@@ -1723,7 +1728,7 @@
 
 "@radix-ui/react-primitive@1.0.3":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz"
   integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1731,21 +1736,21 @@
 
 "@radix-ui/react-primitive@2.1.3":
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz"
   integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
   dependencies:
     "@radix-ui/react-slot" "1.2.3"
 
 "@radix-ui/react-primitive@2.1.4":
   version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz#2626ea309ebd63bf5767d3e7fc4081f81b993df0"
+  resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz"
   integrity sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==
   dependencies:
     "@radix-ui/react-slot" "1.2.4"
 
 "@radix-ui/react-progress@^1.1.1":
   version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.8.tgz#9f9a68d75bf763f9c64808724a83d2de804bd061"
+  resolved "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz"
   integrity sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==
   dependencies:
     "@radix-ui/react-context" "1.1.3"
@@ -1753,7 +1758,7 @@
 
 "@radix-ui/react-roving-focus@1.1.11":
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"
+  resolved "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz"
   integrity sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1768,7 +1773,7 @@
 
 "@radix-ui/react-scroll-area@^1.2.2":
   version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz#e4fd3b4a79bb77bec1a52f0c8f26d8f3f1ca4b22"
+  resolved "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz"
   integrity sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==
   dependencies:
     "@radix-ui/number" "1.1.1"
@@ -1783,7 +1788,7 @@
 
 "@radix-ui/react-select@^2.1.4":
   version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.2.6.tgz#022cf8dab16bf05d0d1b4df9e53e4bea1b744fd9"
+  resolved "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz"
   integrity sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==
   dependencies:
     "@radix-ui/number" "1.1.1"
@@ -1810,14 +1815,14 @@
 
 "@radix-ui/react-separator@^1.1.8":
   version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.1.8.tgz#24f871fbf9630af316d0c14cbc7519a6e33aa11e"
+  resolved "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz"
   integrity sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==
   dependencies:
     "@radix-ui/react-primitive" "2.1.4"
 
 "@radix-ui/react-slider@^1.2.3":
   version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.3.6.tgz#409453110b8f34ca00972750b80cd792f0b23a8c"
+  resolved "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz"
   integrity sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==
   dependencies:
     "@radix-ui/number" "1.1.1"
@@ -1834,7 +1839,7 @@
 
 "@radix-ui/react-slot@1.0.2":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz"
   integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1842,21 +1847,21 @@
 
 "@radix-ui/react-slot@1.2.3":
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz"
   integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
 "@radix-ui/react-slot@1.2.4", "@radix-ui/react-slot@^1.2.4":
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.4.tgz#63c0ba05fdf90cc49076b94029c852d7bac1fb83"
+  resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz"
   integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
 "@radix-ui/react-tabs@^1.1.2":
   version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"
+  resolved "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz"
   integrity sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1870,7 +1875,7 @@
 
 "@radix-ui/react-toggle@^1.1.1":
   version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz#b04ba0f9609599df666fce5b2f38109a197f08cf"
+  resolved "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz"
   integrity sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1879,7 +1884,7 @@
 
 "@radix-ui/react-tooltip@^1.2.8":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"
+  resolved "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz"
   integrity sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==
   dependencies:
     "@radix-ui/primitive" "1.1.3"
@@ -1897,19 +1902,19 @@
 
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz"
   integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-use-callback-ref@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz"
   integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
 
 "@radix-ui/react-use-controllable-state@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz"
   integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1917,7 +1922,7 @@
 
 "@radix-ui/react-use-controllable-state@1.2.2":
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz"
   integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
   dependencies:
     "@radix-ui/react-use-effect-event" "0.0.2"
@@ -1925,14 +1930,14 @@
 
 "@radix-ui/react-use-effect-event@0.0.2":
   version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz"
   integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-use-escape-keydown@1.0.3":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz"
   integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1940,98 +1945,98 @@
 
 "@radix-ui/react-use-escape-keydown@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz"
   integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
   dependencies:
     "@radix-ui/react-use-callback-ref" "1.1.1"
 
 "@radix-ui/react-use-is-hydrated@0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz#544da73369517036c77659d7cdd019dc0f5ff9a0"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz"
   integrity sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==
   dependencies:
     use-sync-external-store "^1.5.0"
 
 "@radix-ui/react-use-layout-effect@1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz"
   integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
 "@radix-ui/react-use-layout-effect@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz"
   integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
 
 "@radix-ui/react-use-previous@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz#1a1ad5568973d24051ed0af687766f6c7cb9b5b5"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz"
   integrity sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==
 
 "@radix-ui/react-use-rect@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz#01443ca8ed071d33023c1113e5173b5ed8769152"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz"
   integrity sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==
   dependencies:
     "@radix-ui/rect" "1.1.1"
 
 "@radix-ui/react-use-size@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz#6de276ffbc389a537ffe4316f5b0f24129405b37"
+  resolved "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz"
   integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-visually-hidden@1.2.3":
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz#a8c38c8607735dc9f05c32f87ab0f9c2b109efbf"
+  resolved "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz"
   integrity sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
 "@radix-ui/rect@1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
+  resolved "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz"
   integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
 "@rolldown/pluginutils@1.0.0-rc.7":
   version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz#0414869467f0e471a6515d4f506c85fde867e022"
+  resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz"
   integrity sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@swc/helpers@^0.5.11":
   version "0.5.18"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.18.tgz#feeeabea0d10106ee25aaf900165df911ab6d3b1"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz"
   integrity sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==
   dependencies:
     tslib "^2.8.0"
 
 "@tanstack/history@1.154.14":
   version "1.154.14"
-  resolved "https://registry.yarnpkg.com/@tanstack/history/-/history-1.154.14.tgz#eccbfd62a14c8364a0287ede0fb955bd6ae5aade"
+  resolved "https://registry.npmjs.org/@tanstack/history/-/history-1.154.14.tgz"
   integrity sha512-xyIfof8eHBuub1CkBnbKNKQXeRZC4dClhmzePHVOEel4G7lk/dW+TQ16da7CFdeNLv6u6Owf5VoBQxoo6DFTSA==
 
 "@tanstack/query-core@5.90.20":
   version "5.90.20"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.90.20.tgz#e12128e39210715d4ce4fb299c33498ac297771e"
+  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz"
   integrity sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==
 
 "@tanstack/react-query@^5.62.16":
   version "5.90.21"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.90.21.tgz#e0eb40831a76510be438109435b8807ef63ab1b9"
+  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz"
   integrity sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==
   dependencies:
     "@tanstack/query-core" "5.90.20"
 
 "@tanstack/react-router@^1.151.6":
   version "1.159.5"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-router/-/react-router-1.159.5.tgz#b228812387f433f4a1780000ebdb9b0cc7a1e960"
+  resolved "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.159.5.tgz"
   integrity sha512-rVb0MtKzP5c0BkWIoFgWBiRAJHYSU3bhsEHbT0cRdRLmlJiw21Awb6VEjgYq3hJiEhowcKKm6J8AdRD/8oZ5dQ==
   dependencies:
     "@tanstack/history" "1.154.14"
@@ -2043,7 +2048,7 @@
 
 "@tanstack/react-store@^0.8.0":
   version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-store/-/react-store-0.8.0.tgz#af2e73f1a466e08897349829bae1073f6172e7da"
+  resolved "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.8.0.tgz"
   integrity sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow==
   dependencies:
     "@tanstack/store" "0.8.0"
@@ -2051,14 +2056,14 @@
 
 "@tanstack/react-table@^8.20.6":
   version "8.21.3"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  resolved "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz"
   integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
   dependencies:
     "@tanstack/table-core" "8.21.3"
 
 "@tanstack/router-core@1.159.4":
   version "1.159.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/router-core/-/router-core-1.159.4.tgz#9638076f0280a52a0969da0ce0005e561d9e26a1"
+  resolved "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.159.4.tgz"
   integrity sha512-MFzPH39ijNO83qJN3pe7x4iAlhZyqgao3sJIzv3SJ4Pnk12xMnzuDzIAQT/1WV6JolPQEcw0Wr4L5agF8yxoeg==
   dependencies:
     "@tanstack/history" "1.154.14"
@@ -2071,7 +2076,7 @@
 
 "@tanstack/router-generator@1.159.4":
   version "1.159.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/router-generator/-/router-generator-1.159.4.tgz#3ac095ca7c9d6cc57340fb2055fdd54c20b5867d"
+  resolved "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.159.4.tgz"
   integrity sha512-O8tICQoSuvK6vs3mvBdI3zVLFmYfj/AYDCX0a5msSADP/2S0GsgDDTB5ah731TqYCtjeNriaWz9iqst38cjF/Q==
   dependencies:
     "@tanstack/router-core" "1.159.4"
@@ -2085,7 +2090,7 @@
 
 "@tanstack/router-plugin@^1.151.6":
   version "1.159.5"
-  resolved "https://registry.yarnpkg.com/@tanstack/router-plugin/-/router-plugin-1.159.5.tgz#5e999fce193c19cc836c6562c79bf6b9056baa55"
+  resolved "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.159.5.tgz"
   integrity sha512-i2LR3WRaBOAZ1Uab5QBG9UxZIRJ3V56JVu890NysbuX15rgzRiL5yLAbfenOHdhaHy2+4joX35VICAHuVWy7Og==
   dependencies:
     "@babel/core" "^7.28.5"
@@ -2104,7 +2109,7 @@
 
 "@tanstack/router-utils@1.158.0":
   version "1.158.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/router-utils/-/router-utils-1.158.0.tgz#411d519360504276238ececf92f36138be5abaf1"
+  resolved "https://registry.npmjs.org/@tanstack/router-utils/-/router-utils-1.158.0.tgz"
   integrity sha512-qZ76eaLKU6Ae9iI/mc5zizBX149DXXZkBVVO3/QRIll79uKLJZHQlMKR++2ba7JsciBWz1pgpIBcCJPE9S0LVg==
   dependencies:
     "@babel/core" "^7.28.5"
@@ -2119,22 +2124,22 @@
 
 "@tanstack/store@0.8.0", "@tanstack/store@^0.8.0":
   version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/store/-/store-0.8.0.tgz#f1c533b9cff000fc792ed77edda178000abc9442"
+  resolved "https://registry.npmjs.org/@tanstack/store/-/store-0.8.0.tgz"
   integrity sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==
 
 "@tanstack/table-core@8.21.3":
   version "8.21.3"
-  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  resolved "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz"
   integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
 
 "@tanstack/virtual-file-routes@1.154.7":
   version "1.154.7"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-file-routes/-/virtual-file-routes-1.154.7.tgz#dedb62bafd01b93e95eafca16618c04f9992fb3a"
+  resolved "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.154.7.tgz"
   integrity sha512-cHHDnewHozgjpI+MIVp9tcib6lYEQK5MyUr0ChHpHFGBl8Xei55rohFK0I0ve/GKoHeioaK42Smd8OixPp6CTg==
 
 "@turf/boolean-clockwise@^5.1.5":
   version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz#3302b7dac62c5e291a0789e29af7283387fa9deb"
+  resolved "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz"
   integrity sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==
   dependencies:
     "@turf/helpers" "^5.1.5"
@@ -2142,33 +2147,33 @@
 
 "@turf/clone@^5.1.5":
   version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-5.1.5.tgz#253e8d35477181976e33adfab50a0f02a7f0e367"
+  resolved "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz"
   integrity sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==
   dependencies:
     "@turf/helpers" "^5.1.5"
 
 "@turf/helpers@^5.1.5":
   version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
+  resolved "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz"
   integrity sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==
 
 "@turf/invariant@^5.1.5":
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
+  resolved "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz"
   integrity sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==
   dependencies:
     "@turf/helpers" "^5.1.5"
 
 "@turf/meta@^5.1.5":
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
+  resolved "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz"
   integrity sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==
   dependencies:
     "@turf/helpers" "^5.1.5"
 
 "@turf/rewind@^5.1.5":
   version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-5.1.5.tgz#9ea3db4a68b73c1fd1dd11f57631b143cfefa1c9"
+  resolved "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz"
   integrity sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==
   dependencies:
     "@turf/boolean-clockwise" "^5.1.5"
@@ -2179,7 +2184,7 @@
 
 "@types/chai@^5.2.2":
   version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  resolved "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz"
   integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
   dependencies:
     "@types/deep-eql" "*"
@@ -2187,48 +2192,48 @@
 
 "@types/command-line-args@^5.2.3":
   version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.2.3.tgz#553ce2fd5acf160b448d307649b38ffc60d39639"
+  resolved "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz"
   integrity sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==
 
 "@types/command-line-usage@^5.0.4":
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
+  resolved "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz"
   integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
 "@types/d3-color@*":
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  resolved "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz"
   integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
 
 "@types/d3-drag@^3.0.7":
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  resolved "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz"
   integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-interpolate@*", "@types/d3-interpolate@^3.0.4":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  resolved "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz"
   integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
   dependencies:
     "@types/d3-color" "*"
 
 "@types/d3-selection@*", "@types/d3-selection@^3.0.10":
   version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  resolved "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz"
   integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
 
 "@types/d3-transition@^3.0.8":
   version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  resolved "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz"
   integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-zoom@^3.0.8":
   version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  resolved "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz"
   integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
   dependencies:
     "@types/d3-interpolate" "*"
@@ -2236,48 +2241,48 @@
 
 "@types/deep-eql@*":
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/geojson-vt@3.2.5":
   version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@types/geojson-vt/-/geojson-vt-3.2.5.tgz#b6c356874991d9ab4207533476dfbcdb21e38408"
+  resolved "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz"
   integrity sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==
   dependencies:
     "@types/geojson" "*"
 
 "@types/geojson@*", "@types/geojson@^7946.0.14", "@types/geojson@^7946.0.7", "@types/geojson@^7946.0.8":
   version "7946.0.16"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  resolved "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz"
   integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/hammerjs@^2.0.41":
   version "2.0.46"
-  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
+  resolved "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz"
   integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
 
 "@types/mapbox-gl@>=1.0.0":
   version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz#b6a1b81b802e62fb7e1d1d13a97ccece63b232a3"
+  resolved "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz"
   integrity sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==
   dependencies:
     "@types/geojson" "*"
 
 "@types/mapbox-gl@^2.6.3":
   version "2.7.21"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.21.tgz#b0cad1e4c3d1bf1592444de36a4f27e890310416"
+  resolved "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.21.tgz"
   integrity sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==
   dependencies:
     "@types/geojson" "*"
 
 "@types/mapbox__point-geometry@*", "@types/mapbox__point-geometry@^0.1.4":
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz#0ef017b75eedce02ff6243b4189210e2e6d5e56d"
+  resolved "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz"
   integrity sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==
 
 "@types/mapbox__vector-tile@^1.3.4":
   version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz#ad757441ef1d34628d9e098afd9c91423c1f8734"
+  resolved "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz"
   integrity sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==
   dependencies:
     "@types/geojson" "*"
@@ -2286,41 +2291,41 @@
 
 "@types/node@^20.13.0":
   version "20.19.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.33.tgz#ac8364c623b72d43125f0e7dd722bbe968f0c65e"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz"
   integrity sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==
   dependencies:
     undici-types "~6.21.0"
 
 "@types/node@^22.10.5":
   version "22.19.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.11.tgz#7e1feaad24e4e36c52fa5558d5864bb4b272603e"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz"
   integrity sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==
   dependencies:
     undici-types "~6.21.0"
 
 "@types/offscreencanvas@^2019.7.0":
   version "2019.7.3"
-  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
+  resolved "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz"
   integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
 
 "@types/pbf@*", "@types/pbf@^3.0.5":
   version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/pbf/-/pbf-3.0.5.tgz#a9495a58d8c75be4ffe9a0bd749a307715c07404"
+  resolved "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz"
   integrity sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==
 
 "@types/prop-types@*":
   version "15.7.15"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
+  resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz"
   integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
 "@types/react-dom@^18.3.5":
   version "18.3.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz"
   integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react@^18.3.18":
   version "18.3.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.28.tgz#0a85b1a7243b4258d9f626f43797ba18eb5f8781"
+  resolved "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz"
   integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
   dependencies:
     "@types/prop-types" "*"
@@ -2328,21 +2333,21 @@
 
 "@types/supercluster@^7.1.3":
   version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@types/supercluster/-/supercluster-7.1.3.tgz#1a1bc2401b09174d9c9e44124931ec7874a72b27"
+  resolved "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz"
   integrity sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==
   dependencies:
     "@types/geojson" "*"
 
 "@vitejs/plugin-react@^6.0.0":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz#d9113b71a0a592714913eafd9e5e63bcafd0ff15"
+  resolved "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz"
   integrity sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==
   dependencies:
     "@rolldown/pluginutils" "1.0.0-rc.7"
 
 "@voidzero-dev/vite-plus-core@0.1.8":
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.1.8.tgz#0784beb59997a23fc81c1ae72ffd56ad502b608a"
+  resolved "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.1.8.tgz"
   integrity sha512-XGAJyvJLBnAg53ltZ++j7kDZkRIcjFNUIIGus+02ZqsOT0GkKSv6t0nPhVpmRZbgzDx4sR9rSeDzSqRteoVHvQ==
   dependencies:
     "@oxc-project/runtime" "=0.115.0"
@@ -2354,7 +2359,7 @@
 
 "@voidzero-dev/vite-plus-darwin-arm64@0.1.8":
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.1.8.tgz#4ce255a6c2e35b4f6a052378460bb2717e03c5af"
+  resolved "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.1.8.tgz"
   integrity sha512-sIYoR9NXMW2NtOsVzhlsJBKuB1xfO93a6o32w3gvp8Fo7fndqKTgOQlXxFyWhoxxBd8zZAxCO3/fCsUM96I3Ng==
 
 "@voidzero-dev/vite-plus-darwin-x64@0.1.8":
@@ -2374,7 +2379,7 @@
 
 "@voidzero-dev/vite-plus-test@0.1.8":
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@voidzero-dev/vite-plus-test/-/vite-plus-test-0.1.8.tgz#4be48e9d5ba6d72675c9838effdc38a4c95fc951"
+  resolved "https://registry.npmjs.org/@voidzero-dev/vite-plus-test/-/vite-plus-test-0.1.8.tgz"
   integrity sha512-pSMP4Pb7+1JRrL2DAFOHR36ncICmPYxqY4t9XPUEnquujwTDs0vDRvvk7MhGjOlMnNhhX2WBN2jUo+vzPfEY5Q==
   dependencies:
     "@standard-schema/spec" "^1.1.0"
@@ -2403,7 +2408,7 @@
 
 "@xyflow/react@^12.10.1":
   version "12.10.2"
-  resolved "https://registry.yarnpkg.com/@xyflow/react/-/react-12.10.2.tgz#40f6d71944f674f0ffbb83c660f9473018adbe61"
+  resolved "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz"
   integrity sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==
   dependencies:
     "@xyflow/system" "0.0.76"
@@ -2412,7 +2417,7 @@
 
 "@xyflow/system@0.0.76":
   version "0.0.76"
-  resolved "https://registry.yarnpkg.com/@xyflow/system/-/system-0.0.76.tgz#57da5e4d230cdbec56548a6d5eec115f22858259"
+  resolved "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz"
   integrity sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==
   dependencies:
     "@types/d3-drag" "^3.0.7"
@@ -2427,34 +2432,34 @@
 
 acorn@^8.15.0:
   version "8.15.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
 
 ansis@^4.1.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.2.0.tgz#2e6e61c46b11726ac67f78785385618b9e658780"
+  resolved "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz"
   integrity sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==
 
 any-promise@^1.0.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
 anymatch@~3.1.2:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
@@ -2462,7 +2467,7 @@ anymatch@~3.1.2:
 
 apache-arrow@^17.0.0:
   version "17.0.0"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-17.0.0.tgz#73d98566c86352c9a0314c03890dbd7211073827"
+  resolved "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz"
   integrity sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==
   dependencies:
     "@swc/helpers" "^0.5.11"
@@ -2477,58 +2482,58 @@ apache-arrow@^17.0.0:
 
 arg@^5.0.2:
   version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  resolved "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^1.0.10:
   version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 aria-hidden@^1.1.1, aria-hidden@^1.2.4:
   version "1.2.6"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  resolved "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz"
   integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
   dependencies:
     tslib "^2.0.0"
 
 arr-union@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  resolved "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
 array-back@^3.0.1, array-back@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz"
   integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
 array-back@^6.2.2:
   version "6.2.2"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz"
   integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 assertion-error@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
 
 ast-types@^0.16.1:
   version "0.16.1"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.16.1.tgz#7a9da1617c9081bc121faafe91711b4c8bb81da2"
+  resolved "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz"
   integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
   dependencies:
     tslib "^2.0.1"
 
 autoprefixer@^10.4.20:
   version "10.4.24"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.24.tgz#2c29595f3abd820a79976a609d0bf40eecf212fb"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz"
   integrity sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==
   dependencies:
     browserslist "^4.28.1"
@@ -2539,7 +2544,7 @@ autoprefixer@^10.4.20:
 
 babel-dead-code-elimination@^1.0.12:
   version "1.0.12"
-  resolved "https://registry.yarnpkg.com/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz#9471fc492fdfb7a0f7348aeacdaff3f1a9ecc6d3"
+  resolved "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz"
   integrity sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==
   dependencies:
     "@babel/core" "^7.23.7"
@@ -2548,25 +2553,25 @@ babel-dead-code-elimination@^1.0.12:
     "@babel/types" "^7.23.6"
 
 baseline-browser-mapping@^2.9.0:
-  version "2.9.19"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz#3e508c43c46d961eb4d7d2e5b8d1dd0f9ee4f488"
-  integrity sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==
+  version "2.10.43"
+  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz"
+  integrity sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
 
 browserslist@^4.24.0, browserslist@^4.28.1:
   version "4.28.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
   dependencies:
     baseline-browser-mapping "^2.9.0"
@@ -2577,24 +2582,24 @@ browserslist@^4.24.0, browserslist@^4.28.1:
 
 buf-compare@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
+  resolved "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz"
   integrity sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==
 
 buffer-from@^1.0.0:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 bytewise-core@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/bytewise-core/-/bytewise-core-1.2.3.tgz#3fb410c7e91558eb1ab22a82834577aa6bd61d42"
+  resolved "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz"
   integrity sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==
   dependencies:
     typewise-core "^1.2"
 
 bytewise@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bytewise/-/bytewise-1.1.0.tgz#1d13cbff717ae7158094aa881b35d081b387253e"
+  resolved "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz"
   integrity sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==
   dependencies:
     bytewise-core "^1.2.2"
@@ -2602,36 +2607,36 @@ bytewise@^1.1.0:
 
 cac@^6.7.14:
   version "6.7.14"
-  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  resolved "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
 camelcase-css@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
+  resolved "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001759, caniuse-lite@^1.0.30001766:
-  version "1.0.30001769"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz#1ad91594fad7dc233777c2781879ab5409f7d9c2"
-  integrity sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==
+  version "1.0.30001805"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz"
+  integrity sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==
 
 cartocolor@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cartocolor/-/cartocolor-4.0.2.tgz#ef1aa12860f6eeedc8d2420e2b9d7337937c4993"
+  resolved "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.2.tgz"
   integrity sha512-+Gh9mb6lFxsDOLQlBLPxAHCnWXlg2W8q3AcVwqRcy95TdBbcOU89Wrb6h2Hd/6Ww1Kc1pzXmUdpnWD+xeCG0dg==
   dependencies:
     colorbrewer "1.0.0"
 
 chalk-template@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  resolved "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz"
   integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
   dependencies:
     chalk "^4.1.2"
 
 chalk@^4.1.2:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
@@ -2639,7 +2644,7 @@ chalk@^4.1.2:
 
 chokidar@^3.6.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
@@ -2654,19 +2659,19 @@ chokidar@^3.6.0:
 
 class-variance-authority@^0.7.1:
   version "0.7.1"
-  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz#4008a798a0e4553a781a57ac5177c9fb5d043787"
+  resolved "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz"
   integrity sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==
   dependencies:
     clsx "^2.1.1"
 
 classcat@^5.0.3:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.5.tgz#8c209f359a93ac302404a10161b501eba9c09c77"
+  resolved "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz"
   integrity sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==
 
 cliui@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
   integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
     string-width "^4.2.0"
@@ -2675,12 +2680,12 @@ cliui@^8.0.1:
 
 clsx@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 cmdk@1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.0.0.tgz#0a095fdafca3dfabed82d1db78a6262fb163ded9"
+  resolved "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz"
   integrity sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==
   dependencies:
     "@radix-ui/react-dialog" "1.0.5"
@@ -2688,24 +2693,24 @@ cmdk@1.0.0:
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorbrewer@1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/colorbrewer/-/colorbrewer-1.0.0.tgz#4f97333b969ba7612382be4bc3394b341fb4c8a2"
+  resolved "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz"
   integrity sha512-NZuIOVdErK/C6jDH3jWT/roxWJbJAinMiqEpbuWniKvQAoWdg6lGra3pPrSHvaIf8PlX8wLs/RAC6nULFJbgmg==
 
 command-line-args@^5.2.1:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz"
   integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
   dependencies:
     array-back "^3.1.0"
@@ -2715,7 +2720,7 @@ command-line-args@^5.2.1:
 
 command-line-usage@^7.0.1:
   version "7.0.3"
-  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.3.tgz#6bce992354f6af10ecea2b631bfdf0c8b3bfaea3"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz"
   integrity sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==
   dependencies:
     array-back "^6.2.2"
@@ -2725,27 +2730,27 @@ command-line-usage@^7.0.1:
 
 commander@2, commander@^2.20.0:
   version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.0:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 cookie-es@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-2.0.0.tgz#ca6163d7ef8686ea6bbdd551f1de575569c1ed69"
+  resolved "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz"
   integrity sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==
 
 core-assert@^0.2.0:
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/core-assert/-/core-assert-0.2.1.tgz#f85e2cf9bfed28f773cc8b3fa5c5b69bdc02fe3f"
+  resolved "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz"
   integrity sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==
   dependencies:
     buf-compare "^1.0.0"
@@ -2753,12 +2758,12 @@ core-assert@^0.2.0:
 
 core-util-is@~1.0.0:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-spawn@^7.0.5:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -2767,34 +2772,34 @@ cross-spawn@^7.0.5:
 
 cssesc@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 csstype@^3.2.2:
   version "3.2.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 "d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.2.0:
   version "3.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
   dependencies:
     internmap "1 - 2"
 
 "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 "d3-dispatch@1 - 3":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
 "d3-drag@2 - 3", d3-drag@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
   dependencies:
     d3-dispatch "1 - 3"
@@ -2802,7 +2807,7 @@ csstype@^3.2.2:
 
 d3-dsv@^1.0.8:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  resolved "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz"
   integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
   dependencies:
     commander "2"
@@ -2811,29 +2816,29 @@ d3-dsv@^1.0.8:
 
 "d3-ease@1 - 3":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
 
 "d3-format@1 - 3", d3-format@^3.1.0:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz"
   integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
 
 d3-hexbin@^0.2.1:
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/d3-hexbin/-/d3-hexbin-0.2.2.tgz#9c5837dacfd471ab05337a9e91ef10bfc4f98831"
+  resolved "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz"
   integrity sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==
 
 "d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
 d3-scale@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
   dependencies:
     d3-array "2.10.0 - 3"
@@ -2844,31 +2849,31 @@ d3-scale@^4.0.0:
 
 "d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
 "d3-time-format@2 - 4":
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  resolved "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
 
 "d3-time@1 - 3", "d3-time@2.1.1 - 3":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  resolved "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
 "d3-timer@1 - 3":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 "d3-transition@2 - 3":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
   dependencies:
     d3-color "1 - 3"
@@ -2879,7 +2884,7 @@ d3-scale@^4.0.0:
 
 d3-zoom@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  resolved "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz"
   integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
   dependencies:
     d3-dispatch "1 - 3"
@@ -2888,16 +2893,21 @@ d3-zoom@^3.0.0:
     d3-selection "2 - 3"
     d3-transition "2 - 3"
 
+date-fns@^4.1.0, date-fns@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz"
+  integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
+
 debug@^4.1.0, debug@^4.3.1, debug@^4.3.4:
   version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
 deck.gl@8.9.34:
   version "8.9.34"
-  resolved "https://registry.yarnpkg.com/deck.gl/-/deck.gl-8.9.34.tgz#990193a7779a0175f6887490c4acfabb19357491"
+  resolved "https://registry.npmjs.org/deck.gl/-/deck.gl-8.9.34.tgz"
   integrity sha512-3c7gu7xSDlNmBXDexk+RF783cVbl6D/WbSQNpPrmY5glct102A3hXqbVSV3l4jiCG2zd4y3AMBjSHdkHzgfBrw==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -2915,79 +2925,79 @@ deck.gl@8.9.34:
 
 deep-strict-equal@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz#4a078147a8ab57f6a0d4f5547243cd22f44eb4e4"
+  resolved "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz"
   integrity sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==
   dependencies:
     core-assert "^0.2.0"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  resolved "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 detect-libc@^2.0.3:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  resolved "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
+  resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
 diff@^8.0.2:
   version "8.0.3"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  resolved "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
 dlv@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 draco3d@1.5.5:
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.5.5.tgz#6bf4bbdd65950e6153e991cb0dcb8a10323f610e"
+  resolved "https://registry.npmjs.org/draco3d/-/draco3d-1.5.5.tgz"
   integrity sha512-JVuNV0EJzD3LBYhGyIXJLeBID/EVtmFO1ZNhAYflTgiMiAJlbhXQmRRda/azjc8MRVMHh0gqGhiqHUo5dIXM8Q==
 
 earcut@^2.0.6, earcut@^2.2.4:
   version "2.2.4"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  resolved "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz"
   integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
 earcut@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-3.0.2.tgz#d478a29aaf99acf418151493048aa197d0512248"
+  resolved "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz"
   integrity sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==
 
 electron-to-chromium@^1.5.263:
   version "1.5.286"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz#142be1ab5e1cd5044954db0e5898f60a4960384e"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz"
   integrity sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==
 
 elkjs@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.11.1.tgz#d27fcdbbf5a8aeeff80420d17d1666f78cfc8544"
+  resolved "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz"
   integrity sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 es-module-lexer@^1.7.0:
   version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 esbuild@^0.28.0:
   version "0.28.0"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz"
   integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.28.0"
@@ -3019,7 +3029,7 @@ esbuild@^0.28.0:
 
 esbuild@~0.27.0:
   version "0.27.3"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.3.tgz#5859ca8e70a3af956b26895ce4954d7e73bd27a8"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz"
   integrity sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.27.3"
@@ -3051,31 +3061,31 @@ esbuild@~0.27.0:
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 esprima@~4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 expression-eval@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-2.1.0.tgz#422915caa46140a7c5b5f248650dea8bf8236e62"
+  resolved "https://registry.npmjs.org/expression-eval/-/expression-eval-2.1.0.tgz"
   integrity sha512-FUJO/Akvl/JOWkvlqZaqbkhsEWlCJWDeZG4tzX96UH68D9FeRgYgtb55C2qtqbORC0Q6x5419EDjWu4IT9kQfg==
   dependencies:
     jsep "^0.3.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
   integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
   dependencies:
     is-extendable "^0.1.0"
 
 extend-shallow@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
   integrity sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==
   dependencies:
     assign-symbols "^1.0.0"
@@ -3083,7 +3093,7 @@ extend-shallow@^3.0.0:
 
 fast-glob@^3.3.2:
   version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
@@ -3094,121 +3104,121 @@ fast-glob@^3.3.2:
 
 fast-xml-parser@^4.2.5:
   version "4.5.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz#c54d6b35aa0f23dc1ea60b6c884340c006dc6efb"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz"
   integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
   dependencies:
     strnum "^1.1.1"
 
 fastq@^1.6.0:
   version "1.20.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz"
   integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
   dependencies:
     reusify "^1.0.4"
 
 fdir@^6.5.0:
   version "6.5.0"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 fill-range@^7.1.1:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
 find-replace@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  resolved "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz"
   integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
   dependencies:
     array-back "^3.0.1"
 
 flatbuffers@^24.3.25:
   version "24.12.23"
-  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-24.12.23.tgz#6eea59d2bcda0c5d59bcacefd6216348b3086883"
+  resolved "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz"
   integrity sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==
 
 fraction.js@^5.3.4:
   version "5.3.4"
-  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
+  resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
 fsevents@2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 geojson-vt@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-4.0.2.tgz#1162f6c7d61a0ba305b1030621e6e111f847828a"
+  resolved "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz"
   integrity sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-nonce@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  resolved "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz"
   integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-stream@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-tsconfig@^4.7.5:
   version "4.13.6"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.13.6.tgz#2fbfda558a98a691a798f123afd95915badce876"
+  resolved "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz"
   integrity sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
 get-value@^2.0.2, get-value@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
   integrity sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==
 
 gl-matrix@^3.0.0, gl-matrix@^3.4.0, gl-matrix@^3.4.3:
   version "3.4.4"
-  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.4.tgz#7789ee4982f62c7a7af447ee488f3bd6b0c77003"
+  resolved "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz"
   integrity sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob-parent@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
 
 global-prefix@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-4.0.0.tgz#e9cc79aab9be1d03287e156a3f912dd0895463ed"
+  resolved "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz"
   integrity sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==
   dependencies:
     ini "^4.1.3"
@@ -3217,51 +3227,51 @@ global-prefix@^4.0.0:
 
 h3-js@^3.7.0:
   version "3.7.2"
-  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-3.7.2.tgz#61d4feb7bb42868ca9cdb2d5cf9d9dda94f9e5a3"
+  resolved "https://registry.npmjs.org/h3-js/-/h3-js-3.7.2.tgz"
   integrity sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w==
 
 hammerjs@^2.0.8:
   version "2.0.8"
-  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  resolved "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz"
   integrity sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 hasown@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
 
 iconv-lite@0.4:
   version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.12:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 image-size@^0.7.4:
   version "0.7.5"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.7.5.tgz#269f357cf5797cb44683dfa99790e54c705ead04"
+  resolved "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz"
   integrity sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==
 
 immediate@~3.0.5:
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  resolved "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
   integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-from-esm@^1.3.3:
   version "1.3.4"
-  resolved "https://registry.yarnpkg.com/import-from-esm/-/import-from-esm-1.3.4.tgz#39e97c84085e308fe66cf872a667046b45449df0"
+  resolved "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz"
   integrity sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==
   dependencies:
     debug "^4.3.4"
@@ -3269,164 +3279,164 @@ import-from-esm@^1.3.3:
 
 import-meta-resolve@^4.0.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  resolved "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz"
   integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
 
 inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^4.1.3:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.3.tgz#4c359675a6071a46985eb39b14e4a2c0ec98a795"
+  resolved "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz"
   integrity sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==
 
 "internmap@1 - 2":
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  resolved "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
 is-core-module@^2.16.1:
   version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-error@^2.2.0:
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843"
+  resolved "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz"
   integrity sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
   integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
 
 is-extendable@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz"
   integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
 is-wsl@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isbot@^5.1.22:
   version "5.1.35"
-  resolved "https://registry.yarnpkg.com/isbot/-/isbot-5.1.35.tgz#a120bac86f23318397955890e178e118b0ef151a"
+  resolved "https://registry.npmjs.org/isbot/-/isbot-5.1.35.tgz"
   integrity sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isexe@^3.1.1:
   version "3.1.5"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz"
   integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
 
 isobject@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 jiti@^1.21.7:
   version "1.21.7"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
+  resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 jsep@^0.3.0:
   version "0.3.5"
-  resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.5.tgz#3fd79ebd92f6f434e4857d5272aaeef7d948264d"
+  resolved "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz"
   integrity sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==
 
 jsesc@^3.0.2:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 json-bignum@^0.0.3:
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
+  resolved "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz"
   integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
 
 json-stringify-pretty-compact@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
+  resolved "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
 
 json-stringify-pretty-compact@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz#cf4844770bddee3cb89a6170fe4b00eee5dbf1d4"
+  resolved "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz"
   integrity sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==
 
 json5@^2.2.3:
   version "2.2.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jszip@^3.10.1:
   version "3.10.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  resolved "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
   dependencies:
     lie "~3.3.0"
@@ -3436,27 +3446,27 @@ jszip@^3.10.1:
 
 kdbush@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.0.2.tgz#2f7b7246328b4657dd122b6c7f025fbc2c868e39"
+  resolved "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz"
   integrity sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==
 
 kind-of@^6.0.3:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 ktx-parse@^0.0.4:
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.0.4.tgz#6fd3eca82490de8a1e48cb8367a9980451fa1ac4"
+  resolved "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz"
   integrity sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A==
 
 lerc@^4.0.1:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lerc/-/lerc-4.0.4.tgz#1034f132104123c1d22469e382fb2c57a2bf8f84"
+  resolved "https://registry.npmjs.org/lerc/-/lerc-4.0.4.tgz"
   integrity sha512-nHZH+ffiGPkgKUQtiZrljGUGV2GddvPcVTV5E345ZFncbKz+/rBIjDPrSxkiqW0EAtg1Jw7qAgRdaCwV+95Fow==
 
 lie@~3.3.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  resolved "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz"
   integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
@@ -3468,7 +3478,7 @@ lightningcss-android-arm64@1.32.0:
 
 lightningcss-darwin-arm64@1.32.0:
   version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
   integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
 
 lightningcss-darwin-x64@1.32.0:
@@ -3518,7 +3528,7 @@ lightningcss-win32-x64-msvc@1.32.0:
 
 lightningcss@^1.30.2:
   version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  resolved "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz"
   integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
   dependencies:
     detect-libc "^2.0.3"
@@ -3537,51 +3547,51 @@ lightningcss@^1.30.2:
 
 lilconfig@^3.1.1, lilconfig@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz"
   integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
 long@^3.2.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  resolved "https://registry.npmjs.org/long/-/long-3.2.0.tgz"
   integrity sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==
 
 long@^5.2.1:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  resolved "https://registry.npmjs.org/long/-/long-5.3.2.tgz"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 loose-envify@^1.1.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
 
 lucide-react@^0.563.0:
   version "0.563.0"
-  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.563.0.tgz#9a660d6f009942914a0df42391cf7d7d4dbcc713"
+  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz"
   integrity sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==
 
 maplibre-gl@^4.7.1:
   version "4.7.1"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.7.1.tgz#06a524438ee2aafbe8bcd91002a4e01468ea5486"
+  resolved "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz"
   integrity sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.2"
@@ -3613,19 +3623,19 @@ maplibre-gl@^4.7.1:
 
 math.gl@^3.6.2:
   version "3.6.3"
-  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.6.3.tgz#f87e0d24cb33c1a215185ae3a4e16839f1ce6db2"
+  resolved "https://registry.npmjs.org/math.gl/-/math.gl-3.6.3.tgz"
   integrity sha512-Yq9CyECvSDox9+5ETi2+x1bGTY5WvGUGL3rJfC4KPoCZAM51MGfrCm6rIn4yOJUVfMPs2a5RwMD+yGS/n1g3gg==
   dependencies:
     "@math.gl/core" "3.6.3"
 
 merge2@^1.3.0:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^4.0.8:
   version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
@@ -3633,12 +3643,12 @@ micromatch@^4.0.8:
 
 minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mjolnir.js@^2.7.0:
   version "2.7.3"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.7.3.tgz#b71902edaa387f14c7fe6e9b1f611c0ce814240a"
+  resolved "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.7.3.tgz"
   integrity sha512-Z5z/+FzZqOSO3juSVKV3zcm4R2eAlWwlKMcqHmyFEJAaLILNcDKnIbnb4/kbcGyIuhtdWrzu8WOIR7uM6I34aw==
   dependencies:
     "@types/hammerjs" "^2.0.41"
@@ -3646,34 +3656,34 @@ mjolnir.js@^2.7.0:
 
 moment-timezone@^0.5.33:
   version "0.5.48"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  resolved "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz"
   integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
   dependencies:
     moment "^2.29.4"
 
 moment@^2.29.4:
   version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 mrmime@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  resolved "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz"
   integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
 
 ms@^2.1.3:
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 murmurhash-js@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
+  resolved "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz"
   integrity sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==
 
 mz@^2.7.0:
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  resolved "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz"
   integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
   dependencies:
     any-promise "^1.0.0"
@@ -3682,37 +3692,37 @@ mz@^2.7.0:
 
 nanoid@^3.3.11:
   version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 node-releases@^2.0.27:
   version "2.0.27"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 object-assign@^4.0.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-hash@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  resolved "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
 obug@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  resolved "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz"
   integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
 
 open@^8.0.0, open@^8.4.0:
   version "8.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  resolved "https://registry.npmjs.org/open/-/open-8.4.2.tgz"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
   dependencies:
     define-lazy-prop "^2.0.0"
@@ -3721,7 +3731,7 @@ open@^8.0.0, open@^8.4.0:
 
 oxfmt@=0.39.0:
   version "0.39.0"
-  resolved "https://registry.yarnpkg.com/oxfmt/-/oxfmt-0.39.0.tgz#d68639ecbbe522a19f07f373fa0b40317755e7eb"
+  resolved "https://registry.npmjs.org/oxfmt/-/oxfmt-0.39.0.tgz"
   integrity sha512-OwfwFtNb0ImDUPTKiy4ew/t7WXjAqH11CsXmpXe3nxWX5/4WntswrpC8DYsFfHt6jVvyQHXTYUOudT1ayB/cPw==
   dependencies:
     tinypool "2.1.0"
@@ -3748,7 +3758,7 @@ oxfmt@=0.39.0:
 
 oxlint-tsgolint@=0.16.0:
   version "0.16.0"
-  resolved "https://registry.yarnpkg.com/oxlint-tsgolint/-/oxlint-tsgolint-0.16.0.tgz#f17cb4cdf792daff212ece3b9a0ba5cf4a74f532"
+  resolved "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.16.0.tgz"
   integrity sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==
   optionalDependencies:
     "@oxlint-tsgolint/darwin-arm64" "0.16.0"
@@ -3760,7 +3770,7 @@ oxlint-tsgolint@=0.16.0:
 
 oxlint@=1.54.0:
   version "1.54.0"
-  resolved "https://registry.yarnpkg.com/oxlint/-/oxlint-1.54.0.tgz#32ad30782c40be07e42a38d616c47277342be35e"
+  resolved "https://registry.npmjs.org/oxlint/-/oxlint-1.54.0.tgz"
   integrity sha512-ObSjVwf0ZYA5U5Cmelj0PsCuqCJXsm2TxZ40tgUSAY7Wu0lKAsNjor6cgXHXSys8jOwv1ICjtzouoWHdKGHbZg==
   optionalDependencies:
     "@oxlint/binding-android-arm-eabi" "1.54.0"
@@ -3785,32 +3795,32 @@ oxlint@=1.54.0:
 
 pako@^1.0.11, pako@~1.0.2:
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 papaparse@^5.4.1:
   version "5.5.3"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.5.3.tgz#07f8994dec516c6dab266e952bed68e1de59fa9a"
+  resolved "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz"
   integrity sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==
 
 path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.7:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 pathe@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
 pbf@^3.2.1, pbf@^3.3.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.3.0.tgz#1790f3d99118333cc7f498de816028a346ef367f"
+  resolved "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz"
   integrity sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==
   dependencies:
     ieee754 "^1.1.12"
@@ -3818,44 +3828,44 @@ pbf@^3.2.1, pbf@^3.3.0:
 
 picocolors@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pify@^2.3.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 pirates@^4.0.1:
   version "4.0.7"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
+  resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
 pixelmatch@^7.1.0:
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-7.1.0.tgz#9d59bddc8c779340e791106c0f245ac33ae4d113"
+  resolved "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz"
   integrity sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==
   dependencies:
     pngjs "^7.0.0"
 
 playwright-core@1.59.1:
   version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz"
   integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
 
 playwright@1.59.1:
   version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz"
   integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
   dependencies:
     playwright-core "1.59.1"
@@ -3864,12 +3874,12 @@ playwright@1.59.1:
 
 pngjs@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
+  resolved "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz"
   integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
 postcss-import@^15.1.0:
   version "15.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-15.1.0.tgz#41c64ed8cc0e23735a9698b3249ffdbf704adc70"
+  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz"
   integrity sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==
   dependencies:
     postcss-value-parser "^4.0.0"
@@ -3878,28 +3888,28 @@ postcss-import@^15.1.0:
 
 postcss-js@^4.0.1:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.1.0.tgz#003b63c6edde948766e40f3daf7e997ae43a5ce6"
+  resolved "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz"
   integrity sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==
   dependencies:
     camelcase-css "^2.0.1"
 
 "postcss-load-config@^4.0.2 || ^5.0 || ^6.0":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-6.0.1.tgz#6fd7dcd8ae89badcf1b2d644489cbabf83aa8096"
+  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz"
   integrity sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==
   dependencies:
     lilconfig "^3.1.1"
 
 postcss-nested@^6.2.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-6.2.0.tgz#4c2d22ab5f20b9cb61e2c5c5915950784d068131"
+  resolved "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz"
   integrity sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==
   dependencies:
     postcss-selector-parser "^6.1.1"
 
 postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
   version "6.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
   integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
   dependencies:
     cssesc "^3.0.0"
@@ -3907,12 +3917,12 @@ postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
 
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.4.47, postcss@^8.4.49:
   version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
   dependencies:
     nanoid "^3.3.11"
@@ -3921,7 +3931,7 @@ postcss@^8.4.47, postcss@^8.4.49:
 
 postcss@^8.5.6:
   version "8.5.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.9.tgz#f6ee9e0b94f0f19c97d2f172bfbd7fc71fe1cca4"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz"
   integrity sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==
   dependencies:
     nanoid "^3.3.11"
@@ -3930,49 +3940,57 @@ postcss@^8.5.6:
 
 potpack@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.1.0.tgz#fe548e2f9061e9937f17191c1ab6dd98ca30e02f"
+  resolved "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz"
   integrity sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==
 
 prettier@^3.5.0:
   version "3.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.1.tgz#edf48977cf991558f4fcbd8a3ba6015ba2a3a173"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz"
   integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 protocol-buffers-schema@^3.3.1:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
+  resolved "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz"
   integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
 
 quadbin@^0.1.9:
   version "0.1.9"
-  resolved "https://registry.yarnpkg.com/quadbin/-/quadbin-0.1.9.tgz#322bd5f8b63960ef0a31a8b69863b0a0ab0b2e22"
+  resolved "https://registry.npmjs.org/quadbin/-/quadbin-0.1.9.tgz"
   integrity sha512-5V6m6+cL/6+uBl3hYL+CWF06rRvlHkIepYKGQjTLYaHhu9InPppql0+0ROiCaOQdz8gPNlgge3glk5Qg1mWOYw==
   dependencies:
     "@mapbox/tile-cover" "3.0.1"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 quickselect@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
+  resolved "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz"
   integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
 
 quickselect@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-3.0.0.tgz#a37fc953867d56f095a20ac71c6d27063d2de603"
+  resolved "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz"
   integrity sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==
+
+react-day-picker@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz"
+  integrity sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==
+  dependencies:
+    "@date-fns/tz" "^1.4.1"
+    date-fns "^4.1.0"
 
 react-dom@^18.3.1:
   version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
@@ -3980,17 +3998,17 @@ react-dom@^18.3.1:
 
 react-hook-form@^7.54.2:
   version "7.71.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.71.1.tgz#6a758958861682cf0eb22131eead684ba3618f66"
+  resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz"
   integrity sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==
 
 react-icons@^5.5.0:
   version "5.5.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
+  resolved "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz"
   integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
 
 react-map-gl@^7.1.7:
   version "7.1.9"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-7.1.9.tgz#d41093ce266c342f89a2c49dec3739e980835fa7"
+  resolved "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.9.tgz"
   integrity sha512-KsCc8Gyn05wVGlHZoopaiiCr0RCAQ6LDISo5sEy1/pV/d7RlozkF946tiX7IgyijJQMRujHol5QdwUPESjh73w==
   dependencies:
     "@maplibre/maplibre-gl-style-spec" "^19.2.1"
@@ -3998,7 +4016,7 @@ react-map-gl@^7.1.7:
 
 react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.7:
   version "2.3.8"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  resolved "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz"
   integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
   dependencies:
     react-style-singleton "^2.2.2"
@@ -4006,7 +4024,7 @@ react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.7:
 
 react-remove-scroll@2.5.5:
   version "2.5.5"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  resolved "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz"
   integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
   dependencies:
     react-remove-scroll-bar "^2.3.3"
@@ -4017,7 +4035,7 @@ react-remove-scroll@2.5.5:
 
 react-remove-scroll@^2.6.3:
   version "2.7.2"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  resolved "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz"
   integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
   dependencies:
     react-remove-scroll-bar "^2.3.7"
@@ -4028,7 +4046,7 @@ react-remove-scroll@^2.6.3:
 
 react-style-singleton@^2.2.1, react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  resolved "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz"
   integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
   dependencies:
     get-nonce "^1.0.0"
@@ -4036,26 +4054,26 @@ react-style-singleton@^2.2.1, react-style-singleton@^2.2.2, react-style-singleto
 
 react-use-media-query-ts@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-use-media-query-ts/-/react-use-media-query-ts-1.0.1.tgz#299372dfa809ad26e18a778fa157b6633d432f76"
+  resolved "https://registry.npmjs.org/react-use-media-query-ts/-/react-use-media-query-ts-1.0.1.tgz"
   integrity sha512-E4zu99PV6iQ+zL6L9uko3+YIKnX5ug5sn1E6kKJMFvhnonvSv6hPLsrD6dd7JCE82zUG+dLdTJQpWRdFcJ+uTA==
 
 react@^18.3.1:
   version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
 
 read-cache@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  resolved "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz"
   integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
   dependencies:
     pify "^2.3.0"
 
 readable-stream@~2.3.6:
   version "2.3.8"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
@@ -4068,14 +4086,14 @@ readable-stream@~2.3.6:
 
 readdirp@~3.6.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
 recast@^0.23.11:
   version "0.23.11"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.11.tgz#8885570bb28cf773ba1dc600da7f502f7883f73f"
+  resolved "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz"
   integrity sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==
   dependencies:
     ast-types "^0.16.1"
@@ -4086,24 +4104,24 @@ recast@^0.23.11:
 
 require-directory@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  resolved "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
+  resolved "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz"
   integrity sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==
   dependencies:
     protocol-buffers-schema "^3.3.1"
 
 resolve@^1.1.7, resolve@^1.22.8:
   version "1.22.11"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz"
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
   dependencies:
     is-core-module "^2.16.1"
@@ -4112,12 +4130,12 @@ resolve@^1.1.7, resolve@^1.22.8:
 
 reusify@^1.0.4:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 rollup-plugin-visualizer@^5.11.0:
   version "5.14.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz#be82d43fb3c644e396e2d50ac8a53d354022d57c"
+  resolved "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz"
   integrity sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==
   dependencies:
     open "^8.4.0"
@@ -4127,7 +4145,7 @@ rollup-plugin-visualizer@^5.11.0:
 
 rollup-plugin-visualizer@^6.0.5:
   version "6.0.5"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.5.tgz#9cf774cff88f4ba2887c97354766b68931323280"
+  resolved "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.5.tgz"
   integrity sha512-9+HlNgKCVbJDs8tVtjQ43US12eqaiHyyiLMdBwQ7vSZPiHMysGNo2E88TAp1si5wx8NAoYriI2A5kuKfIakmJg==
   dependencies:
     open "^8.0.0"
@@ -4137,51 +4155,51 @@ rollup-plugin-visualizer@^6.0.5:
 
 run-parallel@^1.1.9:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
 
 rw@1, rw@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  resolved "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 scheduler@^0.23.2:
   version "0.23.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz"
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 
 semver@^6.3.1:
   version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 seroval-plugins@^1.4.2:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/seroval-plugins/-/seroval-plugins-1.5.0.tgz#c02ba5f41d50b8105d4d9d4c553a4d01cec4226a"
+  resolved "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz"
   integrity sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==
 
 seroval@^1.4.2:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/seroval/-/seroval-1.5.0.tgz#aba4cffbd0c4c8a4351358362acf40ee8d74d97b"
+  resolved "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz"
   integrity sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==
 
 set-value@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  resolved "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz"
   integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
@@ -4191,24 +4209,24 @@ set-value@^2.0.1:
 
 setimmediate@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 sirv@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
+  resolved "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz"
   integrity sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==
   dependencies:
     "@polka/url" "^1.0.0-next.24"
@@ -4217,17 +4235,17 @@ sirv@^3.0.2:
 
 sort-asc@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.2.0.tgz#00a49e947bc25d510bfde2cbb8dffda9f50eb2fc"
+  resolved "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz"
   integrity sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==
 
 sort-desc@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/sort-desc/-/sort-desc-0.2.0.tgz#280c1bdafc6577887cedbad1ed2e41c037976646"
+  resolved "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz"
   integrity sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==
 
 sort-object@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-3.0.3.tgz#945727165f244af9dc596ad4c7605a8dee80c269"
+  resolved "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz"
   integrity sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==
   dependencies:
     bytewise "^1.1.0"
@@ -4239,12 +4257,12 @@ sort-object@^3.0.3:
 
 source-map-js@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-support@~0.5.20:
   version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
@@ -4252,34 +4270,34 @@ source-map-support@~0.5.20:
 
 source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@^0.7.4:
   version "0.7.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
 
 split-string@^3.0.1:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 std-env@^3.10.0:
   version "3.10.0"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  resolved "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -4288,26 +4306,26 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
 
 strnum@^1.1.1:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
+  resolved "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
 sucrase@^3.35.0:
   version "3.35.1"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.35.1.tgz#4619ea50393fe8bd0ae5071c26abd9b2e346bfe1"
+  resolved "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz"
   integrity sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"
@@ -4320,26 +4338,26 @@ sucrase@^3.35.0:
 
 supercluster@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-8.0.1.tgz#9946ba123538e9e9ab15de472531f604e7372df5"
+  resolved "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz"
   integrity sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==
   dependencies:
     kdbush "^4.0.2"
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 table-layout@^4.1.0:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-4.1.1.tgz#0f72965de1a5c0c1419c9ba21cae4e73a2f73a42"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz"
   integrity sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==
   dependencies:
     array-back "^6.2.2"
@@ -4347,17 +4365,17 @@ table-layout@^4.1.0:
 
 tailwind-merge@^2.6.0:
   version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.6.1.tgz#a9d58240f664d21c33c379a092d9a273f833443b"
+  resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz"
   integrity sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==
 
 tailwindcss-animate@^1.0.7:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz#318b692c4c42676cc9e67b19b78775742388bef4"
+  resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
 tailwindcss@^3.4.17:
   version "3.4.19"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.19.tgz#af2a0a4ae302d52ebe078b6775e799e132500ee2"
+  resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz"
   integrity sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
@@ -4385,7 +4403,7 @@ tailwindcss@^3.4.17:
 
 terser@^5.46.0:
   version "5.46.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.46.0.tgz#1b81e560d584bbdd74a8ede87b4d9477b0ff9695"
+  resolved "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz"
   integrity sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
@@ -4395,7 +4413,7 @@ terser@^5.46.0:
 
 texture-compressor@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/texture-compressor/-/texture-compressor-1.0.2.tgz#b5a54a9e5f9eb884d7c33b149f1f23a429465cd4"
+  resolved "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz"
   integrity sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==
   dependencies:
     argparse "^1.0.10"
@@ -4403,46 +4421,46 @@ texture-compressor@^1.0.2:
 
 thenify-all@^1.0.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  resolved "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
   integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
   dependencies:
     thenify ">= 3.1.0 < 4"
 
 "thenify@>= 3.1.0 < 4":
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  resolved "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz"
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
 
 tilebelt@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tilebelt/-/tilebelt-1.0.1.tgz#3bbf7113b3fec468efb0d9148f4bb71ef126a21a"
+  resolved "https://registry.npmjs.org/tilebelt/-/tilebelt-1.0.1.tgz"
   integrity sha512-cxHzpa5JgsugY9NUVRH43gPaGJw/29LecAn4X7UGOP64+kB8pU4VQ3bIhSyfb5Mk4jDxwl3yk330L/EIhbJ5aw==
 
 tiny-invariant@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
 tiny-warning@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinybench@^2.9.0:
   version "2.9.0"
-  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  resolved "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
 tinyexec@^1.0.2:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.1.tgz#e1ff45dfa60d1dedb91b734956b78f6c2a3e821b"
+  resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz"
   integrity sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==
 
 tinyglobby@^0.2.11, tinyglobby@^0.2.15:
   version "0.2.15"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz"
   integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
   dependencies:
     fdir "^6.5.0"
@@ -4450,44 +4468,44 @@ tinyglobby@^0.2.11, tinyglobby@^0.2.15:
 
 tinypool@2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-2.1.0.tgz#303a671d6ef68d03c9512cdc9a47c86b8a85f20c"
+  resolved "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz"
   integrity sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==
 
 tinyqueue@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-3.0.0.tgz#101ea761ccc81f979e29200929e78f1556e3661e"
+  resolved "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz"
   integrity sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==
 
 tmp@^0.2.1:
   version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz"
   integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
 totalist@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  resolved "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz"
   integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"
-  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
+  resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
 tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsx@^4.19.2:
   version "4.21.0"
-  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.21.0.tgz#32aa6cf17481e336f756195e6fe04dae3e6308b1"
+  resolved "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz"
   integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==
   dependencies:
     esbuild "~0.27.0"
@@ -4497,39 +4515,39 @@ tsx@^4.19.2:
 
 typescript@~5.6.2:
   version "5.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/typewise-core/-/typewise-core-1.2.0.tgz#97eb91805c7f55d2f941748fa50d315d991ef195"
+  resolved "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz"
   integrity sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==
 
 typewise@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/typewise/-/typewise-1.0.3.tgz#1067936540af97937cc5dcf9922486e9fa284651"
+  resolved "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz"
   integrity sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==
   dependencies:
     typewise-core "^1.2.0"
 
 typical@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  resolved "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz"
   integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
 
 typical@^7.1.1:
   version "7.3.0"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-7.3.0.tgz#930376be344228709f134613911fa22aa09617a4"
+  resolved "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz"
   integrity sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==
 
 undici-types@~6.21.0:
   version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 union-value@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+  resolved "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz"
   integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   dependencies:
     arr-union "^3.1.0"
@@ -4539,7 +4557,7 @@ union-value@^1.0.1:
 
 unplugin@^2.1.2:
   version "2.3.11"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-2.3.11.tgz#411e020dd2ba90e2fbe1e7bd63a5a399e6ee3b54"
+  resolved "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz"
   integrity sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==
   dependencies:
     "@jridgewell/remapping" "^2.3.5"
@@ -4549,7 +4567,7 @@ unplugin@^2.1.2:
 
 update-browserslist-db@^1.2.0:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
   dependencies:
     escalade "^3.2.0"
@@ -4557,14 +4575,14 @@ update-browserslist-db@^1.2.0:
 
 use-callback-ref@^1.3.0, use-callback-ref@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  resolved "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz"
   integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
   dependencies:
     tslib "^2.0.0"
 
 use-sidecar@^1.1.2, use-sidecar@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  resolved "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz"
   integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
   dependencies:
     detect-node-es "^1.1.0"
@@ -4572,24 +4590,24 @@ use-sidecar@^1.1.2, use-sidecar@^1.1.3:
 
 use-sync-external-store@^1.2.2, use-sync-external-store@^1.5.0, use-sync-external-store@^1.6.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 vaul@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vaul/-/vaul-1.1.2.tgz#c959f8b9dc2ed4f7d99366caee433fbef91f5ba9"
+  resolved "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz"
   integrity sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==
   dependencies:
     "@radix-ui/react-dialog" "^1.1.1"
 
 vite-bundle-visualizer@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz#8be34033f0216de529abec4b18a8b62aa1b65c9e"
+  resolved "https://registry.npmjs.org/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz"
   integrity sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==
   dependencies:
     cac "^6.7.14"
@@ -4599,7 +4617,7 @@ vite-bundle-visualizer@^1.2.1:
 
 vite-plus@0.1.8:
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/vite-plus/-/vite-plus-0.1.8.tgz#465bc3e7d0cbe282b58cab6b94af19f0dc35294c"
+  resolved "https://registry.npmjs.org/vite-plus/-/vite-plus-0.1.8.tgz"
   integrity sha512-vZ4Xb/3AA2m1wlsUN8sd0ucGSqfnL//SPnE7JdSY4IJO8W9nfKar0z8pHwmRO6WHSjhY9XH3Sp9EXwlMuzhNZg==
   dependencies:
     "@oxc-project/types" "=0.115.0"
@@ -4621,7 +4639,7 @@ vite-plus@0.1.8:
 
 "vite@npm:@voidzero-dev/vite-plus-core@0.1.8":
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.1.8.tgz#0784beb59997a23fc81c1ae72ffd56ad502b608a"
+  resolved "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.1.8.tgz"
   integrity sha512-XGAJyvJLBnAg53ltZ++j7kDZkRIcjFNUIIGus+02ZqsOT0GkKSv6t0nPhVpmRZbgzDx4sR9rSeDzSqRteoVHvQ==
   dependencies:
     "@oxc-project/runtime" "=0.115.0"
@@ -4652,7 +4670,7 @@ vite-plus@0.1.8:
 
 vt-pbf@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.3.tgz#68fd150756465e2edae1cc5c048e063916dcfaac"
+  resolved "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz"
   integrity sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==
   dependencies:
     "@mapbox/point-geometry" "0.1.0"
@@ -4661,31 +4679,31 @@ vt-pbf@^3.1.3:
 
 webpack-virtual-modules@^0.6.2:
   version "0.6.2"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz#057faa9065c8acf48f24cb57ac0e77739ab9a7e8"
+  resolved "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz"
   integrity sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
 which@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
+  resolved "https://registry.npmjs.org/which/-/which-4.0.0.tgz"
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
 
 wordwrapjs@^5.1.0:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.1.tgz#bfd1eb426f0f7eec73b7df32cf7df1f618bfb3a9"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz"
   integrity sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -4694,27 +4712,27 @@ wrap-ansi@^7.0.0:
 
 ws@^8.18.3:
   version "8.20.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
 
 y18n@^5.0.5:
   version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^3.0.2:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^17.5.1:
   version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
@@ -4727,12 +4745,12 @@ yargs@^17.5.1:
 
 zod@^3.24.2:
   version "3.25.76"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 zustand@^4.4.0:
   version "4.5.7"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.7.tgz#7d6bb2026a142415dd8be8891d7870e6dbe65f55"
+  resolved "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz"
   integrity sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==
   dependencies:
     use-sync-external-store "^1.2.2"


### PR DESCRIPTION
## New Features

### Web
- Trip compare mode — compare up to 5 trips side-by-side across timetable, timeline, and map views
- Trip stop times editing — add, remove, reorder, and modify arrival/departure times for any trip
- Timetable edit view with drag-and-drop reorder, inline time editing, and undo/redo stack
- Timeline and map views support editing with synchronized edit panel across all views
- Capsule shapes for overlapping stops on compare map, parallel lines for shared route segments
- Bidirectional segment matching for opposite-direction trips with station-merged stop centroids
- Export stop_times grouped by service_id with per-trip side-by-side compare diff
- LCS-based diff alignment detects inserted/shifted stops vs actual content changes
- Save blocking overlay disables all controls during save processing
- Validation errors in collapsible section with "Go to stop" links to jump to problem stops
- Form save UI blocks all interaction — hides close/X button, prevents outside click during save

### CLI
- `trips` / `trip` commands with `--route`, `--service`, `--compare`, `--view` flags
- `calendar` command with `--route` filter and service detail lookup
- `shapes` command with `--route` filter and shape point listing
- `stop-info` falls back to StationsTable and raw stops for station names and platform IDs
- `station_shortest_route` falls back to any timed route when no entrance-to-entrance route exists
- `stations --pathways "yes"` / `--wheelchair "accessible"` accept text labels (mapped to emoji)
- `routes --type Subway` uses substring match (matches "Subway, Metro")
- `stops --id` and `stop-info --id` fall back to raw stops table for platform IDs
- `import` now starts a dashboard session automatically

### Skills
- Updated commands.md with trips, calendar, shapes, compare docs
- Updated SKILL.md with trip editing and compare examples

## Improvements
- Fix "Constructor Map requires 'new'" crash — stale `icon: Map` refs replaced with `BiMap`
- Fix react-map-gl `useImperativeHandle` crash — wrap raw import in `forwardRef`
- Fix `useDuckDB` null crash on route pages
- Route service page quote stripping for CLI URL params
- Root URL redirect includes CLI session params
- Edit timetable shows all rows during edits (removed `showOnlyChanged` filter that hid rows after reorder)
- Stop order input commits immediately on change
- Deferred `updateSearch` in compare mode to fix Transitioner setState-in-render warning
- `DialogContent` supports `hideCloseButton` prop for save-blocking UX