### PR TITLE
release: v1.5.2 — reroute deep links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,6 @@ jobs:
       - name: Publish CLI to npm
         if: steps.npm_check.outputs.skip != 'true'
         working-directory: packages/cli
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gtfs-viz",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Lightweight GTFS data visualizer and editor",
   "keywords": [

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -63,7 +63,7 @@ gtfs-viz examples                     # See all commands
 | `query --sql <sql>` | Run SQL |
 | `edit_table [pathways\|stops\|routes]` | View pending edits |
 | `edits [--trip --view --url-only]` | Review categories or open Edits & Export |
-| `reroute --trip --via --from --to` | Replace a trip section using donor stops |
+| `reroute --trip [--via --from --to]` | Open the reroute form or replace a trip section using donor stops |
 | `stop` | Stop dashboard session and clear session state |
 | `restart` | Stop session and remove local DuckDB/feed import |
 | `examples` | Show usage examples |
@@ -80,7 +80,12 @@ Direct review links:
 gtfs-viz edits --url-only
 gtfs-viz edits --trip TRIP_ID --compare-view map --url-only
 gtfs-viz edits --view table --trips-page 3 --trips-page-size 20 --url-only
+gtfs-viz reroute --trip TRIP_ID --url-only
 ```
+
+`reroute --trip TRIP_ID` opens the selected trip's reroute form. Providing `--via`, `--from`, and
+`--to` applies the splice and opens the edited trip. Add `--url-only` for the deep link without
+browser navigation or `--data` for terminal-only operation.
 
 ## Local Development
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@gabrielahn/gtfs-viz-cli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Lightweight GTFS data visualizer and editor — import, browse stations/stops/routes/pathways, edit connections, compare schedules, and export feeds from the terminal with DuckDB and a browser dashboard",
   "license": "MIT",
   "author": "Gabriel AHN",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gabrielAHN/gtfs-viz.git",
+    "url": "git+https://github.com/gabrielAHN/gtfs-viz.git",
     "directory": "packages/cli"
   },
   "homepage": "https://github.com/gabrielAHN/gtfs-viz/tree/main/packages/cli#readme",
@@ -25,7 +25,7 @@
     "export"
   ],
   "bin": {
-    "gtfs-viz": "./dist/index.js"
+    "gtfs-viz": "dist/index.js"
   },
   "files": [
     "dist",

--- a/packages/cli/skills/gtfs-viz/SKILL.md
+++ b/packages/cli/skills/gtfs-viz/SKILL.md
@@ -4,7 +4,7 @@ description: Import GTFS transit feeds, query station/stop/pathway/route/trip/ca
 license: MIT
 metadata:
   author: gabrielahn
-  version: "1.5.1"
+  version: "1.5.2"
   repository: gabrielAHN/gtfs-viz
 ---
 

--- a/packages/cli/skills/gtfs-viz/SKILL.md
+++ b/packages/cli/skills/gtfs-viz/SKILL.md
@@ -252,6 +252,7 @@ gtfs-viz update_trip --trip-id T2 --headsign "Express"        # only given field
 gtfs-viz delete_trip --trip-id T2                             # cascades to stop_times
 
 gtfs-viz set_stop_times --trip-id T2 --stops-json '[{"stop_sequence":1,"stop_id":"S1","arrival_time":"09:00:00","departure_time":"09:00:00"}]'
+gtfs-viz reroute --trip A_TRIP   # open the affected trip directly in the reroute form
 gtfs-viz reroute --trip A_TRIP --via F_TRIP --from "W 4 St-Wash Sq" --to "Jay St-MetroTech"   # run A via the F between those stops
 gtfs-viz remove_stops --trip T2 --stops "Spring St,Canal St"                # skip/express, station bypass
 gtfs-viz truncate_trip --trip T2 --to "14 St"                                # short-turn / ends early
@@ -353,3 +354,7 @@ defaults with `GTFS_VIZ_DUCKDB_THREADS`, `GTFS_VIZ_DUCKDB_MEMORY_LIMIT`, or
 - Use `gtfs-viz edits --trip <id> --compare-view map --url-only` for a direct reroute verification
   link in Edits & Export; use `gtfs-viz trip <id> --compare <donor> --view map --url-only` to compare
   affected and donor trips.
+- Use `gtfs-viz reroute --trip <id>` to open the selected trip's reroute form. A complete
+  `gtfs-viz reroute --trip <id> --via <donor> --from <station> --to <station>` opens the edited trip
+  after applying the splice; add `--url-only` for a link without browser navigation or `--data` for
+  terminal-only operation.

--- a/packages/cli/skills/gtfs-viz/references/commands.md
+++ b/packages/cli/skills/gtfs-viz/references/commands.md
@@ -226,6 +226,7 @@ gtfs-viz update_trip --trip-id T2 --headsign "Express"       # only given fields
 gtfs-viz delete_trip --trip-id T2                            # cascades to stop_times
 gtfs-viz set_stop_times --trip-id T2 --stops-json '[{"stop_sequence":1,"stop_id":"S1","arrival_time":"09:00:00","departure_time":"09:00:00"}]'
 gtfs-viz set_stop_times --trip-id T2 --stops-file ./stops.json
+gtfs-viz reroute --trip A_TRIP   # open the selected trip's reroute form
 gtfs-viz reroute --trip A_TRIP --via F_TRIP --from "W 4 St-Wash Sq" --to "Jay St-MetroTech"   # splice a donor route's stops in (scaled timing)
 gtfs-viz remove_stops --trip T2 --stops "Spring St,Canal St"          # skip/express, station bypass
 gtfs-viz truncate_trip --trip T2 --to "14 St"                          # short-turn / ends early (also --from)
@@ -237,6 +238,10 @@ gtfs-viz delete_calendar --service-id WKND
 gtfs-viz add_calendar_date --service-id WKD --date 20260906 --exception-type 1   # 1=add, 2=remove
 gtfs-viz delete_calendar_date --service-id WKD --date 20260906
 ```
+
+`reroute --trip <id>` opens `/trips/table` with the trip selected and its reroute form open. A
+complete reroute opens the edited trip after applying the splice. Add `--url-only` to print that
+deep link without browser navigation, or `--data` to apply the reroute in terminal-only mode.
 
 ### Batch Changeset
 

--- a/packages/cli/skills/gtfs-viz/references/edits.md
+++ b/packages/cli/skills/gtfs-viz/references/edits.md
@@ -132,8 +132,14 @@ A **reroute** (e.g. "A/C run via the F line") carries the **donor** route's stop
 section — it is **not** a plain skip (which just leaves a gap). Use the built-in command:
 
 ```bash
+gtfs-viz reroute --trip <affected_trip>
 gtfs-viz reroute --trip <affected_trip> --via <donor_trip> --from "<boundary stop>" --to "<boundary stop>"
 ```
+
+The trip-only command opens the selected trip directly in the dashboard reroute form. A complete
+command applies the splice and opens the affected trip with its edited stops visible. Use
+`--url-only` to return the affected-trip link without navigating the browser, or `--data` to apply
+without opening the dashboard.
 
 - `--from` / `--to` are the two stops (by **name**) the affected route shares with the donor, where it
   leaves its normal path and where it rejoins. (A/F share **W 4 St-Wash Sq** and **Jay St-MetroTech**.)
@@ -153,7 +159,7 @@ gtfs-viz reroute --trip <C_trip> --via <F_trip> --from "W 4 St-Wash Sq" --to "Ja
 ```
 
 The spliced-in stops become `new`, the removed originals `deleted` — `gtfs-viz edits --trip <id>` shows
-the swap. **View the reroute** by comparing against the donor (a single-trip view can't reveal it):
+the swap. Compare against the donor when you also need to inspect the physical alignment:
 ```bash
 gtfs-viz trip <affected_trip> --compare <donor_trip> --view map    # physical reroute on the map
 gtfs-viz trip <affected_trip> --compare <donor_trip>               # stop-by-stop timetable

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1492,6 +1492,41 @@ const commandTrips = async (args: Args) => {
   await openDashboardView("trips/table", params);
 };
 
+const openTripDashboard = async (
+  args: Args,
+  tripId: string,
+  extraParams: Record<string, string> = {},
+): Promise<boolean> => {
+  const ds = await readDatasetState();
+  const tripRows = await queryRows(
+    ds.dbPath,
+    `SELECT route_id, service_id FROM TripsView WHERE trip_id = ${sqlString(tripId)} LIMIT 1`,
+  );
+  if (tripRows.length === 0) {
+    console.log(`No trip found with ID "${tripId}".`);
+    return false;
+  }
+  const params = dashboardParamsFromFlags(args);
+  const routeId = String(tripRows[0].route_id);
+  params.selectedRouteId = routeId;
+  params.cliSelectedRoute = routeId;
+  params.routeId = routeId;
+  if (tripRows[0].service_id) params.selectedServiceId = String(tripRows[0].service_id);
+  const view = getViewFlag(args);
+  if (view === "timeline" || view === "map") params.view = view;
+  const compareRaw = getFlagString(args.flags, "compare");
+  if (compareRaw) {
+    const allIds = compareRaw.split(",").map((value) => value.trim()).filter(Boolean);
+    if (!allIds.includes(tripId)) allIds.unshift(tripId);
+    params.compareTripIds = allIds.join(",");
+  } else {
+    params.selectedTripId = tripId;
+  }
+  Object.assign(params, extraParams);
+  await openDashboardView("trips/table", params);
+  return true;
+};
+
 const commandTrip = async (args: Args) => {
   ensureOutputMode(args);
   const tripId = getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "id") || getPositionalId(args);
@@ -1540,27 +1575,7 @@ const commandTrip = async (args: Args) => {
     return;
   }
 
-  // Dashboard mode
-  const ds = await readDatasetState();
-  // Resolve via TripsView so newly-added (edit-only) trips also open in the dashboard.
-  const tripRows = await queryRows(ds.dbPath, `SELECT route_id, service_id FROM TripsView WHERE trip_id = ${sqlString(tripId)} LIMIT 1`);
-  if (tripRows.length === 0) { console.log(`No trip found with ID "${tripId}".`); return; }
-  const params = dashboardParamsFromFlags(args);
-  const resolvedRoute = String(tripRows[0].route_id);
-  params.selectedRouteId = resolvedRoute;
-  params.cliSelectedRoute = resolvedRoute;
-  params.routeId = resolvedRoute;
-  if (tripRows[0].service_id) params.selectedServiceId = String(tripRows[0].service_id);
-  const view = getViewFlag(args);
-  if (view === "timeline" || view === "map") params.view = view;
-  if (compareRaw) {
-    const allIds = compareRaw.split(",").map((s) => s.trim()).filter(Boolean);
-    if (!allIds.includes(tripId)) allIds.unshift(tripId);
-    params.compareTripIds = allIds.join(",");
-  } else {
-    params.selectedTripId = tripId;
-  }
-  await openDashboardView("trips/table", params);
+  await openTripDashboard(args, tripId);
 };
 
 const commandCalendar = async (args: Args) => {
@@ -2716,6 +2731,7 @@ const commandSetStopTimes = async (args: Args) => {
 };
 
 const commandReroute = async (args: Args) => {
+  ensureOutputMode(args);
   const ds = await readDatasetState();
   const tripId =
     getFlagString(args.flags, "trip-id") || getFlagString(args.flags, "trip") || getFlagString(args.flags, "id");
@@ -2723,17 +2739,34 @@ const commandReroute = async (args: Args) => {
     getFlagString(args.flags, "via") || getFlagString(args.flags, "donor-trip") || getFlagString(args.flags, "donor");
   const from = getFlagString(args.flags, "from");
   const to = getFlagString(args.flags, "to");
-  if (!tripId || !donor || !from || !to)
+  if (!tripId)
     throw new Error(
-      'Usage: gtfs-viz reroute --trip <trip_id> --via <donor_trip_id> --from "<boundary stop>" --to "<boundary stop>"',
+      'Usage: gtfs-viz reroute --trip <trip_id> [--via <donor_trip_id> --from "<boundary stop>" --to "<boundary stop>"]',
     );
+  if (!donor && !from && !to) {
+    if (wantsDataOutput(args.flags)) {
+      throw new Error("Remove --data to open the reroute form for the selected trip");
+    }
+    await openTripDashboard(args, tripId, { reroute: "true" });
+    return;
+  }
+  if (!donor || !from || !to) {
+    throw new Error(
+      'Provide --via <donor_trip_id>, --from "<boundary stop>", and --to "<boundary stop>" together',
+    );
+  }
   const changed = await rerouteViaDonor(ds.dbPath, tripId, donor, from, to);
   await refreshTrips(ds.dbPath);
-  console.log(
-    changed
-      ? `Rerouted ${tripId} via ${donor} between "${from}" and "${to}"`
-      : `No change for ${tripId} (already follows that path)`,
-  );
+  if (!wantsUrlOnly(args)) {
+    console.log(
+      changed
+        ? `Rerouted ${tripId} via ${donor} between "${from}" and "${to}"`
+        : `No change for ${tripId} (already follows that path)`,
+    );
+  }
+  if (!wantsDataOutput(args.flags)) {
+    await openTripDashboard(args, tripId);
+  }
 };
 
 // Skip/express or station bypass — drop named stops from a trip.

--- a/packages/cli/src/output/print.ts
+++ b/packages/cli/src/output/print.ts
@@ -335,11 +335,22 @@ const commandHelp: Record<string, string> = {
   boundaries must occur in the same order, and replacement times are fitted
   to the affected trip's boundary window.
 
+  With only --trip, open that trip's reroute form. After a complete reroute,
+  open the edited trip so the replaced stops are immediately visible.
+
   Flags:
     --trip <id>             Affected trip ID
     --via <id>              Donor trip ID
     --from <station>        Shared start boundary station
     --to <station>          Shared end boundary station
+    --data                  Apply without opening the dashboard
+    --url-only              Apply and print the edited trip URL without opening it
+
+  Open form:
+    gtfs-viz reroute --trip <id>
+
+  Apply:
+    gtfs-viz reroute --trip <id> --via <donor-id> --from "W 4 St-Wash Sq" --to "Jay St-MetroTech"
 
   Review:
     gtfs-viz query --sql "SELECT * FROM get_trip_reroute_routes('trip-id')" --data

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtfs-viz/web",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Lightweight GTFS data visualizer and editor — web app",
   "license": "MIT",

--- a/packages/web/src/client/Trips/AllTrips/index.tsx
+++ b/packages/web/src/client/Trips/AllTrips/index.tsx
@@ -61,7 +61,6 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
   }, [updateSearch]);
   const [isPicking, setIsPicking] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [showReroute, setShowReroute] = useState(false);
   const [hiddenTripIndices, setHiddenTripIndices] = useState<Set<number>>(new Set());
   const toggleTripVisibility = useCallback((idx: number) => {
     setHiddenTripIndices((prev) => { const next = new Set(prev); if (next.has(idx)) next.delete(idx); else next.add(idx); return next; });
@@ -84,6 +83,7 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
   const routeId = search.routeId;
   const routeType = search.routeType;
   const selectedTripId = search.selectedTripId;
+  const showReroute = search.reroute === true;
 
   // Ref for TripMap zoom-to-stop function
   const zoomToStopRef = useRef<((stopIdx: number) => void) | null>(null);
@@ -290,12 +290,11 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
   };
 
   const handleTripSelect = (trip?: TripRow) => {
-    updateSearch({ selectedTripId: trip?.trip_id || undefined });
+    updateSearch({ selectedTripId: trip?.trip_id || undefined, reroute: undefined });
     if (trip) setTripView("timetable");
     setCompareTripIds([]);
     setIsPicking(false);
     setIsEditing(false);
-    setShowReroute(false);
     setViewSelectedIdx(null);
   };
 
@@ -698,7 +697,7 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
           {hasStopTimes && compareTrips.length === 0 && (
             <Button
               variant="outline"
-              onClick={() => setShowReroute(true)}
+              onClick={() => updateSearch({ reroute: true })}
               size="sm"
               className="flex items-center"
               disabled={
@@ -738,7 +737,7 @@ function AllTrips({ allTrips, tripTimeBounds, hasStopTimes, search, updateSearch
           key={selectedTripId}
           open={showReroute}
           tripId={selectedTripId}
-          onOpenChange={setShowReroute}
+          onOpenChange={(open) => updateSearch({ reroute: open ? true : undefined })}
         />
       ) : null}
       {/* Compare trips chips */}

--- a/packages/web/src/client/Trips/AllTrips/types.ts
+++ b/packages/web/src/client/Trips/AllTrips/types.ts
@@ -18,6 +18,7 @@ export interface AllTripsProps {
     routeId?: string;
     routeType?: string[];
     selectedTripId?: string;
+    reroute?: boolean;
     view?: string;
     compareTripIds?: string;
   };

--- a/packages/web/src/routes/_layout/trips/table.tsx
+++ b/packages/web/src/routes/_layout/trips/table.tsx
@@ -6,6 +6,7 @@ type TripsTableSearchParams = {
   routeId?: string;
   routeType?: string[];
   selectedTripId?: string;
+  reroute?: boolean;
   view?: string;
   compareTripIds?: string;
   page?: number;
@@ -23,6 +24,7 @@ export const Route = createFileRoute("/_layout/trips/table")({
           ? [search.routeType as string]
           : undefined,
       selectedTripId: search.selectedTripId as string | undefined,
+      reroute: search.reroute === true || search.reroute === "true" ? true : undefined,
       view: search.view as string | undefined,
       compareTripIds: search.compareTripIds as string | undefined,
       ...tablePaginationSearch(search),


### PR DESCRIPTION
## GTFS Viz v1.5.2

A small NYC subway-focused release that makes reroute work land in the correct view from both the CLI and agent skill.

### Highlights

- `gtfs-viz reroute --trip <id>` opens the selected trip directly in the reroute form.
- A completed reroute opens the edited trip so its replacement stops are immediately visible.
- Reroute form state is URL-backed, preserving the trip, route, service, and review context.
- `--url-only` and `--data` keep browser-free and data-only agent workflows predictable.
- CLI help, npm documentation, and the bundled GTFS Viz skill now describe the same reroute flow.
- npm publishing explicitly promotes 1.5.2 to the `latest` tag.

### NYC validation

Validated against the current MTA supplemented subway feed at `https://rrgtfsfeeds.s3.amazonaws.com/gtfs_supplemented.zip`. The CLI generated a direct reroute-form link for trip `L0S3-A-1087-S01_140900_A..S74R` with the selected A route and L0S3 service preserved.

### Checks

- `yarn build`
- `yarn workspace @gabrielahn/gtfs-viz-cli run check`
- `npm publish --dry-run --access public --tag latest`
- `gtfs-viz --version` → `1.5.2`
- Browser-free reroute deep-link verification with `--url-only`